### PR TITLE
parse NO_MPIF from environment

### DIFF
--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -100,6 +100,10 @@ ifeq ($(TARGET),MACX64)
   EXTRA_OBJ += macx_trapfpe.o
 endif
 
+ifdef NO_MPIF
+  LIB_DEFINES += -DNO_MPIF
+endif
+
 ifeq ($(TARGET),$(findstring $(TARGET),BGL BGP BGQ LINUX CYGWIN CYGWIN64 CYGNUS INTERIX LINUX64 MACX MACX64))
   EXTRA_OBJ = linux_cpu.o linux_shift.o linux_random.o  erfc.o linux_printaff.o
   ifeq ($(LINUXCPU),x86)


### PR DESCRIPTION
NO_MPIF is used when no MPI Fortran library is available.
we set this automatically for Mac but it is useful to parse it directly
from the user environment.  i am currently using this on FreeBSD to
workaround gfortran/flang issues.