### PR TITLE
Add support for Python 3

### DIFF
--- a/contrib/python/basopt.nw
+++ b/contrib/python/basopt.nw
@@ -19,6 +19,8 @@ end
 print none
 
 python noprint
+  from __future__ import print_function
+  
   from mathutil import *
 
   # It should only be necessary to modify these three lines for 
@@ -38,12 +40,12 @@ python noprint
     return task_energy(theory)
 
   def printexp(z):
-    print "\n Exponents:"
+    print("\n Exponents:")
     for i in range(len(z)):
       print " %14.8f" % (z[i]*z[i]),
       if ((i+1)%5) == 0:
-        print ""
-    print " "
+        print("")
+    print(" ")
 
   z = array('d',exponents)
   for i in range(len(z)):

--- a/contrib/python/basopt2.nw
+++ b/contrib/python/basopt2.nw
@@ -23,6 +23,7 @@ set int:acc_std 1e-25
 print none
 
 python noprint
+  from __future__ import print_function
   from mathutil import *
 
   # It should only be necessary to modify these three lines for 
@@ -62,12 +63,12 @@ python noprint
     return task_energy(theory)
 
   def printexp(z):
-    print "\n Exponents:"
+    print("\n Exponents:")
     for i in range(len(z)):
       print " %14.8f" % (z[i]*z[i]),
       if ((i+1)%5) == 0:
-        print ""
-    print " "
+        print("")
+    print(" ")
 
   z = array('d',exponents)
   for i in range(len(z)):

--- a/contrib/python/basopt3.nw
+++ b/contrib/python/basopt3.nw
@@ -24,6 +24,8 @@ set int:acc_std 1e-25
 print none
 
 python noprint
+  from __future__ import print_function
+  
   from mathutil import *
 
   # It should only be necessary to modify these three lines for 
@@ -74,12 +76,12 @@ python noprint
     return task_energy(theory)
 
   def printexp(z):
-    print "\n Exponents:"
+    print("\n Exponents:")
     for i in range(len(z)):
-      print " %14.8f" % (z[i]*z[i]),
+      print(" %14.8f" % (z[i]*z[i]),)
       if ((i+1)%5) == 0:
-        print ""
-    print " "
+        print("")
+    print(" ")
 
   z = array('d',exponents)
   for i in range(len(z)):

--- a/contrib/python/basopt4.nw
+++ b/contrib/python/basopt4.nw
@@ -25,6 +25,7 @@ set int:acc_std 1e-25
 print none
 
 python
+  from __future__ import print_function
   from mathutil import *
 
   n = 6
@@ -56,13 +57,13 @@ python
 
   def printexp(z):
     exponents = make_exp(z)
-    print '\n alpha %f beta %f' % (z[0]*z[0],z[1]*z[1])
-    print ' Exponents:'
+    print('\n alpha %f beta %f' % (z[0]*z[0],z[1]*z[1]))
+    print(' Exponents:')
     for i in range(n):
-      print " %14.8f" % exponents[i],
+      print(" %14.8f" % exponents[i],)
       if ((i+1)%5) == 0:
-        print ""
-    print " "
+        print("")
+    print(" ")
 
   z = zerovector(2)
   z[0] = sqrt(alpha - 0.001)
@@ -73,13 +74,13 @@ python
     (value,z) = quasinr(energy, z, 1e-4, 1e-9, printexp)
     (alpha, beta) = make_alpha_beta(z)
     results[n] = (alpha, beta, value)
-  print '\n\n    Results\n'
-  print '  n     alpha      beta        energy       error '
-  print ' ---  ---------  ---------  ------------  -----------'
+  print('\n\n    Results\n')
+  print('  n     alpha      beta        energy       error ')
+  print(' ---  ---------  ---------  ------------  -----------')
   (alpha, beta, limit) = results[20]
   for n in range(2,21):
     (alpha, beta, value) = results[n]
-    print '%4i %10.6f %10.6f %12.6f %12.6f' % (n, alpha, beta, value, value-limit)
+    print('%4i %10.6f %10.6f %12.6f %12.6f' % (n, alpha, beta, value, value-limit))
 end
 
 task python

--- a/contrib/python/bpy.nw
+++ b/contrib/python/bpy.nw
@@ -13,6 +13,7 @@ mp2; tight; freeze core atomic; end
 #print low
  
 python noprint
+from __future__ import print_function
 supermolecule = 'geometry noprint;   N 13.356 -4.360 16.307;H 12.631 -4.575 16.716;N 11.384 -5.455 18.225;C 10.267 -4.749 18.620 ; end\n'
 fragment1     = 'geometry noprint;   N 13.356 -4.360 16.307;H 12.631 -4.575 16.716;bqN 11.384 -5.455 18.225;bqC 10.267 -4.749 18.620; end\n'
 fragment2     = 'geometry noprint; bqN 13.356 -4.360 16.307;bqH 12.631 -4.575 16.716;N 11.384 -5.455 18.225;C 10.267 -4.749 18.620; end\n'
@@ -31,7 +32,7 @@ def bsse_energy():
         
 e = bsse_energy()
 if (ga_nodeid() == 0):
-    print '  BSSE energy (hartrees) = %10.7f ' % (e)
+    print('  BSSE energy (hartrees) = %10.7f ' % (e))
 end
  
 task python

--- a/contrib/python/coulombfitting.XF.mol.nw
+++ b/contrib/python/coulombfitting.XF.mol.nw
@@ -38,6 +38,8 @@ set int:acc_std 1e-25
 print none
 
 python
+  from __future__ import print_function
+  
   from mathutil import *
 
   run_type = "scf"
@@ -129,13 +131,13 @@ python
   def printexp(z):
     function_type = ["s", "p", "d", "f", "g", "h", "i"]
     exponents = make_exp(z)
-    print ' Exponents:'
+    print(' Exponents:')
     for j in range(0,l+1):
-        print "%s - functions" % (function_type[j])
+        print("%s - functions" % (function_type[j]))
         for i in range(0,n[j]):
-          print " %14.8f" % exponents[i][j]
-        print ""
-    print " "
+          print(" %14.8f" % exponents[i][j])
+        print("")
+    print(" ")
 
   # Setup list of variables to be optimized
 
@@ -174,14 +176,14 @@ python
 
   # Print the final results
  
-  print '\n\n    Results\n'
-  print '  l   n     exp0       beta       gamma   ' 
-  print ' --- ---  ---------  ---------  --------- '
+  print('\n\n    Results\n')
+  print('  l   n     exp0       beta       gamma   ')
+  print(' --- ---  ---------  ---------  --------- ')
   for j in range(0,l+1):
      (exp0_n, beta_n, gamma_n) = get_exp0_beta_gamma(z,j)
-     print '%4i %4i %12.6f %10.6f %10.6f' % (j, n[j], exp0_n, beta_n, gamma_n)
-  print '\n Final energy difference = %12.6f' % value
-  print '\n Energy without Coulomb fitting = %12.6f' % reference
+     print('%4i %4i %12.6f %10.6f %10.6f' % (j, n[j], exp0_n, beta_n, gamma_n))
+  print('\n Final energy difference = %12.6f' % value)
+  print('\n Energy without Coulomb fitting = %12.6f' % reference)
   printexp(z)
 end
 

--- a/contrib/python/coulombfitting.XH.mol.nw
+++ b/contrib/python/coulombfitting.XH.mol.nw
@@ -38,6 +38,7 @@ set int:acc_std 1e-25
 print none
 
 python
+  from __future__ import print_function
   from mathutil import *
 
   run_type = "scf"
@@ -129,13 +130,13 @@ python
   def printexp(z):
     function_type = ["s", "p", "d", "f", "g", "h", "i"]
     exponents = make_exp(z)
-    print ' Exponents:'
+    print(' Exponents:')
     for j in range(0,l+1):
-        print "%s - functions" % (function_type[j])
+        print("%s - functions" % (function_type[j]))
         for i in range(0,n[j]):
-          print " %14.8f" % exponents[i][j]
-        print ""
-    print " "
+          print(" %14.8f" % exponents[i][j])
+        print("")
+    print(" ")
 
   # Setup list of variables to be optimized
 
@@ -174,14 +175,14 @@ python
 
   # Print the final results
  
-  print '\n\n    Results\n'
-  print '  l   n     exp0       beta       gamma   ' 
-  print ' --- ---  ---------  ---------  --------- '
+  print('\n\n    Results\n')
+  print('  l   n     exp0       beta       gamma   ')
+  print(' --- ---  ---------  ---------  --------- ')
   for j in range(0,l+1):
      (exp0_n, beta_n, gamma_n) = get_exp0_beta_gamma(z,j)
-     print '%4i %4i %12.6f %10.6f %10.6f' % (j, n[j], exp0_n, beta_n, gamma_n)
-  print '\n Final energy difference = %12.6f' % value
-  print '\n Energy without Coulomb fitting = %12.6f' % reference
+     print('%4i %4i %12.6f %10.6f %10.6f' % (j, n[j], exp0_n, beta_n, gamma_n))
+  print('\n Final energy difference = %12.6f' % value)
+  print('\n Energy without Coulomb fitting = %12.6f' % reference)
   printexp(z)
 end
 

--- a/contrib/python/coulombfitting.atom.nw
+++ b/contrib/python/coulombfitting.atom.nw
@@ -37,6 +37,7 @@ set int:acc_std 1e-25
 print none
 
 python
+  from __future__ import print_function
   from mathutil import *
 
   run_type = "scf"
@@ -127,13 +128,13 @@ python
   def printexp(z):
     function_type = ["s", "p", "d", "f", "g", "h", "i"]
     exponents = make_exp(z)
-    print ' Exponents:'
+    print(' Exponents:')
     for j in range(0,l+1):
-        print "%s - functions" % (function_type[j])
+        print("%s - functions" % (function_type[j]))
         for i in range(0,n[j]):
-          print " %14.8f" % exponents[i][j]
-        print ""
-    print " "
+          print(" %14.8f" % exponents[i][j])
+        print("")
+    print(" ")
 
   # Setup list of variables to be optimized
 
@@ -170,14 +171,14 @@ python
 
   # Print the final results
  
