### PR TITLE
convert TCE cuda codes to hip codes which can run on AMD GPUs

### DIFF
--- a/contrib/distro-tools/build_nwchem
+++ b/contrib/distro-tools/build_nwchem
@@ -1956,6 +1956,30 @@ if [ ${#TCE_CUDA} -ne 0 ] ; then
   fi
   # There is also a variable CUDA_FLAGS but I have no idea what that should be.
 fi
+
+if [ ${#TCE_HIP} -ne 0 ] ; then
+  if [ ${#HIP} -eq 0 ] ; then
+     HIP=`which hipcc`
+     if [ ${#HIP} -ne 0 ] ; then
+       export HIP
+     else
+       unset HIP
+     fi
+  fi
+  if [ ${#HIP} -ne 0 ] ; then
+     HIP_PATH="`dirname ${HIP}`"
+     HIP_PATH="`dirname ${HIP_PATH}`"
+     if [ ${#HIP_INCLUDE} -eq 0 ] ; then
+       export HIP_INCLUDE="-I${HIP_PATH}/include"
+     fi
+     if [ ${#HIP_LIBS} -eq 0 ] ; then
+       export HIP_LIBS="-L${HIP_PATH}/lib -lhip_hcc"
+     fi
+     unset HIP_PATH
+  fi
+  # There is also a variable CUDA_FLAGS but I have no idea what that should be.
+fi
+
 #
 # Work out whether BLAS, LAPACK and SCALAPACK are compatible and based on that
 # what we are actually going to use.
@@ -2257,6 +2281,27 @@ if [ ${#CUDA_LIBS} -ne 0 ] ; then
   echo "setenv CUDA_LIBS \"${CUDA_LIBS}\"" >> ${NWCHEM_ENV_CSH}
   echo "unset CUDA_LIBS"                   >> ${NWCHEM_UNENV_SH}
   echo "unsetenv CUDA_LIBS"                >> ${NWCHEM_UNENV_CSH}
+fi
+if [ ${#HIP} -ne 0 ] ; then
+  echo "HIP               =" ${HIP}
+  echo "export HIP=${HIP}" >> ${NWCHEM_ENV_SH}
+  echo "setenv HIP ${HIP}" >> ${NWCHEM_ENV_CSH}
+  echo "unset HIP"          >> ${NWCHEM_UNENV_SH}
+  echo "unsetenv HIP"       >> ${NWCHEM_UNENV_CSH}
+fi
+if [ ${#HIP_INCLUDE} -ne 0 ] ; then
+  echo "HIP_INCLUDE       =" ${HIP_INCLUDE}
+  echo "export HIP_INCLUDE=\"${HIP_INCLUDE}\"" >> ${NWCHEM_ENV_SH}
+  echo "setenv HIP_INCLUDE \"${HIP_INCLUDE}\"" >> ${NWCHEM_ENV_CSH}
+  echo "unset HIP_INCLUDE"                      >> ${NWCHEM_UNENV_SH}
+  echo "unsetenv HIP_INCLUDE"                   >> ${NWCHEM_UNENV_CSH}
+fi
+if [ ${#HIP_LIBS} -ne 0 ] ; then
+  echo "HIP_LIBS          =" ${HIP_LIBS}
+  echo "export HIP_LIBS=\"${HIP_LIBS}\"" >> ${NWCHEM_ENV_SH}
+  echo "setenv HIP_LIBS \"${HIP_LIBS}\"" >> ${NWCHEM_ENV_CSH}
+  echo "unset HIP_LIBS"                  >> ${NWCHEM_UNENV_SH}
+  echo "unsetenv HIP_LIBS"               >> ${NWCHEM_UNENV_CSH}
 fi
 if [ ${#MRCC_METHODS} -ne 0 ] ; then
   echo "MRCC_METHODS       =" ${MRCC_METHODS}

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -2862,6 +2862,7 @@ ifndef CUDA
   CUDA = nvcc
 endif
 ifdef TCE_CUDA
+  DEFINES += -DTCE_CUDA
   CORE_LIBS += $(CUDA_LIBS)
   EXTRA_LIBS += -lstdc++
   ifdef USE_TTLG
@@ -2870,6 +2871,15 @@ ifdef TCE_CUDA
   ifeq ($(_CC),pgcc)
     COPTIONS += -acc
   endif
+endif
+
+ifndef HIP
+  HIP = hipcc
+endif
+ifdef TCE_HIP
+  DEFINES += -DTCE_HIP $(shell hipconfig --cpp_config)
+  CORE_LIBS += $(HIP_LIBS)
+  EXTRA_LIBS += -lstdc++
 endif
 
 ifdef USE_F90_ALLOCATABLE
@@ -2999,12 +3009,18 @@ CUDA_VERS_GE8=$(shell nvcc --version|egrep rel|  awk '/release 9/ {print "Y";exi
               CUDA_FLAGS = -O3  -std=c++11 -DNOHTIME -Xptxas --warn-on-spills $(CUDA_ARCH) 
         endif
 (%.o):  %.cu
-	$(CUDA) -c $(CUDA_FLAGS) $(CUDA_INCLUDE) -I$(NWCHEM_TOP)/src/tce/ttlg/includes -o $% $<
+	$(CUDA) -c -DTCE_CUDA $(CUDA_FLAGS) $(CUDA_INCLUDE) -I$(NWCHEM_TOP)/src/tce/ttlg/includes -o $% $<
 else
 (%.o):  %.cu
-	$(CUDA) -c $(CUDA_FLAGS) $(CUDA_INCLUDE) -o $% $<
+	$(CUDA) -c -DTCE_CUDA $(CUDA_FLAGS) $(CUDA_INCLUDE) -o $% $<
 endif
 endif
+
+ifdef TCE_HIP
+(%.o):  %.hip.cpp
+	$(HIP) -c -DTCE_HIP -fno-gpu-rdc -o $% $<
+endif
+
 (%.o):  %.o
 
 # Preceding line has a tab to make an empty rule

--- a/src/tce/GNUmakefile
+++ b/src/tce/GNUmakefile
@@ -162,6 +162,11 @@ ifdef TCE_CUDA
         SUBDIRS += ttlg
       endif
 endif
+
+ifdef TCE_HIP
+      LIB_DEFINES += -DTCE_HIP
+endif
+
 ifdef USE_PSTAT
       LIB_DEFINES += -DUSE_PSTAT
 endif

--- a/src/tce/ccsd_t/GNUmakefile
+++ b/src/tce/ccsd_t/GNUmakefile
@@ -44,6 +44,15 @@ ifdef TCE_CUDA
  LIB_DEFINES += $(CUDA_INCLUDE)
 endif
 
+ifdef TCE_HIP
+ LIB_INCLUDES = -I../include
+ OBJ_OPTIMIZE += hybrid.o memory.o ccsd_t_gpu.o ccsd_t_singles_gpu.o ccsd_t_doubles_gpu.o sd_t_total.o
+ USES_BLAS += ccsd_t_singles_gpu.F ccsd_t_doubles_gpu.F
+ LIB_DEFINES += $(HIP_INCLUDE)
+endif
+
+
+
 ifdef TCE_NEW_OPENMP
  OBJ_OPTIMIZE += ccsd_t_omp.o
 endif

--- a/src/tce/ccsd_t/header.h
+++ b/src/tce/ccsd_t/header.h
@@ -1,25 +1,30 @@
 #ifndef __header_h__
 #define __header_h__
-__device__ double* t3_s_d;
-__device__ double* t3_d;
+
+#ifdef TCE_HIP
+#include <hip/hip_runtime_api.h>
+#endif
+
 //static int notset;
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
 #include <stdio.h>
+#ifdef TCE_CUDA
 #ifdef OLD_CUDA
 #include <cuda_runtime_api.h>
 #else
 #include <cuda.h>
 #endif
+#endif
 #include <sys/types.h>
 #include <sys/time.h>
 #include <assert.h>
 #include <time.h>
-#include "cuda.h"
 ////#include "util.h"
 
+#ifdef TCE_CUDA
 #define CHECK_ERR(x) { \
     cudaError_t err = cudaGetLastError();\
     if (cudaSuccess != err) { \
@@ -29,8 +34,20 @@ extern "C" {
 
 #define CUDA_SAFE(x) if ( cudaSuccess != (x) ) {\
     printf("CUDA CALL FAILED AT LINE %d OF FILE %s error %s\n", __LINE__, __FILE__, cudaGetErrorString(cudaGetLastError()) ); exit(1);}
+#endif
 
+#ifdef TCE_HIP
+#define CHECK_ERR(x) { \
+    hipError_t err = hipGetLastError();\
+    if (hipSuccess != err) { \
+        printf("%s\n",hipGetErrorString(err)); \
+        exit(1); \
+    } } 
 
+#define CUDA_SAFE(x) if ( hipSuccess != (x) ) {\
+    printf("HIP CALL FAILED AT LINE %d OF FILE %s error %s\n", __LINE__, __FILE__, hipGetErrorString(hipGetLastError()) ); exit(1);}
+#endif
+  
 typedef long Integer;
 
 #define DIV_UB(x,y) ((x)/(y)+((x)%(y)?1:0))

--- a/src/tce/ccsd_t/hybrid.c
+++ b/src/tce/ccsd_t/hybrid.c
@@ -5,10 +5,15 @@
 static long long device_id=-1;
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef TCE_HIP
+#include <hip/hip_runtime_api.h>
+#endif
+#ifdef TCE_CUDA
 #ifdef OLD_CUDA
 #include <cuda_runtime_api.h>
 #else
 #include <cuda.h>
+#endif
 #endif
 #include "ga.h"
 #include "typesf2c.h"
@@ -28,14 +33,24 @@ int device_init_(long *icuda,long *cuda_device_number ) {
   
   int dev_count_check=0;
   device_id = util_my_smp_index();
+#ifdef TCE_CUDA
   cudaGetDeviceCount(&dev_count_check);
+#endif
+#ifdef TCE_HIP
+  hipGetDeviceCount(&dev_count_check);
+#endif
   if(dev_count_check < *icuda){
     printf("Warning: Please check whether you have %ld cuda devices per node\n",*icuda);
     fflush(stdout);
     *cuda_device_number = 30;
   }
   else {
+#ifdef TCE_CUDA
     cudaSetDevice(device_id);
+#endif
+#ifdef TCE_HIP
+    hipSetDevice(device_id);
+#endif
   }
   return 1;
 }

--- a/src/tce/ccsd_t/memory.hip.cpp
+++ b/src/tce/ccsd_t/memory.hip.cpp
@@ -1,0 +1,179 @@
+#include "header.h"
+#include <map>
+#include <set>
+using namespace std;
+
+/* #define NO_OPT */
+
+extern "C" {
+
+static int is_init=0;
+
+  static map<int,set<void*> > free_list_gpu, free_list_host;
+  static map<void *,int> live_ptrs_gpu, live_ptrs_host;
+
+  static void clearGpuFreeList() {
+    for(map<int,set<void*> >::iterator it=free_list_gpu.begin(); 
+	it!=free_list_gpu.end(); ++it) {
+      for(set<void*>::iterator it2=it->second.begin();
+	  it2!=it->second.end(); ++it2) {
+	hipFree(*it2);
+      }
+    }
+    free_list_gpu.clear();
+  }
+  
+  static void clearHostFreeList() {
+    for(map<int,set<void*> >::iterator it=free_list_host.begin(); 
+	it!=free_list_host.end(); ++it) {
+      for(set<void*>::iterator it2=it->second.begin();
+	  it2!=it->second.end(); ++it2) {
+	hipHostFree(*it2);
+      }
+    }
+    free_list_host.clear();
+  }
+
+  static int num_resurrections=0, num_morecore=0;
+
+  typedef hipError_t (*mallocfn_t)(void **ptr, size_t bytes);
+  static void *morecore(mallocfn_t fn, size_t bytes) {
+    void *ptr;
+    CUDA_SAFE(fn((void **)&ptr, bytes));
+    num_morecore += 1;
+    if(ptr==NULL) {
+      /*try one more time*/
+      clearHostFreeList();
+      clearGpuFreeList();
+      fn((void **)&ptr, bytes);
+    }
+    assert(ptr!=NULL); /*We hopefully have a pointer*/
+    return ptr;
+  }
+
+  static inline void *resurrect_from_free_list(map<int,set<void *> > &free_map,
+					size_t bytes, map<void*,int>& liveset) {
+    void *ptr;
+    num_resurrections +=1 ;
+    assert(free_map.find(bytes) != free_map.end());
+/*     assert(free_map.find(bytes)->second.size() > 0); */
+    set<void *> &st = free_map.find(bytes)->second;
+    ptr = *st.begin();
+    st.erase(ptr);
+    if(st.size()==0)
+      free_map.erase(bytes);
+    liveset[ptr] = bytes;
+    return ptr;
+  }
+
+  void initmemmodule_()  {
+    is_init=1;
+  }
+
+void *getGpuMem(size_t bytes) {
+  assert(is_init);
+  void *ptr;
+#ifdef NO_OPT
+  CUDA_SAFE(hipMalloc((void **) &ptr, bytes));
+#else
+  if(free_list_gpu.find(bytes)!=free_list_gpu.end()) {
+    set<void*> &lst = free_list_gpu.find(bytes)->second;
+    if(lst.size()!=0) {
+      ptr = resurrect_from_free_list(free_list_gpu, bytes, live_ptrs_gpu);
+      return ptr;
+    }
+  }
+  else {
+    for(map<int,set<void *> >::iterator it=free_list_gpu.begin();
+	it != free_list_gpu.end(); ++it) {
+      if(it->first >= bytes && it->second.size()>0) {
+	ptr = resurrect_from_free_list(free_list_gpu, it->first, live_ptrs_gpu);
+	return ptr;
+      }
+    }
+  }
+  ptr = morecore(hipMalloc, bytes);
+/*   cutilSafeCall(hipMalloc((void **) &ptr, bytes)); */
+  live_ptrs_gpu[ptr] = bytes;
+#endif
+  return ptr;
+}
+
+void *getHostMem(size_t bytes) {
+  assert(is_init);
+  void *ptr;
+#ifdef NO_OPT
+  CUDA_SAFE(hipHostMalloc((void **) &ptr, bytes));
+#else
+  if(free_list_host.find(bytes)!=free_list_host.end()) {
+    set<void*> &lst = free_list_host.find(bytes)->second;
+    if(lst.size()!=0) {
+      ptr = resurrect_from_free_list(free_list_host, bytes, live_ptrs_host);
+/*       ptr = *lst.begin(); */
+/*       lst.erase(lst.begin()); */
+/*       live_ptrs_host[ptr] = bytes; */
+      return ptr;
+    }
+  }
+  else {
+    for(map<int,set<void *> >::iterator it=free_list_host.begin();
+	it != free_list_host.end(); ++it) {
+      if(it->first >= bytes && it->second.size()>0) {
+	ptr = resurrect_from_free_list(free_list_host, it->first, live_ptrs_host);
+/* 	set<void*> &lst = it->second; */
+/* 	ptr = *lst.begin(); */
+/* 	lst.erase(lst.begin()); */
+/* 	live_ptrs_gpu[ptr] = bytes; */
+	return ptr;
+      }
+    }
+  }
+/*   cutilSafeCall(hipHostMalloc((void **) &ptr, bytes)); */
+  ptr = morecore(hipMallocHost, bytes);
+  live_ptrs_host[ptr] = bytes;
+#endif
+  return ptr;
+}
+
+void freeHostMem(void *p) {
+  int bytes;
+  assert(is_init);
+#ifdef NO_OPT
+  hipHostFree(p);
+#else
+  assert(live_ptrs_host.find(p) != live_ptrs_host.end());
+  bytes = live_ptrs_host[p];
+  live_ptrs_host.erase(p);
+  free_list_host[bytes].insert(p);
+#endif
+}
+
+void freeGpuMem(void *p) {
+  int bytes;
+  assert(is_init);
+#ifdef NO_OPT
+  hipFree(p);
+#else
+  assert(live_ptrs_gpu.find(p) != live_ptrs_gpu.end());
+  bytes = live_ptrs_gpu[p];
+  live_ptrs_gpu.erase(p);
+  free_list_gpu[bytes].insert(p);
+#endif
+}
+
+void finalizememmodule_() {
+  assert(is_init);
+  is_init = 0;
+  
+  /*there should be no live pointers*/
+  assert(live_ptrs_gpu.size()==0);
+  assert(live_ptrs_host.size()==0);
+
+  /*release all freed pointers*/
+  clearGpuFreeList();
+  clearHostFreeList();
+  //printf("num. resurrections=%d \t num. morecore=%d\n", num_resurrections, num_morecore);
+}
+
+}
+

--- a/src/tce/ccsd_t/sd_t_total_ttlg.cu
+++ b/src/tce/ccsd_t/sd_t_total_ttlg.cu
@@ -2,6 +2,9 @@
 #include <cublas_v2.h>
 #include <cuda.h>
 
+__device__ double* t3_s_d;
+__device__ double* t3_d;
+
 #include "header.h"
 #include "ourinclude.h"
 

--- a/src/tce/tce_energy.F
+++ b/src/tce/tce_energy.F
@@ -221,7 +221,7 @@ c      double precision f2m(50,50)
       external scf
       integer i
       integer j
-#ifdef TCE_CUDA
+#if defined(TCE_CUDA) || defined(TCE_HIP)
       integer icuda
 #endif
 !#ifdef EACCSD
@@ -3060,7 +3060,7 @@ c
           call ccsd_t_fdist_init()
 #endif
           if (restart_ccsd_t.eq.0) then
-#ifdef TCE_CUDA
+#if defined(TCE_CUDA) || defined(TCE_HIP)
               if(.not.rtdb_get(rtdb,'tce:cuda',mt_int,1,icuda)) then
                if (nodezero) write(LuOut,*) 'Using plain CCSD(T) code'
                if (nodezero) call util_flush(LuOut)

--- a/src/tce/ttlg/GNUmakefile
+++ b/src/tce/ttlg/GNUmakefile
@@ -7,7 +7,11 @@ MAKEFLAGS +=" -j1 -l0.001"
 
  #LIB_DEFINES = -I./includes $(CUDA_INCLUDE)
 
- LIB_INCLUDES = -I./includes $(CUDA_INCLUDE)
+LIB_INCLUDES = -I./includes
+
+ifdef TCE_CUDA
+LIB_INCLUDES += $(CUDA_INCLUDE)
+endif
 
  #CUDA_FLAGS = -I./includes $(CUDA_INCLUDE)
 

--- a/src/tce/ttlg/includes/ourmacros.h
+++ b/src/tce/ttlg/includes/ourmacros.h
@@ -48,7 +48,7 @@ case 15:\
  CON(funcname,15) <<<param3, param4, param5>>> callstring;\
 break;
 
-
+#ifdef TCE_CUDA
 #define SAFECUDAMALLOC(pointer, size) cudaMalloc(pointer, size) ;\
         {cudaError_t err = cudaGetLastError();\
                 if(err != cudaSuccess){\
@@ -62,4 +62,20 @@ break;
                         printf("\nKernel ERROR in hostCall: %s (line: %d)\n", cudaGetErrorString(err), __LINE__);\
                         exit(-1);\
                 }}
+#endif
 
+#ifdef TCE_HIP
+#define SAFECUDAMALLOC(pointer, size) hipMalloc(pointer, size) ;\
+        {hipError_t err = hipGetLastError();\
+                if(err != hipSuccess){\
+                        printf("\nKernel ERROR in hostCall: %s (line: %d)\n", hipGetErrorString(err), __LINE__);\
+                        exit(-1);\
+                }}
+
+#define SAFECUDAMEMCPY(dest, src, size, type) hipMemcpy(dest, src, size, type) ;\
+        {hipError_t err = hipGetLastError();\
+                if(err != hipSuccess){\
+                        printf("\nKernel ERROR in hostCall: %s (line: %d)\n", hipGetErrorString(err), __LINE__);\
+                        exit(-1);\
+                }}
+#endif

--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -302,6 +302,11 @@ ifdef TCE_CUDA
   OBJ += util_cuda_support.o
 endif
 
+ifdef TCE_HIP
+  LIB_DEFINES += $(HIP_INCLUDE)
+  OBJ += util_cuda_support.o
+endif
+
 ifdef USE_FORTRAN2003
   LIB_DEFINES += -DUSE_FORTRAN2003
 endif

--- a/src/util/util_cuda_support.c
+++ b/src/util/util_cuda_support.c
@@ -1,15 +1,25 @@
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef TCE_CUDA
 #ifdef OLD_CUDA
 #include <cuda_runtime_api.h>
 #else
 #include <cuda.h>
 #endif
+#endif
+#ifdef TCE_HIP
+#include <hip/hip_runtime_api.h>
+#endif
 #include "ga.h"
 #include "typesf2c.h"
 Integer FATR util_cuda_get_num_devices_(){
   int dev_count_check;
+#ifdef TCE_CUDA
   cudaGetDeviceCount(&dev_count_check);
+#endif
+#ifdef TCE_HIP
+  hipGetDeviceCount(&dev_count_check);
+#endif
   return (Integer) dev_count_check;
 }
 /* $Id$ */


### PR DESCRIPTION
TCE cuda codes(memory.cu and sd_t_total.cu) are converted to hip codes
(memory.hip.cpp and sd_t_total.hip.cpp) which can run on AMD GPUs.
Related source codes and makefiles are also modified to compile on AMD GPUs.
These codes have successfully run on ROCm2.0