### PR TITLE
Fix build on FreeBSD on POWER architecture

### DIFF
--- a/src/peigs/DEFS
+++ b/src/peigs/DEFS
@@ -560,7 +560,7 @@ ifeq ($(FC),pgf90)
 	peigs_FC  +=  -Kieee
 	endif
 	endif
-ifeq ($(_CPU),$(findstring $(_CPU), ppc64 ppc64le))
+ifeq ($(_CPU),$(findstring $(_CPU), powerpc64 ppc64 ppc64le))
 #ppc64 with /tcgmsg
 	peigs_CPU = RS6000
 ifeq ($(FC),xlf)


### PR DESCRIPTION
FreeBSD uses powerpc64 name for POWER architecture.