-  print '\n\n    Results\n'
-  print '  l   n     exp0       beta       gamma   ' 
-  print ' --- ---  ---------  ---------  --------- '
+  print('\n\n    Results\n')
+  print('  l   n     exp0       beta       gamma   ')
+  print(' --- ---  ---------  ---------  --------- ')
   for j in range(0,l+1):
      (exp0_n, beta_n, gamma_n) = get_exp0_beta_gamma(z,j)
-     print '%4i %4i %12.6f %10.6f %10.6f' % (j, n[j], exp0_n, beta_n, gamma_n)
-  print '\n Final energy difference = %12.6f' % value
-  print '\n Energy without Coulomb fitting = %12.6f' % reference
+     print('%4i %4i %12.6f %10.6f %10.6f' % (j, n[j], exp0_n, beta_n, gamma_n))
+  print('\n Final energy difference = %12.6f' % value)
+  print('\n Energy without Coulomb fitting = %12.6f' % reference)
   printexp(z)
 end
 

--- a/contrib/python/hcn.nw
+++ b/contrib/python/hcn.nw
@@ -19,6 +19,7 @@ scf; print none; end
 driver; print low; end
 
 python
+  from __future__ import print_function
   import Gnuplot, time, signal, os
   from math import *
   from nwgeom import *
@@ -70,8 +71,8 @@ python
     cn = bond_length(1,2)
     nh = bond_length(2,3)
     ch = bond_length(1,3)
-    print ' angle=%6.1f => cn=%5.3f ch=%5.3f nh=%5.3f energy=%10.6f ' % \
-                (angle,cn,ch,nh,energy)
+    print(' angle=%6.1f => cn=%5.3f ch=%5.3f nh=%5.3f energy=%10.6f ' % \
+                (angle,cn,ch,nh,energy))
     angle = angle + 180
     edata = edata + [[angle,energy]]
     cndata = cndata + [[angle,cn]]

--- a/contrib/python/isodesmic.nw
+++ b/contrib/python/isodesmic.nw
@@ -5,6 +5,7 @@ mp2; freeze atomic; end
 print none
 
 python
