### PR TITLE
enable debug symbols by default in ARMCI-MPI install script

### DIFF
--- a/src/tools/install-armci-mpi
+++ b/src/tools/install-armci-mpi
@@ -79,7 +79,7 @@ if ! [ -d ${ARMCI_MPI_DIR}/build ] ; then
 fi
 cd ${ARMCI_MPI_DIR}/build
 
-${ARMCI_MPI_DIR}/configure CC=$ARMCIMPICC --prefix=${NWCHEM_TOP}/external-armci >& c.log
+${ARMCI_MPI_DIR}/configure CC=$ARMCIMPICC --prefix=${NWCHEM_TOP}/external-armci --enable-g >& c.log
 stat=$?
 if [ $stat -ne 0 ] ; then
   echo "configure failed."


### PR DESCRIPTION
This does not affect anyone who doesn't use this...