+  from __future__ import print_function
   energies = {}
 
   c2h4 = '''
@@ -43,7 +44,7 @@ python
      energies[basis] = 2*energy(basis, ch4) - \
                        2*energy(basis, h2)  - \
                          energy(basis, c2h4)
-     if (ga_nodeid() == 0): print basis, ' %8.6f' % energies[basis]
+     if (ga_nodeid() == 0): print(basis, ' %8.6f' % energies[basis])
 end 
 
 

--- a/contrib/python/nh3.nw
+++ b/contrib/python/nh3.nw
@@ -12,6 +12,7 @@ end
 print none
 
 python
+  from __future__ import print_function
   import Gnuplot, time, signal
   from math import *
 
@@ -86,7 +87,7 @@ python
     input_parse(geometry % (angle+90))
     (energy,gradient) = task_optimize('scf')
     r = get_bond_length()
-    print ' angle=%6.2f  bond=%6.3f energy=%10.6f ' % (angle,r,energy)
+    print(' angle=%6.2f  bond=%6.3f energy=%10.6f ' % (angle,r,energy))
     energies = energies + [[angle,energy]]
     bonds = bonds + [[angle,r]]
     energies.sort()
@@ -95,7 +96,7 @@ python
       g.plot(energies)
       gr.plot(bonds)
 
-  print ' Done!'
+  print(' Done!')
 
   time.sleep(90)  # time to look at the plot
 end

--- a/contrib/python/scanexp.nw
+++ b/contrib/python/scanexp.nw
@@ -11,13 +11,14 @@ end
 print none
 
 python
+  from __future__ import print_function
   from nwgeom import *
   basis = 'basis noprint; H library 3-21g; O library 3-21g; O d; %f 1.0; end'
 
   results = scan_input(basis, [0.5], [0.6], 20, 'scf', task_energy)
 
   for (p,e) in results:
-     print ' Exponent = %7.4f  Energy = %10.6f ' % (p[0], e)
+     print(' Exponent = %7.4f  Energy = %10.6f ' % (p[0], e))
 end
 
 task python

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -1323,7 +1323,6 @@ ifeq ($(BUILDING_PYTHON),python)
 # needed if python was built with pthread support
   ifneq ($(GOTMINGW32),1)
    PYMAJOR:=$(word 1, $(subst ., ,$(PYTHONVERSION)))
-   $(error pyversion is $(echo $PYTHONVERSION | cut -d. -f1))
    ifeq (${PYMAJOR},3)
    EXTRA_LIBS += $(shell $(PYTHONHOME)/bin/python3-config --libs)  -lnwcutil
    else
@@ -2406,7 +2405,6 @@ ifeq ($(_CPU),$(findstring $(_CPU), ppc64 ppc64le))
      ifeq ($(BUILDING_PYTHON),python)
 #   EXTRA_LIBS += -ltk -ltcl -L/usr/X11R6/lib -lX11 -ldl
    PYMAJOR:=$(word 1, $(subst ., ,$(PYTHONVERSION)))
-   $(error pyversion is ${PYMAJOR})
    ifeq (${PYMAJOR},3)
    EXTRA_LIBS += -lnwcutil $(shell $(PYTHONHOME)/bin/python3-config --libs) #-lz
    else

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -1322,7 +1322,8 @@ ifeq ($(BUILDING_PYTHON),python)
 #   EXTRA_LIBS += -L/home/edo/tcltk/lib/LINUX -ltk8.3 -ltcl8.3 -L/usr/X11R6/lib -lX11 -ldl
 # needed if python was built with pthread support
   ifneq ($(GOTMINGW32),1)
-   PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+   PYMAJOR:=$(word 1, $(subst ., ,$(PYTHONVERSION)))
+   $(error pyversion is $(echo $PYTHONVERSION | cut -d. -f1))
    ifeq (${PYMAJOR},3)
    EXTRA_LIBS += $(shell $(PYTHONHOME)/bin/python3-config --libs)  -lnwcutil
    else
@@ -2404,7 +2405,8 @@ ifeq ($(_CPU),$(findstring $(_CPU), ppc64 ppc64le))
 
      ifeq ($(BUILDING_PYTHON),python)
 #   EXTRA_LIBS += -ltk -ltcl -L/usr/X11R6/lib -lX11 -ldl
-   PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+   PYMAJOR:=$(word 1, $(subst ., ,$(PYTHONVERSION)))
+   $(error pyversion is ${PYMAJOR})
    ifeq (${PYMAJOR},3)
    EXTRA_LIBS += -lnwcutil $(shell $(PYTHONHOME)/bin/python3-config --libs) #-lz
    else
@@ -2586,7 +2588,7 @@ $(error )
 endif
 #
 ifdef USE_PYTHONCONFIG
-PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+PYMAJOR:=$(word 1, $(subst ., ,$(PYTHONVERSION)))
 ifeq (${PYMAJOR},3)
 EXTRA_LIBS += $(shell $(PYTHONHOME)/bin/python3-config --ldflags)
 else

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -1322,7 +1322,12 @@ ifeq ($(BUILDING_PYTHON),python)
 #   EXTRA_LIBS += -L/home/edo/tcltk/lib/LINUX -ltk8.3 -ltcl8.3 -L/usr/X11R6/lib -lX11 -ldl
 # needed if python was built with pthread support
   ifneq ($(GOTMINGW32),1)
+   PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+   ifeq (${PYMAJOR},3)
+   EXTRA_LIBS += $(shell $(PYTHONHOME)/bin/python3-config --libs)  -lnwcutil
+   else
    EXTRA_LIBS += $(shell $(PYTHONHOME)/bin/python-config --libs)  -lnwcutil
+   endif
   endif
 endif
 
@@ -2399,7 +2404,12 @@ ifeq ($(_CPU),$(findstring $(_CPU), ppc64 ppc64le))
 
      ifeq ($(BUILDING_PYTHON),python)
 #   EXTRA_LIBS += -ltk -ltcl -L/usr/X11R6/lib -lX11 -ldl
+   PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+   ifeq (${PYMAJOR},3)
+   EXTRA_LIBS += -lnwcutil $(shell $(PYTHONHOME)/bin/python3-config --libs) #-lz
+   else
    EXTRA_LIBS += -lnwcutil $(shell $(PYTHONHOME)/bin/python-config --libs) #-lz
+   endif
   LDOPTIONS += -Wl,--export-dynamic 
      endif
 ifeq ($(NWCHEM_TARGET),CATAMOUNT)
@@ -2576,7 +2586,12 @@ $(error )
 endif
 #
 ifdef USE_PYTHONCONFIG
+PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+ifeq (${PYMAJOR},3)
+EXTRA_LIBS += $(shell $(PYTHONHOME)/bin/python3-config --ldflags)
+else
 EXTRA_LIBS += $(shell $(PYTHONHOME)/bin/python-config --ldflags)
+endif
 else
 ifndef PYTHONLIBTYPE
     PYTHONLIBTYPE=a

--- a/src/python/GNUmakefile
+++ b/src/python/GNUmakefile
@@ -19,8 +19,12 @@ error1:
 	@exit 1
 endif
 
-
-LIB_INCLUDES = -I$(PYTHONHOME)/include/python$(PYTHONVERSION)$(PYTHONABIFLAGS) -I$(PYTHONHOME)/include -I$(PYTHONHOME)/Include -I$(PYTHONHOME)
+PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+ifeq (${PYMAJOR},3)
+LIB_INCLUDES = $(shell $(PYTHONHOME)/bin/python3-config --includes)
+else
+LIB_INCLUDES = $(shell $(PYTHONHOME)/bin/python-config --includes)
+endif
 
 
 include ../config/makefile.h

--- a/src/python/GNUmakefile
+++ b/src/python/GNUmakefile
@@ -19,7 +19,7 @@ error1:
 	@exit 1
 endif
 
-PYMAJOR = $(echo $PYTHONVERSION | cut -d. -f1)
+PYMAJOR:=$(word 1, $(subst ., ,$(PYTHONVERSION)))
 ifeq (${PYMAJOR},3)
 LIB_INCLUDES = $(shell $(PYTHONHOME)/bin/python3-config --includes)
 else

--- a/src/python/nwchem_wrap.c
+++ b/src/python/nwchem_wrap.c
@@ -150,7 +150,7 @@ char *Parse_String(PyObject *arg)
   if (PyUnicode_Check(arg)) {
     ascii_string = PyUnicode_AsASCIIString(arg);
     out = PyBytes_AsString(ascii_string);
-    Py_DECREF(ascii_string)
+    Py_DECREF(ascii_string);
   } else if (PyBytes_Check(arg)) {
     out = PyBytes_AsString(arg);
   } else {
@@ -240,8 +240,8 @@ static PyObject *wrap_rtdb_put(PyObject *self, PyObject *args)
     void *array = 0;
     PyObject *obj, *obj_item, *ascii_string;
     
-    ma_type = -1
-    PyArg_ParseTuple(args, "so|i", &name, &obj, &ma_type)
+    ma_type = -1;
+    PyArg_ParseTuple(args, "so|i", &name, &obj, &ma_type);
 
     if (PyList_Check(obj)) 
       list = 1; 
@@ -1709,7 +1709,7 @@ static struct module_state _state;
 #endif
 
 static PyObject* error_out(PyObject *m) {
-  struct module-state *st = GETSTATE(m);
+  struct module_state *st = GETSTATE(m);
   PyErr_SetString(st->error, "something bad happened");
   return NULL;
 }

--- a/src/python/nwchem_wrap.c
+++ b/src/python/nwchem_wrap.c
@@ -14,6 +14,7 @@
 #include "macdecls.h"
 #include "ga.h"
 #include "typesf2c.h"
+#include "bytesobject.h"
 
 static PyObject *NwchemError;
 
@@ -64,11 +65,11 @@ static PyObject *nwwrap_integers(int n, Integer a[])
   int i;
 
   if (n == 1)
-    return PyInt_FromLong(a[0]);
+    return PyLong_FromLong(a[0]);
 
   if (!(sObj=PyList_New(n))) return NULL;
   for(i=0; i<n; i++) {
-    PyObject *oObj = PyInt_FromLong(a[i]);
+    PyObject *oObj = PyLong_FromLong(a[i]);
     if (!oObj) {
       Py_DECREF(sObj);
       return NULL;
@@ -130,13 +131,40 @@ static PyObject *nwwrap_strings(int n, char *a[])
   return sObj;
 }
 
+static int check_type(PyObject *obj)
+{
+  if (PyLong_Check(obj))
+		return MT_F_INT;
+	else if (PyFloat_Check(obj))
+    return MT_F_DBL;
+  else if (PyUnicode_Check(obj) || PyBytes_Check(obj))
+    return MT_CHAR;
+  else
+    return -1;
+}
+
+char *Parse_String(PyObject *arg)
+{
+  char *out;
+  PyObject *ascii_string;
+  if (PyUnicode_Check(arg)) {
+    ascii_string = PyUnicode_AsASCIIString(arg);
+    out = PyBytes_AsString(ascii_string);
+    Py_DECREF(ascii_string)
+  } else if (PyBytes_Check(arg)) {
+    out = PyBytes_AsString(arg);
+  } else {
+    out = NULL;
+  }
+  return out;
+} 
 
 static PyObject *wrap_rtdb_open(PyObject *self, PyObject *args)
 {
    const char *filename, *mode;
    int inthandle;
 
-   if (PyArg_Parse(args, "(ss)", &filename, &mode)) {
+   if (PyArg_ParseTuple(args, "ss", &filename, &mode)) {
        if (!rtdb_open(filename, mode, &inthandle)) {
            PyErr_SetString(NwchemError, "rtdb_open failed");
            return NULL;
@@ -156,7 +184,7 @@ static PyObject *wrap_rtdb_close(PyObject *self, PyObject *args)
    const char *mode;
    int  result;
 
-   if (PyArg_Parse(args, "s", &mode)) {
+   if (PyArg_ParseTuple(args, "s", &mode)) {
        if (!(result = rtdb_close(rtdb_handle, mode))) {
            PyErr_SetString(NwchemError, "rtdb_close failed");
            return NULL;
@@ -173,7 +201,7 @@ static PyObject *wrap_rtdb_close(PyObject *self, PyObject *args)
 static PyObject *wrap_pass_handle(PyObject *self, PyObject *args)
 {
   int inthandle;
-   if (!(PyArg_Parse(args, "i", &inthandle))) {
+   if (!(PyArg_ParseTuple(args, "i", &inthandle))) {
       PyErr_SetString(PyExc_TypeError, "Usage: pass_handle(rtdb_handle)");
       return NULL;
    }
@@ -186,7 +214,7 @@ static PyObject *wrap_rtdb_print(PyObject *self, PyObject *args)
 {
    int flag;
 
-   if (PyArg_Parse(args, "i", &flag)) {
+   if (PyArg_ParseTuple(args, "i", &flag)) {
       if (!rtdb_print(rtdb_handle, flag)) 
            PyErr_SetString(NwchemError, "rtdb_print failed");
    }
@@ -199,6 +227,7 @@ static PyObject *wrap_rtdb_print(PyObject *self, PyObject *args)
 }
 
 
+
 static PyObject *wrap_rtdb_put(PyObject *self, PyObject *args)
 {
     int i, list, list_len;
@@ -209,134 +238,112 @@ static PyObject *wrap_rtdb_put(PyObject *self, PyObject *args)
     char *char_array;
     char cbuf[8192], *ptr;
     void *array = 0;
-    PyObject *obj, *option_obj;
+    PyObject *obj, *obj_item, *ascii_string;
+    
+    ma_type = -1
+    PyArg_ParseTuple(args, "so|i", &name, &obj, &ma_type)
 
-    if ((PyTuple_Size(args) == 2) || (PyTuple_Size(args) == 3)) {
-      obj = PyTuple_GetItem(args, 0);      /* get var name */
-      PyArg_Parse(obj, "s", &name);
-      obj = PyTuple_GetItem(args, 1);      /* get an array or single value */
-      
-      if (PyList_Check(obj)) 
-        list = 1; 
-      else 
-        list = 0;
-      
+    if (PyList_Check(obj)) 
+      list = 1; 
+    else 
+      list = 0;
+    
+    if (ma_type == -1) {
       if (list) {
         list_len = PyList_Size(obj);
-        if (   PyInt_Check(PyList_GetItem(obj, 0)))  
-          ma_type = MT_F_INT;
-        else if ( PyFloat_Check(PyList_GetItem(obj, 0)))  
-          ma_type = MT_F_DBL;
-        else if (PyString_Check(PyList_GetItem(obj, 0))) 
-          ma_type = MT_CHAR;
-        else {
+        ma_type = check_type(PyList_GetItem(obj, 0));
+        if (ma_type == -1) {
           printf("ERROR A\n");
-          ma_type = -1;
         }
       } else {
         list_len = 1;
-        if (   PyInt_Check(obj))  
-          ma_type = MT_F_INT;
-        else if ( PyFloat_Check(obj))  
-          ma_type = MT_F_DBL;
-        else if (PyString_Check(obj))  
-          ma_type = MT_CHAR; 
-        else {
+        ma_type = check_type(obj);
+        if (ma_type == -1) {
           printf("ERROR B\n");
-          ma_type = -1;
         }
       } 
+    }
 
-      if (ma_type == -1) {
-          PyErr_SetString(PyExc_TypeError, 
-                          "Usage: rtdb_put - ma_type is confused");
-          return NULL;
-      }
-      
-      if (PyTuple_Size(args) == 3) {
-        int intma_type;
-        option_obj = PyTuple_GetItem(args, 2);      /* get optional type */
-        if (!(PyArg_Parse(option_obj, "i", &intma_type))) {
-          PyErr_SetString(PyExc_TypeError, 
-                          "Usage: rtdb_put(value or values,[optional type])");
-          return NULL;
-        }
-        ma_type = intma_type;
-      }
-      
-      if (ma_type != MT_CHAR) {
-        if (!(array = malloc(MA_sizeof(ma_type, list_len, MT_CHAR)))) {
-          PyErr_SetString(PyExc_MemoryError,
-                          "rtdb_put failed allocating work array");
-          return NULL;
-        }
-      }
-      
-      switch (ma_type) {
-      case MT_INT:
-      case MT_F_INT:  
-      case MT_BASE + 11:        /* Logical */
-        int_array = array;
-        for (i = 0; i < list_len; i++) {
-          if (list) 
-            int_array[i] = PyInt_AS_LONG(PyList_GetItem(obj, i));
-          else 
-            int_array[i] = PyInt_AS_LONG(obj);
-        }
-        break;
-        
-      case MT_DBL:  
-      case MT_F_DBL:
-        dbl_array = array;
-        for (i = 0; i < list_len; i++) {
-          if (list) 
-            PyArg_Parse(PyList_GetItem(obj, i), "d", dbl_array+i);
-          else 
-            PyArg_Parse(obj, "d", dbl_array+i);
-        }
-        break;
-        
-      case MT_CHAR: 
-        ptr = cbuf;
-        *ptr = 0;
-        for (i = 0; i < list_len; i++) {
-          if (list) 
-            PyArg_Parse(PyList_GetItem(obj, i), "s", &char_array); 
-          else 
-            PyArg_Parse(obj, "s", &char_array); 
-          /*printf("PROCESSED '%s'\n", char_array);*/
-          if ((ptr+strlen(char_array)) >= (cbuf+sizeof(cbuf))) {
-             PyErr_SetString(PyExc_MemoryError,"rtdb_put too many strings");
-             return NULL;
-           }
-          strcpy(ptr,char_array);
-          ptr = ptr+strlen(char_array);
-          strcpy(ptr,"\n");
-          ptr = ptr + 1;
-        }                
-        list_len = strlen(cbuf) + 1;
-        array = cbuf;
-        break;
-        
-      default:
-        PyErr_SetString(NwchemError, "rtdb_put: ma_type is incorrect");
-        if (array) free(array);
+    if (ma_type == -1) {
+        PyErr_SetString(PyExc_TypeError, 
+                        "Usage: rtdb_put - ma_type is confused");
         return NULL;
-        break;
+    }
+    
+    if (ma_type != MT_CHAR) {
+      if (!(array = malloc(MA_sizeof(ma_type, list_len, MT_CHAR)))) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "rtdb_put failed allocating work array");
+        return NULL;
+      }
+    }
+    
+    switch (ma_type) {
+    case MT_INT:
+    case MT_F_INT:  
+    case MT_BASE + 11:        /* Logical */
+      int_array = array;
+      for (i = 0; i < list_len; i++) {
+        if (list) 
+          int_array[i] = PyLong_AsLong(PyList_GetItem(obj, i));
+        else 
+          int_array[i] = PyLong_AsLong(obj);
+      }
+      break;
+      
+    case MT_DBL:  
+    case MT_F_DBL:
+      dbl_array = array;
+      for (i = 0; i < list_len; i++) {
+        if (list) 
+          dbl_array[i] = PyFloat_AsDouble(PyList_GetItem(obj, i));
+        else 
+          dbl_array[i] = PyFloat_AsDouble(obj);
+      }
+      break;
+      
+    case MT_CHAR: 
+      ptr = cbuf;
+      *ptr = 0;
+      for (i = 0; i < list_len; i++) {
+        if (list) {
+          char_array = Parse_String(PyList_GetItem(obj, i));
+        } else {
+          char_array = Parse_String(obj);
+        }
+        /*printf("PROCESSED '%s'\n", char_array);*/
+        if ((ptr+strlen(char_array)) >= (cbuf+sizeof(cbuf))) {
+           PyErr_SetString(PyExc_MemoryError,"rtdb_put too many strings");
+           return NULL;
+         }
+        strcpy(ptr,char_array);
+        ptr = ptr+strlen(char_array);
+        strcpy(ptr,"\n");
+        ptr = ptr + 1;
       }                
+      list_len = strlen(cbuf) + 1;
+      array = cbuf;
+      break;
       
-      if (!(rtdb_put(rtdb_handle, name, ma_type, list_len, array))) {
-        PyErr_SetString(NwchemError, "rtdb_put failed");
-        if ((ma_type != MT_CHAR) && array) free(array);
-        return NULL;
-      }
-      
-    } else {
-      PyErr_SetString(PyExc_TypeError, 
-                      "Usage: rtdb_put(value or values,[optional type])");
+    default:
+      PyErr_SetString(NwchemError, "rtdb_put: ma_type is incorrect");
+      if (array) free(array);
+      return NULL;
+      break;
+    }                
+    
+    if (!(rtdb_put(rtdb_handle, name, ma_type, list_len, array))) {
+      PyErr_SetString(NwchemError, "rtdb_put failed");
       if ((ma_type != MT_CHAR) && array) free(array);
       return NULL;
     }
+    
+    //} else {
+    //  PyErr_SetString(PyExc_TypeError, 
+    //                  "Usage: rtdb_put(value or values,[optional type])");
+    //  if ((ma_type != MT_CHAR) && array) free(array);
+    //  return NULL;
+    //}
     Py_INCREF(Py_None);
     if ((ma_type != MT_CHAR) && array) free(array);
     return Py_None;
@@ -353,7 +360,7 @@ PyObject *wrap_rtdb_get(PyObject *self, PyObject *args)
   void *array=0;
   int ma_handle;
   
-  if (PyArg_Parse(args, "s", &name)) {
+  if (PyArg_ParseTuple(args, "s", &name)) {
     if (!rtdb_ma_get(rtdb_handle, name, &ma_type, &nelem, &ma_handle)) {
       PyErr_SetString(NwchemError, "rtdb_ma_get failed");
       return NULL;
@@ -436,7 +443,7 @@ PyObject *wrap_rtdb_delete(PyObject *self, PyObject *args)
    char *name;
    PyObject *returnObj = NULL;
 
-   if (PyArg_Parse(args, "s", &name)) {
+   if (PyArg_ParseTuple(args, "s", &name)) {
        if (rtdb_delete(rtdb_handle, name)) {
          returnObj = Py_None;
          Py_INCREF(Py_None);
@@ -458,7 +465,7 @@ PyObject *wrap_rtdb_get_info(PyObject *self, PyObject *args)
    PyObject *returnObj = 0;
    char date[26];
 
-   if (PyArg_Parse(args, "s", &name)) {
+   if (PyArg_ParseTuple(args, "s", &name)) {
        if (!rtdb_get_info(rtdb_handle, name, &ma_type, &nelem, date)) {
            PyErr_SetString(NwchemError, "rtdb_get_info failed");
            return NULL;
@@ -467,8 +474,8 @@ PyObject *wrap_rtdb_get_info(PyObject *self, PyObject *args)
            PyErr_SetString(NwchemError, "rtdb_get_info failed with pyobj");
            return NULL;
        }
-       PyTuple_SET_ITEM(returnObj, 0, PyInt_FromLong((long) ma_type)); 
-       PyTuple_SET_ITEM(returnObj, 1, PyInt_FromLong((long) nelem)); 
+       PyTuple_SET_ITEM(returnObj, 0, PyLong_FromLong((long) ma_type)); 
+       PyTuple_SET_ITEM(returnObj, 1, PyLong_FromLong((long) nelem)); 
        PyTuple_SET_ITEM(returnObj, 2, PyString_FromString(date)); 
    }
    else {
@@ -519,8 +526,7 @@ static PyObject *wrap_task(PyObject *self, PyObject *args)
     double energy;
 /*     task [qmmm] <string theory> [<string operation = energy>] [numerical || analytic] [ignore]
 */
-
-    if (PyArg_Parse(args, "(sssss)", &qmmm,&theory,&operation,&other,&ignore)){
+    if (PyArg_ParseTuple(args, "sssss", &qmmm,&theory,&operation,&other,&ignore)){
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task: putting theory failed");
@@ -535,7 +541,7 @@ static PyObject *wrap_task(PyObject *self, PyObject *args)
         if (!rtdb_get(rtdb_handle, "task:energy", MT_F_DBL, 1, &energy))
             energy = 0.0;
     }
-    else if (PyArg_Parse(args, "(ssss)", &qmmm,&theory,&operation,&other)){
+    else if (PyArg_ParseTuple(args, "ssss", &qmmm,&theory,&operation,&other)){
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task: putting theory failed");
@@ -550,7 +556,7 @@ static PyObject *wrap_task(PyObject *self, PyObject *args)
         if (!rtdb_get(rtdb_handle, "task:energy", MT_F_DBL, 1, &energy))
             energy = 0.0;
     }
-    else if (PyArg_Parse(args, "(sss)", &theory,&operation,&other)){
+    else if (PyArg_ParseTuple(args, "sss", &theory,&operation,&other)){
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task: putting theory failed");
@@ -565,7 +571,7 @@ static PyObject *wrap_task(PyObject *self, PyObject *args)
         if (!rtdb_get(rtdb_handle, "task:energy", MT_F_DBL, 1, &energy))
             energy = 0.0;
     }
-    else if (PyArg_Parse(args, "(ss)", &theory,&operation)){
+    else if (PyArg_ParseTuple(args, "ss", &theory,&operation)){
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_energy: putting theory failed");
@@ -581,7 +587,7 @@ static PyObject *wrap_task(PyObject *self, PyObject *args)
             energy = 0.0;
 
     }
-    else if (PyArg_Parse(args, "s", &theory)){
+    else if (PyArg_ParseTuple(args, "s", &theory)){
         operation = "energy";
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
@@ -615,7 +621,7 @@ static PyObject *wrap_task_coulomb_ref(PyObject *self, PyObject *args)
     char *theory;
     double energy;
     
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_coulomb_ref: putting theory failed");
@@ -651,7 +657,7 @@ static PyObject *wrap_task_coulomb(PyObject *self, PyObject *args)
     char *theory;
     double energy, refenergy;
     
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_coulomb: putting theory failed");
@@ -688,7 +694,7 @@ static PyObject *wrap_task_energy(PyObject *self, PyObject *args)
     char *theory;
     double energy;
     
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_energy: putting theory failed");
@@ -716,7 +722,7 @@ static PyObject *wrap_task_property(PyObject *self, PyObject *args)
     char *theory;
     double energy;
 
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_property: putting theory failed");
@@ -746,7 +752,7 @@ static PyObject *wrap_task_gradient(PyObject *self, PyObject *args)
     int ma_type, nelem, ma_handle;
     PyObject *returnObj, *eObj, *gradObj;
     
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_gradient: putting theory failed");
@@ -793,7 +799,7 @@ static PyObject *wrap_task_stress(PyObject *self, PyObject *args)
     PyObject *returnObj, *eObj, *gradObj, *stressObj;
 
     one = 1;
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_stress: putting theory failed");
@@ -862,7 +868,7 @@ static PyObject *wrap_task_lstress(PyObject *self, PyObject *args)
     PyObject *returnObj, *eObj, *gradObj, *stressObj;
 
     one = 1;
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR,
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_lstress: putting theory failed");
@@ -932,7 +938,7 @@ static PyObject *wrap_task_optimize(PyObject *self, PyObject *args)
     int ma_type, nelem, ma_handle;
     PyObject *returnObj, *eObj, *gradObj;
     
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_optimize: putting theory failed");
@@ -975,7 +981,7 @@ static PyObject *wrap_task_hessian(PyObject *self, PyObject *args)
 {
     char *theory;
 
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_hessian: putting theory failed");
@@ -1018,7 +1024,7 @@ static PyObject *wrap_task_freq(PyObject *self, PyObject *args)
     PyObject *returnObj, *zpeObj, *freqObj, *intObj;
 
 
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_freq: putting theory failed");
@@ -1086,7 +1092,7 @@ static PyObject *wrap_task_saddle(PyObject *self, PyObject *args)
     int ma_type, nelem, ma_handle;
     PyObject *returnObj, *eObj, *gradObj;
 
-    if (PyArg_Parse(args, "s", &theory)) {
+    if (PyArg_ParseTuple(args, "s", &theory)) {
         if (!rtdb_put(rtdb_handle, "task:theory", MT_CHAR, 
                       strlen(theory)+1, theory)) {
             PyErr_SetString(NwchemError, "task_saddle: putting theory failed");
@@ -1132,7 +1138,7 @@ static PyObject *wrap_nw_inp_from_string(PyObject *self, PyObject *args)
 {
    char *pchar;
 
-   if (PyArg_Parse(args, "s", &pchar)) {
+   if (PyArg_ParseTuple(args, "s", &pchar)) {
        if (!nw_inp_from_string(rtdb_handle, pchar)) {
            PyErr_SetString(NwchemError, "input_parse failed");
            return NULL;
@@ -1172,38 +1178,17 @@ static PyObject *do_pgroup_create(PyObject *self, PyObject *args)
    Integer my_ga_group ; // The Global Arrays group ID - useful for debug only at this time
 
    dir = 0; /* default set to permanent_dir */
-// Additional code to parse input: now a tuple of two elements
-// First is either an integer, tuple, or nested tuples: connects with previous argument assignment(args -> args2)
-// Second is additional argument(dir): an integer
-   if (!PyTuple_Check(args)) { // Not a tuple
-        PyErr_SetString(PyExc_TypeError, "pgroup_create() input error 1a - not a tuple");
-        return NULL;
-   }
-   size = PyTuple_Size(args);
-   if (size != 2) { // Not a tuple of two elements
-      PyErr_SetString(PyExc_TypeError, "pgroup_create() input error 1b - not a tuple of two elements");
-      return NULL;
-   }
-   args2 = PyTuple_GetItem(args, 1);
-   if (PyTuple_Check(args2)) { // second element Is a tuple
-      PyErr_SetString(PyExc_TypeError, "pgroup_create() input error 1c - second element is a tuple");
-      return NULL;
-   }
-   if (!PyArg_Parse(args2, "i", &input)) { // cannot get integer from second element
-      PyErr_SetString(PyExc_TypeError, "pgroup_create() input error 1d -  cannot get integer from second element" );
-      return NULL;
-   }
-   dir = input; // setting dir
+   PyArg_ParseTuple(args, "(Oi)", &args2, &dir);
    if (dir > 0 ) {
      dir = 1; //integer used as a bool
    }
-   args2 = PyTuple_GetItem(args, 0); // get original argument set
-// End additional code:  Additional code in subroutine (below) is changed such that args is now args2
+
    if (!PyTuple_Check(args2)) { // Not a tuple
-      if (!PyArg_Parse(args2, "i", &input)) {
+      if (!PyLong_Check(args2)) {
         PyErr_SetString(PyExc_TypeError, " pgroup_create() input error 1e - Not a tuple");
         return NULL;
       }
+      input = PyLong_AsLong(args2);
       num_groups = input;
       method = 1 ;
    } else {
@@ -1230,10 +1215,11 @@ static PyObject *do_pgroup_create(PyObject *self, PyObject *args)
       } 
       for (i = 0; i < num_groups; i++ ) {
          obj = PyTuple_GetItem(args2, i);
-         if(!PyArg_Parse(obj, "i", &input)) {
+         if (!PyLong_Check(obj)) {
             PyErr_SetString(PyExc_TypeError, " pgroup_create() input error 2");
             return NULL;
          }
+         input = PyLong_AsLong(obj);
          node_list[i] = (Integer) input ;
       }
       util_sggo_(&rtdb_handle,&num_groups,&method, node_list,&dir); 
@@ -1259,10 +1245,11 @@ static PyObject *do_pgroup_create(PyObject *self, PyObject *args)
          }
          for (j = 0; j< size ; j++) {
            obj2 = PyTuple_GetItem(obj,j);
-           if(!PyArg_Parse(obj2, "i", &input)) {
+           if (!PyLong_Check(obj2)) {
               PyErr_SetString(PyExc_TypeError, " pgroup_create() input error 4");
               return NULL;
            }
+           input = PyLong_AsLong(obj2);
            k++;
            node_list[k] = (Integer) input ;
         }
@@ -1275,11 +1262,11 @@ static PyObject *do_pgroup_create(PyObject *self, PyObject *args)
    nodeid = GA_Pgroup_nodeid(my_ga_group);
    ngroups = util_sgroup_numgroups_() ;
    mygroup = util_sgroup_mygroup_() ;
-   PyTuple_SET_ITEM(returnObj, 0, PyInt_FromLong((long) mygroup ));
-   PyTuple_SET_ITEM(returnObj, 1, PyInt_FromLong((long) ngroups));
-   PyTuple_SET_ITEM(returnObj, 2, PyInt_FromLong((long) nodeid));
-   PyTuple_SET_ITEM(returnObj, 3, PyInt_FromLong((long) nnodes));
-   PyTuple_SET_ITEM(returnObj, 4, PyInt_FromLong((long) my_ga_group));
+   PyTuple_SET_ITEM(returnObj, 0, PyLong_FromLong((long) mygroup ));
+   PyTuple_SET_ITEM(returnObj, 1, PyLong_FromLong((long) ngroups));
+   PyTuple_SET_ITEM(returnObj, 2, PyLong_FromLong((long) nodeid));
+   PyTuple_SET_ITEM(returnObj, 3, PyLong_FromLong((long) nnodes));
+   PyTuple_SET_ITEM(returnObj, 4, PyLong_FromLong((long) my_ga_group));
    return returnObj ;
 }
 
@@ -1294,10 +1281,6 @@ static PyObject *do_pgroup_destroy(PyObject *self, PyObject *args)
    int nodeid ;      // Node ID in this group (they are 0 to nnodes-1)
    int nnodes ;      // Number of nodes in this group
    Integer my_ga_group ; // The Global Arrays group ID - useful for debug only at this time
-   if (args) {
-      PyErr_SetString(PyExc_TypeError, "Usage: pgroup_destroy()");
-      return NULL;
-   }
    if (!(returnObj = PyTuple_New(5))) {
        PyErr_SetString(NwchemError, "do_pgroup_destroy failed with pyobj");
        return NULL;
@@ -1308,22 +1291,18 @@ static PyObject *do_pgroup_destroy(PyObject *self, PyObject *args)
    nodeid = GA_Pgroup_nodeid(my_ga_group);
    ngroups = util_sgroup_numgroups_() ;
    mygroup = util_sgroup_mygroup_() ;
-   PyTuple_SET_ITEM(returnObj, 0, PyInt_FromLong((long) mygroup ));
-   PyTuple_SET_ITEM(returnObj, 1, PyInt_FromLong((long) ngroups));
-   PyTuple_SET_ITEM(returnObj, 2, PyInt_FromLong((long) nodeid));
-   PyTuple_SET_ITEM(returnObj, 3, PyInt_FromLong((long) nnodes));
-   PyTuple_SET_ITEM(returnObj, 4, PyInt_FromLong((long) my_ga_group));
+   PyTuple_SET_ITEM(returnObj, 0, PyLong_FromLong((long) mygroup ));
+   PyTuple_SET_ITEM(returnObj, 1, PyLong_FromLong((long) ngroups));
+   PyTuple_SET_ITEM(returnObj, 2, PyLong_FromLong((long) nodeid));
+   PyTuple_SET_ITEM(returnObj, 3, PyLong_FromLong((long) nnodes));
+   PyTuple_SET_ITEM(returnObj, 4, PyLong_FromLong((long) my_ga_group));
    return returnObj ;
 }
 
    ///  This is a generic barrier that forces all members of a group to 
    ///  sync up before moving on
-static PyObject *do_pgroup_sync_work(PyObject *args, Integer my_group)
+static PyObject *do_pgroup_sync_work(Integer my_group)
 {
-   if (args) {
-      PyErr_SetString(PyExc_TypeError, "Usage: pgroup_sync() or pgroup_sync_all()");
-      return NULL;
-   }
    GA_Pgroup_sync(my_group);
    Py_INCREF(Py_None);
    return Py_None;
@@ -1331,13 +1310,13 @@ static PyObject *do_pgroup_sync_work(PyObject *args, Integer my_group)
 static PyObject *do_pgroup_sync(PyObject *self, PyObject *args)
 {
    Integer my_group = GA_Pgroup_get_default() ;
-   PyObject *returnObj = do_pgroup_sync_work(args,my_group);
+   PyObject *returnObj = do_pgroup_sync_work(my_group);
    return returnObj ;
 }
 static PyObject *do_pgroup_sync_all(PyObject *self, PyObject *args)
 {
    Integer my_group = GA_Pgroup_get_world() ;
-   PyObject *returnObj = do_pgroup_sync_work(args,my_group);
+   PyObject *returnObj = do_pgroup_sync_work(my_group);
    return returnObj ;
 }
 
@@ -1374,7 +1353,8 @@ static PyObject *do_pgroup_global_op_work(PyObject *args, Integer my_group)
     }
     else {
        obj = PyTuple_GetItem(args, 1);
-       if (!PyArg_Parse(obj, "s", &pchar)) pchar = &plus;
+       pchar = Parse_String(obj);
+       if (!pchar) pchar = &plus;
        obj  = PyTuple_GetItem(args, 0);
     }
 
@@ -1390,10 +1370,10 @@ static PyObject *do_pgroup_global_op_work(PyObject *args, Integer my_group)
     for (i = 0; i < nelem; i++) {
        if (list) {
          is_double = PyFloat_Check(PyList_GetItem(obj, i));
-         is_int    = PyInt_Check(PyList_GetItem(obj, i));
+         is_int    = PyLong_Check(PyList_GetItem(obj, i));
        } else {
          is_double = PyFloat_Check(obj);
-         is_int    = PyInt_Check(obj);
+         is_int    = PyLong_Check(obj);
        }
        if (!is_double && !is_int) {
            PyErr_SetString(PyExc_TypeError,
@@ -1415,22 +1395,22 @@ static PyObject *do_pgroup_global_op_work(PyObject *args, Integer my_group)
 
       for (i = 0; i < nelem; i++) {
          if (list) {
-           is_int    = PyInt_Check(PyList_GetItem(obj, i));
+           is_int    = PyLong_Check(PyList_GetItem(obj, i));
          } else {
-           is_int    = PyInt_Check(obj);
+           is_int    = PyLong_Check(obj);
          }
          if (!is_int) {
            if (list) {
-             PyArg_Parse(PyList_GetItem(obj, i), "d", &tmp_double);
+             tmp_double = PyFloat_AsDouble(PyList_GetItem(obj, i));
            } else {
-             PyArg_Parse(obj, "d", &tmp_double);
+             tmp_double = PyFloat_AsDouble(obj);
            }
            array[i] = (DoublePrecision) tmp_double;
          } else {
            if (list) {
-             PyArg_Parse(PyList_GetItem(obj, i), "i", &tmp_int);
+             tmp_int = PyLong_AsLong(PyList_GetItem(obj, i));
            } else {
-             PyArg_Parse(obj, "i", &tmp_int);
+             tmp_int = PyLong_AsLong(obj);
            }
            array[i] = (DoublePrecision) tmp_int;
          }
@@ -1454,9 +1434,9 @@ static PyObject *do_pgroup_global_op_work(PyObject *args, Integer my_group)
       
       for (i = 0; i < nelem; i++) {
          if (list) {
-           PyArg_Parse(PyList_GetItem(obj, i), "i", &tmp_int);
+           tmp_int = PyLong_AsLong(PyList_GetItem(obj, i));
          } else {
-           PyArg_Parse(obj, "i", &tmp_int);
+           tmp_int = PyLong_AsLong(obj);
          }
          array[i] = (Integer) tmp_int;
       }
@@ -1524,10 +1504,10 @@ static PyObject *do_pgroup_broadcast_work(PyObject *args, Integer my_group)
     for (i = 0; i < nelem; i++) {
        if (list) {
          is_double = PyFloat_Check(PyList_GetItem(obj, i));
-         is_int    = PyInt_Check(PyList_GetItem(obj, i));
+         is_int    = PyLong_Check(PyList_GetItem(obj, i));
        } else {
          is_double = PyFloat_Check(obj);
-         is_int    = PyInt_Check(obj);
+         is_int    = PyLong_Check(obj);
        }
        if (!is_double && !is_int) {
            PyErr_SetString(PyExc_TypeError,"global_broadcast() found non-numerical value");
@@ -1548,22 +1528,22 @@ static PyObject *do_pgroup_broadcast_work(PyObject *args, Integer my_group)
 
       for (i = 0; i < nelem; i++) {
          if (list) {
-           is_int    = PyInt_Check(PyList_GetItem(obj, i));
+           is_int    = PyLong_Check(PyList_GetItem(obj, i));
          } else {
-           is_int    = PyInt_Check(obj);
+           is_int    = PyLong_Check(obj);
          }
          if (!is_int) {
            if (list) {
-             PyArg_Parse(PyList_GetItem(obj, i), "d", &tmp_double);
+             tmp_double = PyFloat_AsDouble(PyList_GetItem(obj, i));
            } else {
-             PyArg_Parse(obj, "d", &tmp_double);
+             tmp_double = PyFloat_AsDouble(obj);
            }
            array[i] = (DoublePrecision) tmp_double;
          } else {
            if (list) {
-             PyArg_Parse(PyList_GetItem(obj, i), "i", &tmp_int);
+             tmp_int = PyLong_AsLong(PyList_GetItem(obj, i));
            } else {
-             PyArg_Parse(obj, "i", &tmp_int);
+             tmp_int = PyLong_AsLong(obj);
            }
            array[i] = (DoublePrecision) tmp_int;
          }
@@ -1584,9 +1564,9 @@ static PyObject *do_pgroup_broadcast_work(PyObject *args, Integer my_group)
       
       for (i = 0; i < nelem; i++) {
          if (list) {
-           PyArg_Parse(PyList_GetItem(obj, i), "i", &tmp_int);
+           tmp_int = PyLong_AsLong(PyList_GetItem(obj, i));
          } else {
-           PyArg_Parse(obj, "i", &tmp_int);
+           tmp_int = PyLong_AsLong(obj);
          }
          array[i] = (Integer) tmp_int;
       }
@@ -1627,10 +1607,6 @@ static PyObject *do_pgroup_nnodes(PyObject *self, PyObject *args)
    /// Returns the number of nodes in a group
    Integer my_group = GA_Pgroup_get_default() ;
    int nnodes = GA_Pgroup_nnodes(my_group);
-   if (args) {
-      PyErr_SetString(PyExc_TypeError, "Usage: pgroup_nnodes()");
-      return NULL;
-   }
    return Py_BuildValue("i", nnodes);
 }
 
@@ -1641,10 +1617,6 @@ static PyObject *do_pgroup_nodeid(PyObject *self, PyObject *args)
    /// Nodes are numbered, 0 to NumNodes-1
    Integer my_group = GA_Pgroup_get_default() ;
    int nodeid = GA_Pgroup_nodeid(my_group);
-   if (args) {
-      PyErr_SetString(PyExc_TypeError, "Usage: pgroup_nodeid()");
-      return NULL;
-   }
    return Py_BuildValue("i", nodeid);
 }
 
@@ -1652,10 +1624,6 @@ static PyObject *do_pgroup_ngroups(PyObject *self, PyObject *args)
 {
    /// Returns the number of groups at the current groups level
    Integer ngroups = util_sgroup_numgroups_() ;
-   if (args) {
-      PyErr_SetString(PyExc_TypeError, "Usage: pgroup_ngroups()");
-      return NULL;
-   }
    return Py_BuildValue("i", ngroups);
 }
 
@@ -1663,10 +1631,6 @@ static PyObject *do_pgroup_groupid(PyObject *self, PyObject *args)
 {
    /// Returns the ID of group at the current groups level 
    Integer mygroup = util_sgroup_mygroup_() ;
-   if (args) {
-      PyErr_SetString(PyExc_TypeError, "Usage: pgroup_groupid()");
-      return NULL;
-   }
    return Py_BuildValue("i", mygroup);
 }
 
@@ -1690,55 +1654,111 @@ static PyObject *do_ga_groupid(PyObject *self, PyObject *args)
 
 
 static struct PyMethodDef nwchem_methods[] = {
-   {"rtdb_open",       wrap_rtdb_open, 0}, 
-   {"rtdb_close",      wrap_rtdb_close, 0}, 
-   {"pass_handle",     wrap_pass_handle, 0}, 
-   {"rtdb_print",      wrap_rtdb_print, 0}, 
-   {"rtdb_put",        wrap_rtdb_put, 0}, 
-   {"rtdb_get",        wrap_rtdb_get, 0}, 
-   {"rtdb_delete",     wrap_rtdb_delete, 0}, 
-   {"rtdb_get_info",   wrap_rtdb_get_info, 0}, 
-   {"rtdb_first",      wrap_rtdb_first, 0}, 
-   {"rtdb_next",       wrap_rtdb_next, 0}, 
-   {"task",            wrap_task, 0}, 
-   {"task_energy",     wrap_task_energy, 0}, 
-   {"task_property",   wrap_task_property, 0}, 
-   {"task_gradient",   wrap_task_gradient, 0}, 
-   {"task_stress",     wrap_task_stress, 0}, 
-   {"task_lstress",    wrap_task_lstress, 0}, 
-   {"task_optimize",   wrap_task_optimize, 0}, 
-   {"task_hessian",    wrap_task_hessian, 0},
-   {"dplot",           wrap_dplot, 0},
-   {"task_saddle",     wrap_task_saddle, 0},
-   {"task_freq",       wrap_task_freq, 0},
-   {"task_coulomb",    wrap_task_coulomb, 0}, 
-   {"task_coulomb_ref",    wrap_task_coulomb_ref, 0}, 
-   {"input_parse",     wrap_nw_inp_from_string, 0}, 
-   {"ga_nodeid",       do_pgroup_nodeid, 0},  // This is the same as pgroup_nodeid
-   {"ga_groupid",      do_ga_groupid, 0},    // This is NOT the same as pgroup_groupid
-   {"pgroup_create",   do_pgroup_create, 0},
-   {"pgroup_destroy",  do_pgroup_destroy, 0},
-   {"pgroup_sync",     do_pgroup_sync, 0},
-   {"pgroup_global_op",do_pgroup_global_op, 0},
-   {"pgroup_broadcast",do_pgroup_broadcast, 0},
-   {"pgroup_sync_all",     do_pgroup_sync_all, 0},
-   {"pgroup_global_op_all",do_pgroup_global_op_all, 0},
-   {"pgroup_broadcast_all",do_pgroup_broadcast_all, 0},
-   {"pgroup_global_op_zero",do_pgroup_global_op_zero, 0},
-   {"pgroup_broadcast_zero",do_pgroup_broadcast_zero, 0},
-   {"pgroup_nnodes",   do_pgroup_nnodes, 0},
-   {"pgroup_nodeid",   do_pgroup_nodeid, 0},
-   {"pgroup_groupid",  do_pgroup_groupid, 0},
-   {"pgroup_ngroups",  do_pgroup_ngroups, 0},
+   {"rtdb_open",       wrap_rtdb_open, METH_VARARGS}, 
+   {"rtdb_close",      wrap_rtdb_close, METH_VARARGS}, 
+   {"pass_handle",     wrap_pass_handle, METH_VARARGS}, 
+   {"rtdb_print",      wrap_rtdb_print, METH_VARARGS}, 
+   {"rtdb_put",        wrap_rtdb_put, METH_VARARGS}, 
+   {"rtdb_get",        wrap_rtdb_get, METH_VARARGS}, 
+   {"rtdb_delete",     wrap_rtdb_delete, METH_VARARGS}, 
+   {"rtdb_get_info",   wrap_rtdb_get_info, METH_VARARGS}, 
+   {"rtdb_first",      wrap_rtdb_first, METH_NOARGS}, 
+   {"rtdb_next",       wrap_rtdb_next, METH_NOARGS}, 
+   {"task",            wrap_task, METH_VARARGS}, 
+   {"task_energy",     wrap_task_energy, METH_VARARGS}, 
+   {"task_property",   wrap_task_property, METH_VARARGS}, 
+   {"task_gradient",   wrap_task_gradient, METH_VARARGS}, 
+   {"task_stress",     wrap_task_stress, METH_VARARGS}, 
+   {"task_lstress",    wrap_task_lstress, METH_VARARGS}, 
+   {"task_optimize",   wrap_task_optimize, METH_VARARGS}, 
+   {"task_hessian",    wrap_task_hessian, METH_VARARGS},
+   {"dplot",           wrap_dplot, METH_NOARGS},
+   {"task_saddle",     wrap_task_saddle, METH_VARARGS},
+   {"task_freq",       wrap_task_freq, METH_VARARGS},
+   {"task_coulomb",    wrap_task_coulomb, METH_VARARGS}, 
+   {"task_coulomb_ref",    wrap_task_coulomb_ref, METH_VARARGS}, 
+   {"input_parse",     wrap_nw_inp_from_string, METH_VARARGS}, 
+   {"ga_nodeid",       do_pgroup_nodeid, METH_NOARGS},  // This is the same as pgroup_nodeid
+   {"ga_groupid",      do_ga_groupid, METH_NOARGS},    // This is NOT the same as pgroup_groupid
+   {"pgroup_create",   do_pgroup_create, METH_VARARGS},
+   {"pgroup_destroy",  do_pgroup_destroy, METH_NOARGS},
+   {"pgroup_sync",     do_pgroup_sync, METH_NOARGS},
+   {"pgroup_global_op",do_pgroup_global_op, METH_VARARGS},
+   {"pgroup_broadcast",do_pgroup_broadcast, METH_VARARGS},
+   {"pgroup_sync_all",     do_pgroup_sync_all, METH_NOARGS},
+   {"pgroup_global_op_all",do_pgroup_global_op_all, METH_VARARGS},
+   {"pgroup_broadcast_all",do_pgroup_broadcast_all, METH_VARARGS},
+   {"pgroup_global_op_zero",do_pgroup_global_op_zero, METH_VARARGS},
+   {"pgroup_broadcast_zero",do_pgroup_broadcast_zero, METH_VARARGS},
+   {"pgroup_nnodes",   do_pgroup_nnodes, METH_NOARGS},
+   {"pgroup_nodeid",   do_pgroup_nodeid, METH_NOARGS},
+   {"pgroup_groupid",  do_pgroup_groupid, METH_NOARGS},
+   {"pgroup_ngroups",  do_pgroup_ngroups, METH_NOARGS},
    {NULL, NULL}
 };
 
-void initnwchem()
-{
-    PyObject *mObj, *dObj;
-    mObj = Py_InitModule("nwchem", nwchem_methods);
-    dObj = PyModule_GetDict(mObj);
-    NwchemError = PyErr_NewException("nwchem.error", NULL, NULL);
-    PyDict_SetItemString(dObj, "NWChemError", NwchemError);
+struct module_state {
+  PyObject *error;
+};
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+#endif
+
+static PyObject* error_out(PyObject *m) {
+  struct module-state *st = GETSTATE(m);
+  PyErr_SetString(st->error, "something bad happened");
+  return NULL;
 }
 
+#if PY_MAJOR_VERSION >= 3
+
+static int nwchem_traverse(PyObject *m, visitproc visit, void *arg) {
+  Py_VISIT(GETSTATE(m)->error);
+  return 0;
+}
+
+static int nwchem_clear(PyObject *m) {
+  Py_CLEAR(GETSTATE(m)->error);
+  return 0;
+}
+
+static struct PyModuleDef moduledef = {
+  PyModuleDef_HEAD_INIT,
+  "nwchem",
+  NULL,
+  sizeof(struct module_state),
+  nwchem_methods,
+  NULL,
+  nwchem_traverse,
+  nwchem_clear,
+  NULL
+};
+
+#define INITERROR return NULL
+PyMODINIT_FUNC PyInit_nwchem(void)
+#else
+#define INITERROR return
+void initnwchem()
+#endif
+{
+#if PY_MAJOR_VERSION >= 3
+  PyObject *module = PyModule_Create(&moduledef);
+#else
+  PyObject *module = Py_InitModule("nwchem", nwchem_methods);
+#endif
+  if (module == NULL)
+    INITERROR;
+  struct module_state *st = GETSTATE(module);
+  st->error = PyErr_NewException("nwchem.error", NULL, NULL);
+  if (st->error = NULL) {
+    Py_DECREF(module);
+    INITERROR;
+  }
+#if PY_MAJOR_VERSION >= 3
+  return module;
+#endif
+}

--- a/src/python/nwchem_wrap.c
+++ b/src/python/nwchem_wrap.c
@@ -330,7 +330,7 @@ static PyObject *wrap_rtdb_put(PyObject *self, PyObject *args)
       if (array) free(array);
       return NULL;
       break;
-    }                
+    }
     
     if (!(rtdb_put(rtdb_handle, name, ma_type, list_len, array))) {
       PyErr_SetString(NwchemError, "rtdb_put failed");

--- a/src/python/nwchem_wrap.c
+++ b/src/python/nwchem_wrap.c
@@ -45,9 +45,23 @@ extern void ga_pgroup_igop_(Integer *,Integer *,Integer *,Integer *,char *);
 #define PyInteger_Check(m) PyLong_Check(m)
 #define PyInteger_AsLong(m) PyLong_AsLong(m)
 #else
-#define PyInteger_FromLong(m) PyInt_FromLong(m)
-#define PyInteger_Check(m) PyInt_Check(m)
-#define PyInteger_AsLong(m) PyInt_AsLong(m)
+#define PyInteger_FromLong(m) PyLong_FromLong(m)
+static int PyInteger_Check(PyObject *obj)
+{
+  return (PyInt_Check(obj) || PyLong_Check(obj));
+}
+
+static long PyInteger_AsLong(PyObject *obj)
+{
+  if (PyLong_Check(obj)) {
+    return PyLong_AsLong(obj);
+  } else if (PyInt_Check(obj)) {
+    return PyInt_AsLong(obj);
+  } else {
+    PyErr_SetString(PyExc_TypeError, "Argument is not an Integer type!");
+    return NULL;
+  }
+}
 #endif
 
 extern int nw_inp_from_string(int, const char *);
@@ -1532,7 +1546,11 @@ static PyObject *do_pgroup_broadcast_work(PyObject *args, Integer my_group)
     Integer nelem ;
     PyObject *obj, *returnObj;
 
-    obj  = args;
+    if (PyTuple_Check(args)) {
+      obj = PyTuple_GetItem(args, 0);
+    } else {
+      obj = args;
+    }
 
     if (PyList_Check(obj)){
       list = 1;

--- a/src/python/nwchem_wrap.c
+++ b/src/python/nwchem_wrap.c
@@ -271,7 +271,7 @@ static PyObject *wrap_rtdb_put(PyObject *self, PyObject *args)
     char *char_array;
     char cbuf[8192], *ptr;
     void *array = 0;
-    PyObject *obj, *option_obj, *ascii_string;
+    PyObject *obj, *option_obj;
 
     name = Parse_String(PyTuple_GetItem(args, 0));
     obj = PyTuple_GetItem(args, 1);
@@ -382,12 +382,6 @@ static PyObject *wrap_rtdb_put(PyObject *self, PyObject *args)
       return NULL;
     }
     
-    //} else {
-    //  PyErr_SetString(PyExc_TypeError, 
-    //                  "Usage: rtdb_put(value or values,[optional type])");
-    //  if ((ma_type != MT_CHAR) && array) free(array);
-    //  return NULL;
-    //}
     Py_INCREF(Py_None);
     if ((ma_type != MT_CHAR) && array) free(array);
     return Py_None;

--- a/src/python/task_python.c
+++ b/src/python/task_python.c
@@ -27,8 +27,13 @@ int FATR task_python_(Integer *rtdb_ptr)
    int ret;
    
    Py_SetProgramName("NWChem");
+#if PY_MAJOR_VERSION >= 3
+   PyImport_AppendInittab("nwchem", PyInit_nwchem);
+#endif
    Py_Initialize();		/* set the PYTHONPATH env   */
+#if PY_MAJOR_VERSION < 3
    initnwchem();
+#endif
    if (PyRun_SimpleString("from nwchem import *")) {
      fprintf(stderr,"import of NWCHEM failed\n");
      return 0;

--- a/src/python/task_python.c
+++ b/src/python/task_python.c
@@ -11,7 +11,11 @@
 #include <stdlib.h>
 #include "typesf2c.h"
 
+#if PY_MAJOR_VERSION >= 3
+extern PyMODINIT_FUNC PyInit_nwchem();
+#else
 extern void initnwchem();
+#endif
 extern void util_file_parallel_copy(const char *, const char *);
 
 

--- a/src/python/tests/bsse.nw
+++ b/src/python/tests/bsse.nw
@@ -51,23 +51,25 @@ mp2; freeze core atomic; end
 print none
 
 python noprint
+from __future__ import print_function
+
 energies = {}
 for system in ('supermolecule', 
                'fragment1', 'fragment1+ghost2',
                'fragment2', 'ghost1+fragment2'):
     rtdb_put('geometry',system)
     energies[system] = task_energy('mp2')
-    print '   %16s = %10.6f' % (system,energies[system])
+    print('   %16s = %10.6f' % (system,energies[system]))
 
 uncorrected = energies['supermolecule'] - energies['fragment1'] \
                                         - energies['fragment2']
 corrected   = energies['supermolecule'] - energies['fragment1+ghost2'] \
                                         - energies['ghost1+fragment2']
-print ' '
-print '                Interaction energy = %10.6f' % uncorrected
-print ' BSSE corrected interaction energy = %10.6f' % corrected
-print '                   BSSE correction = %10.6f' % (corrected-uncorrected)
-print ' '
+print(' ')
+print('                Interaction energy = %10.6f' % uncorrected)
+print(' BSSE corrected interaction energy = %10.6f' % corrected)
+print('                   BSSE correction = %10.6f' % (corrected-uncorrected))
+print(' '
 end
 
 task python

--- a/src/python/tests/bsse.nw
+++ b/src/python/tests/bsse.nw
@@ -69,7 +69,7 @@ print(' ')
 print('                Interaction energy = %10.6f' % uncorrected)
 print(' BSSE corrected interaction energy = %10.6f' % corrected)
 print('                   BSSE correction = %10.6f' % (corrected-uncorrected))
-print(' '
+print(' ')
 end
 
 task python

--- a/src/python/tests/optexp.nw
+++ b/src/python/tests/optexp.nw
@@ -14,6 +14,8 @@ print none
 scf; thresh 1e-8; end
 
 python noprint
+from __future__ import print_function
+
 from math import *
 
 #
@@ -35,8 +37,8 @@ def energy_at_exponent(exponent):
 #
 def optimize_exponent(exponent):
    if (ga_nodeid() == 0):
-      print ' exponent     energy     gradient hessian    step '
-      print '---------- ------------ --------- ------- ----------'
+      print(' exponent     energy     gradient hessian    step ')
+      print('---------- ------------ --------- ------- ----------')
 
    scale = 1.0
    gradient = 1.0
@@ -52,17 +54,17 @@ def optimize_exponent(exponent):
          step     = -gradient/hessian
          scale = 1.0
       else:
-         if (ga_nodeid() == 0):print 'Negative curvature'
+         if (ga_nodeid() == 0):print('Negative curvature')
          step = -0.2*gradient*scale
          scale = scale*10
       if (fabs(step) > 0.2):
-         if (ga_nodeid() == 0):print 'Restricting step'
+         if (ga_nodeid() == 0):print('Restricting step')
          step = 0.2*step/fabs(step) - 0.02
       if (ga_nodeid() == 0):
-         print '%10.6f %12.8f %9.6f %6.2f %10.6f' % \
-               (exponent, e, gradient, hessian, step)
+         print('%10.6f %12.8f %9.6f %6.2f %10.6f' % \
+               (exponent, e, gradient, hessian, step))
       exponent = exponent + step
-   if (ga_nodeid() == 0): print ' '
+   if (ga_nodeid() == 0): print(' ')
    return exponent
 
 # Scan from large exponents to small.  As soon as we pass a minimum
@@ -72,20 +74,20 @@ exponent = 2.0
 step = 0.2
 previous = energy_at_exponent(exponent)
 if (ga_nodeid() == 0):
-   print ' exponent=%10.6f energy=%12.8f' % (exponent, previous)
+   print(' exponent=%10.6f energy=%12.8f' % (exponent, previous))
 downhill = 0
 while (exponent > step):
    exponent = exponent - step
    energy = energy_at_exponent(exponent)
    if (ga_nodeid() == 0):
-      print ' exponent=%10.6f energy=%12.8f' % (exponent, energy)
+      print(' exponent=%10.6f energy=%12.8f' % (exponent, energy))
    if (downhill and (energy > previous)):
       exponent = optimize_exponent(exponent+0.5*step)
       previous = energy_at_exponent(exponent)
       if (ga_nodeid() == 0):
-         print ' Minimum found at exponent=%10.6f energy=%12.8f' % \
-               (exponent, previous)
-         print ' '
+         print(' Minimum found at exponent=%10.6f energy=%12.8f' % \
+               (exponent, previous))
+         print(' ')
       downhill = 0
    else:
       downhill = (energy < previous)

--- a/src/python/tests/scanexp.nw
+++ b/src/python/tests/scanexp.nw
@@ -16,6 +16,8 @@ end
 print none
 
 python
+from __future__ import print_function
+
 import os
 plotdata = open("plotdata",'w')
 
@@ -31,10 +33,10 @@ while x <= 0.6:
    
    try:
       energy = task_energy('scf')
-      print ' x = ', x, ' energy = ', energy
+      print(' x = ', x, ' energy = ', energy)
       plotdata.write('%f %f\n' % (x , energy))
    except:
-      print 'task_energy failed'
+      print('task_energy failed')
 
    x = x + 0.02
 

--- a/src/python/tests/scanexp2.nw
+++ b/src/python/tests/scanexp2.nw
@@ -12,6 +12,8 @@ end
 print none
 
 python
+from __future__ import print_function
+
 import os
 plotdata = open("plotdata",'w')
 
@@ -29,7 +31,7 @@ def energy_at_exponent(exponent):
 exponent = 0.5
 while exponent <= 0.6:
    energy = energy_at_exponent(exponent)
-   print ' exponent = ', exponent, ' energy = ', energy
+   print(' exponent = ', exponent, ' energy = ', energy)
    plotdata.write('%f %f\n' % (exponent , energy))
    exponent = exponent + 0.02
 

--- a/src/python/tests/scanexp_simple.nw
+++ b/src/python/tests/scanexp_simple.nw
@@ -13,6 +13,8 @@ geometry units au noprint
 end
 
 python noprint
+from __future__ import print_function
+
 exponent = 0.1
 while (exponent <= 2.0):
    input_parse('''
@@ -23,7 +25,7 @@ while (exponent <= 2.0):
       end
    ''' % (exponent))
 
-   print ' exponent = ', exponent, ' energy = ', task_energy('scf')
+   print(' exponent = ', exponent, ' energy = ', task_energy('scf'))
    exponent = exponent + 0.1
 end
 

--- a/src/python/tests/scangeom.nw
+++ b/src/python/tests/scangeom.nw
@@ -11,8 +11,10 @@ basis noprint
 end
 
 python noprint
-  print '   y     z       energy '
-  print ' ----- ----- --------------'
+  from __future__ import print_function
+  
+  print('   y     z       energy ')
+  print(' ----- ----- --------------')
   y = 1.2
   elo = 0.0
   while y <= 1.61:
@@ -30,12 +32,12 @@ python noprint
            elo = energy
            ylo = y
            zlo = z
-        print ' %5.2f %5.2f %13.8f' % (y, z, energy)
+        print(' %5.2f %5.2f %13.8f' % (y, z, energy))
         z = z + 0.1
      y = y + 0.1
-  print ' '
-  print ' Lowest energy =',elo,' at y=',ylo,', z =',zlo
-  print ' '
+  print(' ')
+  print(' Lowest energy =',elo,' at y=',ylo,', z =',zlo)
+  print(' ')
 end
 
 print none

--- a/src/python/tests/test.nw
+++ b/src/python/tests/test.nw
@@ -6,34 +6,35 @@ start test1
 # test some basic python wrappers.
 
 python
+from __future__ import print_function
 
-print "value check:"
-print "INT     = ", INT
-print "DBL     = ", DBL
-print "CHAR    = ", CHAR
-print "LOGICAL = ", LOGICAL
+print("value check:")
+print("INT     = ", INT)
+print("DBL     = ", DBL)
+print("CHAR    = ", CHAR)
+print("LOGICAL = ", LOGICAL)
 
 rtdb_put("test_int2", 22)
-print ' Done 1'
+print(' Done 1')
 rtdb_put("test_int", [22, 10, 3],    INT)
-print ' Done 2'
+print(' Done 2')
 rtdb_put("test_dbl", [22.9, 12.4, 23.908],  DBL)
-print ' Done 3'
+print(' Done 3')
 rtdb_put("test_str", "hello", CHAR)
-print ' Done 4'
+print(' Done 4')
 rtdb_put("test_logic", [0,1,0,1,0,1], LOGICAL)
-print ' Done 5'
+print(' Done 5')
 rtdb_put("test_logic2", 0, LOGICAL)
-print ' Done 6'
+print(' Done 6')
 
 rtdb_print(1)
 
-print "test_str    = ", rtdb_get("test_str")
-print "test_int    = ", rtdb_get("test_int")
-print "test_in2    = ", rtdb_get("test_int2")
-print "test_dbl    = ", rtdb_get("test_dbl")
-print "test_logic  = ", rtdb_get("test_logic")
-print "test_logic2 = ", rtdb_get("test_logic2")
+print("test_str    = ", rtdb_get("test_str"))
+print("test_int    = ", rtdb_get("test_int"))
+print("test_in2    = ", rtdb_get("test_int2"))
+print("test_dbl    = ", rtdb_get("test_dbl"))
+print("test_logic  = ", rtdb_get("test_logic"))
+print("test_logic2 = ", rtdb_get("test_logic2"))
 
 end
 

--- a/src/python/tests/testgrad.nw
+++ b/src/python/tests/testgrad.nw
@@ -11,8 +11,10 @@ basis noprint
 end
 
 python noprint
-  print '   y     z     energy                     gradient'
-  print ' ----- ----- ---------- -----------------------------------------------------'
+  from __future__ import print_function
+  
+  print('   y     z     energy                     gradient')
+  print(' ----- ----- ---------- -----------------------------------------------------')
   y = 1.2
   elo = 0.0
   while y <= 1.61:
@@ -30,17 +32,17 @@ python noprint
            elo = energy
            ylo = y
            zlo = z
-        print ' %5.2f %5.2f %9.6f' % (y, z, energy),
+        print(' %5.2f %5.2f %9.6f' % (y, z, energy),)
         i = 0
         while (i < len(gradient)):
-           print '%5.2f' % gradient[i],
+           print('%5.2f' % gradient[i],)
            i = i + 1
-        print ''
+        print('')
         z = z + 0.1
      y = y + 0.1
-  print ''
-  print ' Lowest energy =',elo,' at y=',ylo,', z =',zlo
-  print ' '
+  print('')
+  print(' Lowest energy =',elo,' at y=',ylo,', z =',zlo)
+  print(' ')
 end
 
 print none


### PR DESCRIPTION
These changes enable NWChem to link against either Python 2.7 or Python 3.x. 

Some important points:

- This very likely breaks support for Python 1.x, though I haven't tested.
- The examples using the Python task (e.g. src/python/tests) have been modified to support both Python 2 and Python 3, but I have not modified any of the .py files shipped with NWChem.
- Storing logical values with `rtdb_put` is broken. This can be seen with src/python/tests/test.nw. I will share output in a reply to this PR. I don't think this is caused by my changes.
- Many changes were necessary due to the deprecation of `PyArgs_Parse`, and I have not tested every code path. In particular, I am uncertain about the way I modified `do_pgroup_create`. Are there unit tests for this functionality? Otherwise, could someone share a simple example input deck that uses this?
- This assumes that the Python config utility for Python 3.x is named `python3-config`. This will not always be the case; some systems for which Python 3 is the default version will call it simply `python-config`. This problem should be resolved before merging, most likely.