### PR TITLE
NCAP and regSCAN

### DIFF
--- a/QA/tests/dft_ncap/dft_ncap.nw
+++ b/QA/tests/dft_ncap/dft_ncap.nw
@@ -1,0 +1,39 @@
+start n2_ncap
+GEOMETRY noautoz
+ N 0.0 0.0  0.548757
+ N 0.0 0.0 -0.548757
+ symmetry d2h
+END  
+BASIS SPHERICAL  
+ * library aug-cc-pvdz
+ H S
+ 0.0099133 1.0
+ H P
+ 0.0470000 1.0
+ C S
+ 0.0156333 1.0
+ C P
+ 0.0134700 1.0
+ C D
+ 0.0503333 1.0
+ O S
+ 0.0263200 1.0
+ O P
+ 0.0228533 1.0
+ O D
+ 0.1106667 1.0
+ N S
+ 0.0204133 1.0
+ N P
+ 0.0187033 1.0
+ N D
+ 0.0766667 1.0
+END  
+DFT  
+ XC ncap
+ grid medium
+END  
+TDDFT  
+ NROOTS 15
+END  
+TASK TDDFT ENERGY

--- a/QA/tests/dft_ncap/dft_ncap.out
+++ b/QA/tests/dft_ncap/dft_ncap.out
@@ -1,0 +1,1590 @@
+ argument  1 = dft_ncap.nw
+                                         
+                                         
+ 
+ 
+              Northwest Computational Chemistry Package (NWChem) 6.8
+              ------------------------------------------------------
+ 
+ 
+                    Environmental Molecular Sciences Laboratory
+                       Pacific Northwest National Laboratory
+                                Richland, WA 99352
+ 
+                              Copyright (c) 1994-2018
+                       Pacific Northwest National Laboratory
+                            Battelle Memorial Institute
+ 
+             NWChem is an open-source computational chemistry package
+                        distributed under the terms of the
+                      Educational Community License (ECL) 2.0
+             A copy of the license is included with this distribution
+                              in the LICENSE.TXT file
+ 
+                                  ACKNOWLEDGMENT
+                                  --------------
+
+            This software and its documentation were developed at the
+            EMSL at Pacific Northwest National Laboratory, a multiprogram
+            national laboratory, operated for the U.S. Department of Energy
+            by Battelle under Contract Number DE-AC05-76RL01830. Support
+            for this work was provided by the Department of Energy Office
+            of Biological and Environmental Research, Office of Basic
+            Energy Sciences, and the Office of Advanced Scientific Computing.
+
+
+           Job information
+           ---------------
+
+    hostname        = ubuntu-SVT13115FLS
+    program         = /home/dmejiar/Software/nwchemgit/nwchem/bin/LINUX64/nwchem
+    date            = Tue Jun  4 14:51:13 2019
+
+    compiled        = Mon_Jun_03_16:15:07_2019
+    source          = /home/dmejiar/Software/nwchemgit/nwchem
+    nwchem branch   = Development
+    nwchem revision = nwchem_on_git-899-g10985772d
+    ga revision     = 5.7.0
+    use scalapack   = F
+    input           = dft_ncap.nw
+    prefix          = dft_ncap.
+    data base       = ./dft_ncap.db
+    status          = startup
+    nproc           =        1
+    time left       =     -1s
+
+
+
+           Memory information
+           ------------------
+
+    heap     =   13107200 doubles =    100.0 Mbytes
+    stack    =   13107197 doubles =    100.0 Mbytes
+    global   =   26214400 doubles =    200.0 Mbytes (distinct from heap & stack)
+    total    =   52428797 doubles =    400.0 Mbytes
+    verify   = yes
+    hardfail = no 
+
+
+           Directory information
+           ---------------------
+ 
+  0 permanent = .
+  0 scratch   = .
+ 
+ 
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+
+ Scaling coordinates for geometry "geometry" by  1.889725989
+ (inverse scale =  0.529177249)
+
+ Turning off AUTOSYM since
+ SYMMETRY directive was detected!
+ 
+ 
+ 
+                             Geometry "geometry" -> ""
+                             -------------------------
+ 
+ Output coordinates in angstroms (scale by  1.889725989 to convert to a.u.)
+ 
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 N                    7.0000     0.00000000     0.00000000     0.54875700
+    2 N                    7.0000     0.00000000     0.00000000    -0.54875700
+ 
+      Atomic Mass 
+      ----------- 
+ 
+      N                 14.003070
+ 
+
+ Effective nuclear repulsion energy (a.u.)      23.6258354800
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.0000000000
+ 
+      Symmetry information
+      --------------------
+ 
+ Group name             D2h       
+ Group number             26
+ Group order               8
+ No. of unique centers     1
+ 
+      Symmetry unique atoms
+ 
+     1
+ 
+ 
+            XYZ format geometry
+            -------------------
+     2
+ geometry
+ N                     0.00000000     0.00000000     0.54875700
+ N                     0.00000000     0.00000000    -0.54875700
+ 
+ ==============================================================================
+                                internuclear distances
+ ------------------------------------------------------------------------------
+       center one      |      center two      | atomic units |  angstroms
+ ------------------------------------------------------------------------------
+    2 N                |   1 N                |     2.07400  |     1.09751
+ ------------------------------------------------------------------------------
+                         number of included internuclear distances:          1
+ ==============================================================================
+
+
+
+
+
+ Summary of "ao basis" -> "" (spherical)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ H                       user specified              2        4   1s1p
+ C                       user specified              3        9   1s1p1d
+ O                       user specified              3        9   1s1p1d
+ N                       user specified              3        9   1s1p1d
+ *                        aug-cc-pvdz                 on all atoms 
+
+
+ 
+                                 NWChem DFT Module
+                                 -----------------
+ 
+ 
+                      Basis "ao basis" -> "ao basis" (spherical)
+                      -----
+  H (Hydrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  9.91330000E-03  1.000000
+ 
+  2 P  4.70000000E-02  1.000000
+ 
+  C (Carbon)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  1.56333000E-02  1.000000
+ 
+  2 P  1.34700000E-02  1.000000
+ 
+  3 D  5.03333000E-02  1.000000
+ 
+  O (Oxygen)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  2.63200000E-02  1.000000
+ 
+  2 P  2.28533000E-02  1.000000
+ 
+  3 D  1.10666700E-01  1.000000
+ 
+  N (Nitrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  2.04133000E-02  1.000000
+ 
+  2 P  1.87033000E-02  1.000000
+ 
+  3 D  7.66667000E-02  1.000000
+ 
+  4 S  9.04600000E+03  0.000700
+  4 S  1.35700000E+03  0.005389
+  4 S  3.09300000E+02  0.027406
+  4 S  8.77300000E+01  0.103207
+  4 S  2.85600000E+01  0.278723
+  4 S  1.02100000E+01  0.448540
+  4 S  3.83800000E+00  0.278238
+  4 S  7.46600000E-01  0.015440
+ 
+  5 S  9.04600000E+03 -0.000153
+  5 S  1.35700000E+03 -0.001208
+  5 S  3.09300000E+02 -0.005992
+  5 S  8.77300000E+01 -0.024544
+  5 S  2.85600000E+01 -0.067459
+  5 S  1.02100000E+01 -0.158078
+  5 S  3.83800000E+00 -0.121831
+  5 S  7.46600000E-01  0.549003
+ 
+  6 S  2.24800000E-01  1.000000
+ 
+  7 S  6.12400000E-02  1.000000
+ 
+  8 P  1.35500000E+01  0.039919
+  8 P  2.91700000E+00  0.217169
+  8 P  7.97300000E-01  0.510319
+ 
+  9 P  2.18500000E-01  1.000000
+ 
+ 10 P  5.61100000E-02  1.000000
+ 
+ 11 D  8.17000000E-01  1.000000
+ 
+ 12 D  2.30000000E-01  1.000000
+ 
+
+
+ Summary of "ao basis" -> "ao basis" (spherical)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ H                       user specified              2        4   1s1p
+ C                       user specified              3        9   1s1p1d
+ O                       user specified              3        9   1s1p1d
+ N                  modified:user specified         12       32   5s4p3d
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (spherical)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ H                       user specified              2        4   1s1p
+ C                       user specified              3        9   1s1p1d
+ O                       user specified              3        9   1s1p1d
+ N                  modified:user specified         12       32   5s4p3d
+
+
+      Symmetry analysis of basis
+      --------------------------
+ 
+        ag         15
+        au          3
+        b1g         3
+        b1u        15
+        b2g         7
+        b2u         7
+        b3g         7
+        b3u         7
+ 
+  Caching 1-el integrals 
+ 
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     2
+          No. of electrons :    14
+           Alpha electrons :     7
+            Beta electrons :     7
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: off; symmetry adaption is: on 
+          Maximum number of iterations:  30
+          AO basis - number of functions:    64
+                     number of shells:    24
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+ 
+              XC Information
+              --------------
+                         NCAP Method XC Functional
+                      NCAP GGA Exchange Functional  1.000          
+                Perdew 1981 Correlation Functional  1.000 local    
+                Perdew 1986 Correlation Functional  1.000 non-local
+ 
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          N                   0.65       49          14.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    98
+          Spatial weights used:  Erf1
+ 
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         30 iters            30 iters 
+
+ 
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+ 
+      Superposition of Atomic Density Guess
+      -------------------------------------
+ 
+ Sum of atomic energies:        -108.60548222
+ 
+      Non-variational initial energy
+      ------------------------------
+
+ Total energy =    -109.110958
+ 1-e energy   =    -193.778400
+ 2-e energy   =      61.041606
+ HOMO         =      -0.431574
+ LUMO         =       0.011847
+ 
+ 
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+ 
+
+ !! scf_movecs_sym_adapt:   40 vectors were symmetry contaminated
+
+  Symmetry fudging
+
+ !! scf_movecs_sym_adapt:   40 vectors were symmetry contaminated
+
+  Numbering of irreducible representations: 
+ 
+     1 ag          2 au          3 b1g         4 b1u         5 b2g     
+     6 b2u         7 b3g         8 b3u     
+ 
+  Orbital symmetries:
+ 
+     1 ag          2 b1u         3 ag          4 b1u         5 b3u     
+     6 b2u         7 ag          8 b2g         9 b3g        10 b1u     
+    11 ag         12 b3u        13 b2u        14 b2g        15 b3g     
+    16 ag         17 b1u     
+ 
+   Time after variat. SCF:      1.7
+   Time prior to 1st pass:      1.7
+
+ Integral file          = ./dft_ncap.aoints.0
+ Record size in doubles =  65536        No. of integs per rec  =  43688
+ Max. records in memory =     13        Max. records in file   =  99481
+ No. of bits per label  =      8        No. of bits per value  =     64
+
+
+ #quartets = 4.515D+04 #integrals = 5.082D+05 #direct =  0.0% #cached =100.0%
+
+
+ Grid_pts file          = ./dft_ncap.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =     17        Max. recs in file   =    530528
+
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+  Symmetry fudging
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+
+           Memory utilization after 1st SCF pass: 
+           Heap Space remaining (MW):       12.04            12044088
+          Stack Space remaining (MW):       13.11            13106740
+
+   convergence    iter        energy       DeltaE   RMS-Dens  Diis-err    time
+ ---------------- ----- ----------------- --------- --------- ---------  ------
+ d= 0,ls=0.0,diis     1   -109.5528200158 -1.33D+02  1.28D-02  2.04D-01     2.3
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+  Symmetry fudging
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+ d= 0,ls=0.0,diis     2   -109.5642777539 -1.15D-02  3.91D-03  5.40D-02     2.6
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+  Symmetry fudging
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+ d= 0,ls=0.0,diis     3   -109.5704392236 -6.16D-03  1.57D-03  3.92D-03     2.8
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+  Symmetry fudging
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+ d= 0,ls=0.0,diis     4   -109.5709206847 -4.81D-04  1.78D-04  2.39D-06     2.9
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+  Symmetry fudging
+
+ !! scf_movecs_sym_adapt:   16 vectors were symmetry contaminated
+
+ d= 0,ls=0.0,diis     5   -109.5709210097 -3.25D-07  5.12D-05  3.59D-08     3.1
+
+ !! scf_movecs_sym_adapt:   28 vectors were symmetry contaminated
+
+  Symmetry fudging
+
+ !! scf_movecs_sym_adapt:    8 vectors were symmetry contaminated
+
+ d= 0,ls=0.0,diis     6   -109.5709210166 -6.92D-09  1.55D-06  8.86D-10     3.2
+
+
+         Total DFT energy =     -109.570921016575
+      One electron energy =     -194.430552143184
+           Coulomb energy =       74.950754337102
+    Exchange-Corr. energy =      -13.716958690482
+ Nuclear repulsion energy =       23.625835479990
+
+ Numeric. integr. density =       13.999999766430
+
+     Total iterative time =      1.5s
+
+
+ 
+                  Occupations of the irreducible representations
+                  ----------------------------------------------
+ 
+                     irrep           alpha         beta
+                     --------     --------     --------
+                     ag                3.0          3.0
+                     au                0.0          0.0
+                     b1g               0.0          0.0
+                     b1u               2.0          2.0
+                     b2g               0.0          0.0
+                     b2u               1.0          1.0
+                     b3g               0.0          0.0
+                     b3u               1.0          1.0
+ 
+ 
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+ 
+ Vector    1  Occ=2.000000D+00  E=-1.412272D+01  Symmetry=ag
+              MO Center=  8.4D-35, -5.4D-35,  8.4D-17, r^2= 3.2D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10      0.711705  1 N  s                 42      0.711705  2 N  s          
+ 
+ Vector    2  Occ=2.000000D+00  E=-1.412156D+01  Symmetry=b1u
+              MO Center=  1.6D-17,  2.7D-17, -1.8D-16, r^2= 3.2D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10      0.714540  1 N  s                 42     -0.714540  2 N  s          
+    12     -0.108534  1 N  s                 44      0.108534  2 N  s          
+    13     -0.062215  1 N  s                 45      0.062215  2 N  s          
+    19      0.055395  1 N  pz                51      0.055395  2 N  pz         
+ 
+ Vector    3  Occ=2.000000D+00  E=-1.046484D+00  Symmetry=ag
+              MO Center=  1.3D-15, -1.4D-15,  7.4D-15, r^2= 4.3D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      0.328528  1 N  s                 43      0.328528  2 N  s          
+    16     -0.230505  1 N  pz                48      0.230505  2 N  pz         
+    12      0.223857  1 N  s                 44      0.223857  2 N  s          
+    22      0.059121  1 N  pz                54     -0.059121  2 N  pz         
+ 
+ Vector    4  Occ=2.000000D+00  E=-4.991392D-01  Symmetry=b1u
+              MO Center=  2.6D-15, -3.5D-15,  1.7D-15, r^2= 1.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.617028  1 N  s                 44     -0.617028  2 N  s          
+    11      0.325435  1 N  s                 43     -0.325435  2 N  s          
+    13      0.225429  1 N  s                 45     -0.225429  2 N  s          
+    16      0.202892  1 N  pz                48      0.202892  2 N  pz         
+     1     -0.116419  1 N  s                 33      0.116419  2 N  s          
+ 
+ Vector    5  Occ=2.000000D+00  E=-4.275008D-01  Symmetry=b3u
+              MO Center= -1.1D-15,  1.7D-30,  4.0D-17, r^2= 8.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.451544  1 N  px                46      0.451544  2 N  px         
+    17      0.225727  1 N  px                49      0.225727  2 N  px         
+    26      0.035351  1 N  d  1              58     -0.035351  2 N  d  1       
+ 
+ Vector    6  Occ=2.000000D+00  E=-4.275008D-01  Symmetry=b2u
+              MO Center= -1.3D-31,  1.2D-15, -5.4D-17, r^2= 8.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.451544  1 N  py                47      0.451544  2 N  py         
+    18      0.225727  1 N  py                50      0.225727  2 N  py         
+    24     -0.035351  1 N  d -1              56      0.035351  2 N  d -1       
+ 
+ Vector    7  Occ=2.000000D+00  E=-3.776709D-01  Symmetry=ag
+              MO Center= -9.2D-16,  3.7D-16, -1.1D-14, r^2= 1.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.453408  1 N  pz                48     -0.453408  2 N  pz         
+    12      0.251964  1 N  s                 44      0.251964  2 N  s          
+    19      0.178632  1 N  pz                51     -0.178632  2 N  pz         
+    11      0.105577  1 N  s                 43      0.105577  2 N  s          
+    13      0.072382  1 N  s                 45      0.072382  2 N  s          
+ 
+ Vector    8  Occ=0.000000D+00  E=-7.002744D-02  Symmetry=b3g
+              MO Center=  2.0D-31,  3.7D-15, -1.8D-17, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.504123  1 N  py                47     -0.504123  2 N  py         
+    18      0.464719  1 N  py                50     -0.464719  2 N  py         
+    21      0.107278  1 N  py                53     -0.107278  2 N  py         
+     6      0.048693  1 N  d -1              38      0.048693  2 N  d -1       
+ 
+ Vector    9  Occ=0.000000D+00  E=-7.002744D-02  Symmetry=b2g
+              MO Center= -3.0D-15,  7.2D-32,  1.6D-16, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.504123  1 N  px                46     -0.504123  2 N  px         
+    17      0.464719  1 N  px                49     -0.464719  2 N  px         
+    20      0.107278  1 N  px                52     -0.107278  2 N  px         
+     8     -0.048693  1 N  d  1              40     -0.048693  2 N  d  1       
+ 
+ Vector   10  Occ=0.000000D+00  E= 2.345383D-02  Symmetry=b1u
+              MO Center=  8.0D-27,  1.4D-28,  2.8D-13, r^2= 4.8D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1     74.319320  1 N  s                 33    -74.319320  2 N  s          
+    13     15.520057  1 N  s                 45    -15.520057  2 N  s          
+     4    -10.532137  1 N  pz                36    -10.532137  2 N  pz         
+    22     -5.186552  1 N  pz                54     -5.186552  2 N  pz         
+     7      0.453076  1 N  d  0              39     -0.453076  2 N  d  0       
+ 
+ Vector   11  Occ=0.000000D+00  E= 5.114999D-02  Symmetry=ag
+              MO Center= -4.5D-13, -5.9D-16,  8.4D-14, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.539387  1 N  s                 33      0.539387  2 N  s          
+    12     -0.244700  1 N  s                 44     -0.244700  2 N  s          
+    22     -0.164329  1 N  pz                54      0.164329  2 N  pz         
+     4     -0.162936  1 N  pz                36      0.162936  2 N  pz         
+    11     -0.096351  1 N  s                 43     -0.096351  2 N  s          
+ 
+ Vector   12  Occ=0.000000D+00  E= 7.896984D-02  Symmetry=b2u
+              MO Center=  4.4D-31,  4.5D-16,  2.6D-18, r^2= 1.6D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.429442  1 N  py                35      0.429442  2 N  py         
+    21      0.110669  1 N  py                53      0.110669  2 N  py         
+    15     -0.098870  1 N  py                47     -0.098870  2 N  py         
+    18     -0.040077  1 N  py                50     -0.040077  2 N  py         
+ 
+ Vector   13  Occ=0.000000D+00  E= 7.896984D-02  Symmetry=b3u
+              MO Center=  4.3D-13, -3.3D-30,  1.0D-17, r^2= 1.6D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.429442  1 N  px                34      0.429442  2 N  px         
+    20      0.110669  1 N  px                52      0.110669  2 N  px         
+    14     -0.098870  1 N  px                46     -0.098870  2 N  px         
+    17     -0.040077  1 N  px                49     -0.040077  2 N  px         
+ 
+ Vector   14  Occ=0.000000D+00  E= 8.581895D-02  Symmetry=ag
+              MO Center= -7.6D-13,  3.3D-14,  2.7D-11, r^2= 3.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      2.961110  1 N  pz                36     -2.961110  2 N  pz         
+    22     -0.559119  1 N  pz                54      0.559119  2 N  pz         
+     1      0.364657  1 N  s                 33      0.364657  2 N  s          
+    12     -0.203751  1 N  s                 44     -0.203751  2 N  s          
+    13      0.156936  1 N  s                 45      0.156936  2 N  s          
+ 
+ Vector   15  Occ=0.000000D+00  E= 9.466618D-02  Symmetry=b1u
+              MO Center= -2.5D-22,  9.9D-25, -2.3D-11, r^2= 1.3D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1     25.816703  1 N  s                 33    -25.816703  2 N  s          
+     4     -3.435453  1 N  pz                36     -3.435453  2 N  pz         
+    13      0.892104  1 N  s                 45     -0.892104  2 N  s          
+    12     -0.660021  1 N  s                 44      0.660021  2 N  s          
+    19      0.262271  1 N  pz                51      0.262271  2 N  pz         
+ 
+ Vector   16  Occ=0.000000D+00  E= 1.245838D-01  Symmetry=b2g
+              MO Center= -9.5D-17,  2.5D-27,  1.2D-15, r^2= 2.9D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      4.178141  1 N  px                34     -4.178141  2 N  px         
+    20     -1.985817  1 N  px                52      1.985817  2 N  px         
+     8     -0.480415  1 N  d  1              40     -0.480415  2 N  d  1       
+    14     -0.072595  1 N  px                17     -0.072259  1 N  px         
+    46      0.072595  2 N  px                49      0.072259  2 N  px         
+ 
+ Vector   17  Occ=0.000000D+00  E= 1.245838D-01  Symmetry=b3g
+              MO Center= -5.4D-30, -6.5D-18,  4.0D-15, r^2= 2.9D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      4.178141  1 N  py                35     -4.178141  2 N  py         
+    21     -1.985817  1 N  py                53      1.985817  2 N  py         
+     6      0.480415  1 N  d -1              38      0.480415  2 N  d -1       
+    15     -0.072595  1 N  py                18     -0.072259  1 N  py         
+    47      0.072595  2 N  py                50      0.072259  2 N  py         
+ 
+ Vector   18  Occ=0.000000D+00  E= 1.617293D-01  Symmetry=ag
+              MO Center= -2.8D-12, -3.0D-15,  8.8D-13, r^2= 1.8D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      3.094803  1 N  pz                54     -3.094803  2 N  pz         
+    13      1.922203  1 N  s                 45      1.922203  2 N  s          
+     1     -1.234334  1 N  s                 33     -1.234334  2 N  s          
+     7     -0.738356  1 N  d  0              39     -0.738356  2 N  d  0       
+     4     -0.159927  1 N  pz                36      0.159927  2 N  pz         
+ 
+ Vector   19  Occ=0.000000D+00  E= 1.718865D-01  Symmetry=b2u
+              MO Center= -4.9D-30, -2.8D-14,  1.5D-16, r^2= 1.7D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.849713  1 N  py                53      0.849713  2 N  py         
+     3     -0.618444  1 N  py                35     -0.618444  2 N  py         
+     6      0.182362  1 N  d -1              38     -0.182362  2 N  d -1       
+    15     -0.152902  1 N  py                47     -0.152902  2 N  py         
+    18     -0.126151  1 N  py                50     -0.126151  2 N  py         
+ 
+ Vector   20  Occ=0.000000D+00  E= 1.718865D-01  Symmetry=b3u
+              MO Center=  3.6D-12,  1.2D-28,  6.1D-16, r^2= 1.7D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      0.849713  1 N  px                52      0.849713  2 N  px         
+     2     -0.618444  1 N  px                34     -0.618444  2 N  px         
+     8     -0.182362  1 N  d  1              40      0.182362  2 N  d  1       
+    14     -0.152902  1 N  px                46     -0.152902  2 N  px         
+    17     -0.126151  1 N  px                49     -0.126151  2 N  px         
+ 
+ Vector   21  Occ=0.000000D+00  E= 1.799561D-01  Symmetry=ag
+              MO Center=  4.2D-13,  3.4D-15, -3.5D-12, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      1.670313  1 N  pz                36     -1.670313  2 N  pz         
+    22     -1.107753  1 N  pz                54      1.107753  2 N  pz         
+    13      0.596072  1 N  s                 45      0.596072  2 N  s          
+    12     -0.379379  1 N  s                 44     -0.379379  2 N  s          
+     1     -0.212476  1 N  s                 33     -0.212476  2 N  s          
+ 
+ Vector   22  Occ=0.000000D+00  E= 1.902467D-01  Symmetry=ag
+              MO Center= -1.1D-14, -1.1D-15, -2.6D-13, r^2= 6.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      0.503915  1 N  d  2              41      0.503915  2 N  d  2       
+    27      0.031908  1 N  d  2              59      0.031908  2 N  d  2       
+ 
+ Vector   23  Occ=0.000000D+00  E= 1.902477D-01  Symmetry=b1g
+              MO Center= -4.0D-16, -2.3D-15, -2.4D-13, r^2= 6.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.503914  1 N  d -2              37      0.503914  2 N  d -2       
+    23      0.031908  1 N  d -2              55      0.031908  2 N  d -2       
+ 
+ Vector   24  Occ=0.000000D+00  E= 1.997599D-01  Symmetry=b3g
+              MO Center= -5.4D-27, -2.6D-17,  4.3D-16, r^2= 1.9D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      7.896942  1 N  py                53     -7.896942  2 N  py         
+     3     -3.580752  1 N  py                35      3.580752  2 N  py         
+     6     -1.430263  1 N  d -1              38     -1.430263  2 N  d -1       
+    18     -0.229313  1 N  py                50      0.229313  2 N  py         
+    29      0.201352  1 N  d -1              61      0.201352  2 N  d -1       
+ 
+ Vector   25  Occ=0.000000D+00  E= 1.997599D-01  Symmetry=b2g
+              MO Center=  2.9D-16,  2.0D-26, -2.5D-16, r^2= 1.9D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      7.896942  1 N  px                52     -7.896942  2 N  px         
+     2     -3.580752  1 N  px                34      3.580752  2 N  px         
+     8      1.430263  1 N  d  1              40      1.430263  2 N  d  1       
+    17     -0.229313  1 N  px                49      0.229313  2 N  px         
+    31     -0.201352  1 N  d  1              63     -0.201352  2 N  d  1       
+ 
+ Vector   26  Occ=0.000000D+00  E= 2.384358D-01  Symmetry=b1u
+              MO Center= -6.2D-24,  4.3D-26,  5.2D-14, r^2= 2.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1     61.765684  1 N  s                 33    -61.765684  2 N  s          
+    13     23.854574  1 N  s                 45    -23.854574  2 N  s          
+    22     -8.190088  1 N  pz                54     -8.190088  2 N  pz         
+     4     -7.589875  1 N  pz                36     -7.589875  2 N  pz         
+    12      1.816972  1 N  s                 44     -1.816972  2 N  s          
+ 
+ Vector   27  Occ=0.000000D+00  E= 2.993313D-01  Symmetry=b1u
+              MO Center=  6.4D-25,  9.9D-28, -6.8D-13, r^2= 9.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1     16.559865  1 N  s                 33    -16.559865  2 N  s          
+    13     -5.965772  1 N  s                 45      5.965772  2 N  s          
+     4     -2.245191  1 N  pz                36     -2.245191  2 N  pz         
+    12     -2.115092  1 N  s                 44      2.115092  2 N  s          
+    19      1.773113  1 N  pz                51      1.773113  2 N  pz         
+ 
+ Vector   28  Occ=0.000000D+00  E= 3.003052D-01  Symmetry=b1u
+              MO Center=  3.2D-14,  6.0D-16,  2.3D-13, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      1.870642  1 N  d  2              41     -1.870642  2 N  d  2       
+    32     -0.073574  1 N  d  2              64      0.073574  2 N  d  2       
+ 
+ Vector   29  Occ=0.000000D+00  E= 3.003105D-01  Symmetry=au
+              MO Center=  1.1D-14, -1.3D-15,  2.1D-13, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      1.870634  1 N  d -2              37     -1.870634  2 N  d -2       
+    28     -0.073565  1 N  d -2              60      0.073565  2 N  d -2       
+ 
+ Vector   30  Occ=0.000000D+00  E= 3.040087D-01  Symmetry=b2u
+              MO Center=  3.0D-15, -3.6D-15, -9.8D-16, r^2= 8.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.339379  1 N  d -1              38     -1.339379  2 N  d -1       
+    21      0.197290  1 N  py                53      0.197290  2 N  py         
+    18      0.188598  1 N  py                50      0.188598  2 N  py         
+     3     -0.089318  1 N  py                35     -0.089318  2 N  py         
+    15      0.070589  1 N  py                47      0.070589  2 N  py         
+ 
+ Vector   31  Occ=0.000000D+00  E= 3.040087D-01  Symmetry=b3u
+              MO Center= -5.0D-13,  2.0D-15,  5.7D-16, r^2= 8.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      1.339379  1 N  d  1              40     -1.339379  2 N  d  1       
+    20     -0.197290  1 N  px                52     -0.197290  2 N  px         
+    17     -0.188598  1 N  px                49     -0.188598  2 N  px         
+     2      0.089318  1 N  px                34      0.089318  2 N  px         
+    14     -0.070589  1 N  px                46     -0.070589  2 N  px         
+ 
+ Vector   32  Occ=0.000000D+00  E= 4.011944D-01  Symmetry=b1u
+              MO Center=  5.5D-25, -3.8D-27, -1.8D-12, r^2= 1.6D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13     76.576041  1 N  s                 45    -76.576041  2 N  s          
+     1     68.696426  1 N  s                 33    -68.696426  2 N  s          
+    22    -21.833827  1 N  pz                54    -21.833827  2 N  pz         
+     4     -8.165449  1 N  pz                36     -8.165449  2 N  pz         
+     7      2.167890  1 N  d  0              39     -2.167890  2 N  d  0       
+ 
+ Vector   33  Occ=0.000000D+00  E= 4.024226D-01  Symmetry=ag
+              MO Center= -3.7D-13, -6.3D-15,  2.5D-12, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      6.087313  1 N  pz                54     -6.087313  2 N  pz         
+     7     -2.211295  1 N  d  0              39     -2.211295  2 N  d  0       
+    12      1.821111  1 N  s                 44      1.821111  2 N  s          
+    13      0.925719  1 N  s                 45      0.925719  2 N  s          
+     1     -0.860495  1 N  s                 33     -0.860495  2 N  s          
+ 
+ Vector   34  Occ=0.000000D+00  E= 4.098349D-01  Symmetry=b3g
+              MO Center= -1.3D-14, -6.1D-16,  1.6D-14, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21     11.667026  1 N  py                53    -11.667026  2 N  py         
+     6     -3.341062  1 N  d -1              38     -3.341062  2 N  d -1       
+     3     -1.974002  1 N  py                35      1.974002  2 N  py         
+    18      0.396193  1 N  py                50     -0.396193  2 N  py         
+    15      0.240285  1 N  py                47     -0.240285  2 N  py         
+ 
+ Vector   35  Occ=0.000000D+00  E= 4.098349D-01  Symmetry=b2g
+              MO Center= -3.7D-14,  1.1D-15, -1.0D-14, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20     11.667026  1 N  px                52    -11.667026  2 N  px         
+     8      3.341062  1 N  d  1              40      3.341062  2 N  d  1       
+     2     -1.974002  1 N  px                34      1.974002  2 N  px         
+    17      0.396193  1 N  px                49     -0.396193  2 N  px         
+    14      0.240285  1 N  px                46     -0.240285  2 N  px         
+ 
+ Vector   36  Occ=0.000000D+00  E= 5.687637D-01  Symmetry=ag
+              MO Center=  4.3D-13, -5.4D-15,  1.2D-14, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    32      0.689424  1 N  d  2              64      0.689424  2 N  d  2       
+     9     -0.435399  1 N  d  2              41     -0.435399  2 N  d  2       
+    27      0.034852  1 N  d  2              59      0.034852  2 N  d  2       
+ 
+ Vector   37  Occ=0.000000D+00  E= 5.687646D-01  Symmetry=b1g
+              MO Center=  7.4D-14,  2.9D-15,  1.1D-15, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      0.689423  1 N  d -2              60      0.689423  2 N  d -2       
+     5     -0.435400  1 N  d -2              37     -0.435400  2 N  d -2       
+    23      0.034853  1 N  d -2              55      0.034853  2 N  d -2       
+ 
+ Vector   38  Occ=0.000000D+00  E= 5.851153D-01  Symmetry=ag
+              MO Center=  2.1D-13, -3.7D-15,  3.7D-11, r^2= 5.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    30      0.965634  1 N  d  0              62      0.965634  2 N  d  0       
+     4      0.947172  1 N  pz                36     -0.947172  2 N  pz         
+    13      0.881226  1 N  s                 45      0.881226  2 N  s          
+    12     -0.838952  1 N  s                 44     -0.838952  2 N  s          
+     7     -0.541770  1 N  d  0              39     -0.541770  2 N  d  0       
+ 
+ Vector   39  Occ=0.000000D+00  E= 6.039927D-01  Symmetry=b1u
+              MO Center=  6.0D-14, -2.0D-17, -3.9D-11, r^2= 4.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13     43.372103  1 N  s                 45    -43.372103  2 N  s          
+     1     34.694124  1 N  s                 33    -34.694124  2 N  s          
+    22    -12.012151  1 N  pz                54    -12.012151  2 N  pz         
+     4     -4.167948  1 N  pz                36     -4.167948  2 N  pz         
+     7      1.906741  1 N  d  0              39     -1.906741  2 N  d  0       
+ 
+ Vector   40  Occ=0.000000D+00  E= 6.771510D-01  Symmetry=b2u
+              MO Center= -6.4D-14,  1.0D-14,  2.7D-15, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    29      0.754413  1 N  d -1              61     -0.754413  2 N  d -1       
+    18      0.720437  1 N  py                50      0.720437  2 N  py         
+    21     -0.554035  1 N  py                53     -0.554035  2 N  py         
+     6     -0.478684  1 N  d -1              38      0.478684  2 N  d -1       
+    15     -0.245679  1 N  py                47     -0.245679  2 N  py         
+ 
+ Vector   41  Occ=0.000000D+00  E= 6.771510D-01  Symmetry=b3u
+              MO Center= -1.3D-13, -4.3D-15,  5.0D-16, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    31     -0.754413  1 N  d  1              63      0.754413  2 N  d  1       
+    17      0.720437  1 N  px                49      0.720437  2 N  px         
+    20     -0.554035  1 N  px                52     -0.554035  2 N  px         
+     8      0.478684  1 N  d  1              40     -0.478684  2 N  d  1       
+    14     -0.245679  1 N  px                46     -0.245679  2 N  px         
+ 
+ Vector   42  Occ=0.000000D+00  E= 8.099901D-01  Symmetry=b1u
+              MO Center= -4.1D-14, -2.6D-15,  1.4D-14, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    32      1.341119  1 N  d  2              64     -1.341119  2 N  d  2       
+     9     -1.099123  1 N  d  2              41      1.099123  2 N  d  2       
+ 
+ Vector   43  Occ=0.000000D+00  E= 8.099923D-01  Symmetry=au
+              MO Center= -1.0D-14,  1.8D-15,  3.2D-14, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      1.341119  1 N  d -2              60     -1.341119  2 N  d -2       
+     5     -1.099135  1 N  d -2              37      1.099135  2 N  d -2       
+ 
+ Vector   44  Occ=0.000000D+00  E= 8.316706D-01  Symmetry=b1u
+              MO Center= -4.3D-15, -2.9D-16,  9.8D-14, r^2= 6.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13     45.416706  1 N  s                 45    -45.416706  2 N  s          
+    12     17.068351  1 N  s                 44    -17.068351  2 N  s          
+    22    -11.226564  1 N  pz                54    -11.226564  2 N  pz         
+    19    -11.061788  1 N  pz                51    -11.061788  2 N  pz         
+     1     10.870496  1 N  s                 33    -10.870496  2 N  s          
+ 
+ Vector   45  Occ=0.000000D+00  E= 9.103737D-01  Symmetry=b2u
+              MO Center= -1.3D-14,  4.1D-15,  6.9D-17, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15     -0.651904  1 N  py                47     -0.651904  2 N  py         
+    18      0.632420  1 N  py                50      0.632420  2 N  py         
+     6      0.616458  1 N  d -1              38     -0.616458  2 N  d -1       
+    29     -0.531845  1 N  d -1              61      0.531845  2 N  d -1       
+    21     -0.231024  1 N  py                53     -0.231024  2 N  py         
+ 
+ Vector   46  Occ=0.000000D+00  E= 9.103737D-01  Symmetry=b3u
+              MO Center= -1.2D-13,  1.6D-15,  1.6D-16, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.651904  1 N  px                46      0.651904  2 N  px         
+    17     -0.632420  1 N  px                49     -0.632420  2 N  px         
+     8      0.616458  1 N  d  1              40     -0.616458  2 N  d  1       
+    31     -0.531845  1 N  d  1              63      0.531845  2 N  d  1       
+    20      0.231024  1 N  px                52      0.231024  2 N  px         
+ 
+ Vector   47  Occ=0.000000D+00  E= 1.004138D+00  Symmetry=b3g
+              MO Center=  8.2D-15,  2.6D-15, -5.6D-15, r^2= 5.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      7.920647  1 N  py                53     -7.920647  2 N  py         
+    29      2.859941  1 N  d -1              61      2.859941  2 N  d -1       
+     6     -2.675264  1 N  d -1              18     -2.664791  1 N  py         
+    38     -2.675264  2 N  d -1              50      2.664791  2 N  py         
+     3     -1.110132  1 N  py                35      1.110132  2 N  py         
+ 
+ Vector   48  Occ=0.000000D+00  E= 1.004138D+00  Symmetry=b2g
+              MO Center=  4.3D-14, -9.5D-16,  4.7D-15, r^2= 5.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      7.920647  1 N  px                52     -7.920647  2 N  px         
+    31     -2.859941  1 N  d  1              63     -2.859941  2 N  d  1       
+     8      2.675264  1 N  d  1              17     -2.664791  1 N  px         
+    40      2.675264  2 N  d  1              49      2.664791  2 N  px         
+     2     -1.110132  1 N  px                34      1.110132  2 N  px         
+ 
+ Vector   49  Occ=0.000000D+00  E= 1.130450D+00  Symmetry=b3g
+              MO Center=  3.3D-15,  3.1D-16, -1.2D-15, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    18      4.724515  1 N  py                50     -4.724515  2 N  py         
+    21      2.329513  1 N  py                53     -2.329513  2 N  py         
+    29     -2.163233  1 N  d -1              61     -2.163233  2 N  d -1       
+     6     -0.796393  1 N  d -1              38     -0.796393  2 N  d -1       
+    15     -0.615262  1 N  py                47      0.615262  2 N  py         
+ 
+ Vector   50  Occ=0.000000D+00  E= 1.130450D+00  Symmetry=b2g
+              MO Center= -4.9D-14, -6.0D-16,  1.3D-15, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      4.724515  1 N  px                49     -4.724515  2 N  px         
+    20      2.329513  1 N  px                52     -2.329513  2 N  px         
+    31      2.163233  1 N  d  1              63      2.163233  2 N  d  1       
+     8      0.796393  1 N  d  1              40      0.796393  2 N  d  1       
+    14     -0.615262  1 N  px                46      0.615262  2 N  px         
+ 
+ Vector   51  Occ=0.000000D+00  E= 1.163228D+00  Symmetry=b1u
+              MO Center=  6.7D-27,  1.0D-28, -1.1D-12, r^2= 4.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13     47.798807  1 N  s                 45    -47.798807  2 N  s          
+     1     28.245326  1 N  s                 33    -28.245326  2 N  s          
+    22    -12.632594  1 N  pz                54    -12.632594  2 N  pz         
+     4     -3.336475  1 N  pz                36     -3.336475  2 N  pz         
+    19     -2.516930  1 N  pz                51     -2.516930  2 N  pz         
+ 
+ Vector   52  Occ=0.000000D+00  E= 1.169999D+00  Symmetry=ag
+              MO Center=  4.9D-28,  1.3D-29,  3.9D-13, r^2= 3.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      3.432706  1 N  pz                54     -3.432706  2 N  pz         
+    12      2.970958  1 N  s                 44      2.970958  2 N  s          
+    19      2.113268  1 N  pz                51     -2.113268  2 N  pz         
+     7     -1.249486  1 N  d  0              39     -1.249486  2 N  d  0       
+    30     -1.128488  1 N  d  0              62     -1.128488  2 N  d  0       
+ 
+ Vector   53  Occ=0.000000D+00  E= 1.759643D+00  Symmetry=ag
+              MO Center=  6.5D-15,  5.2D-17,  1.9D-13, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      2.107397  1 N  pz                54     -2.107397  2 N  pz         
+    11     -1.612251  1 N  s                 43     -1.612251  2 N  s          
+    30      1.338405  1 N  d  0              62      1.338405  2 N  d  0       
+    12      1.307504  1 N  s                 44      1.307504  2 N  s          
+     7     -1.058766  1 N  d  0              39     -1.058766  2 N  d  0       
+ 
+ Vector   54  Occ=0.000000D+00  E= 1.931840D+00  Symmetry=b2u
+              MO Center=  4.1D-17,  2.7D-16,  2.1D-16, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24      0.734955  1 N  d -1              56     -0.734955  2 N  d -1       
+    29     -0.690316  1 N  d -1              61      0.690316  2 N  d -1       
+     6      0.373143  1 N  d -1              38     -0.373143  2 N  d -1       
+    18     -0.190749  1 N  py                50     -0.190749  2 N  py         
+    21      0.155206  1 N  py                53      0.155206  2 N  py         
+ 
+ Vector   55  Occ=0.000000D+00  E= 1.931840D+00  Symmetry=b3u
+              MO Center= -1.7D-15,  8.3D-18,  1.7D-16, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      0.734955  1 N  d  1              58     -0.734955  2 N  d  1       
+    31     -0.690316  1 N  d  1              63      0.690316  2 N  d  1       
+     8      0.373143  1 N  d  1              40     -0.373143  2 N  d  1       
+    17      0.190749  1 N  px                49      0.190749  2 N  px         
+    20     -0.155206  1 N  px                52     -0.155206  2 N  px         
+ 
+ Vector   56  Occ=0.000000D+00  E= 2.019502D+00  Symmetry=ag
+              MO Center= -3.1D-30,  8.3D-32, -2.6D-14, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    27      0.814929  1 N  d  2              59      0.814929  2 N  d  2       
+    32     -0.547863  1 N  d  2              64     -0.547863  2 N  d  2       
+     9      0.199181  1 N  d  2              41      0.199181  2 N  d  2       
+ 
+ Vector   57  Occ=0.000000D+00  E= 2.019502D+00  Symmetry=b1g
+              MO Center= -1.1D-30, -1.3D-30, -2.4D-14, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    23      0.814929  1 N  d -2              55      0.814929  2 N  d -2       
+    28     -0.547863  1 N  d -2              60     -0.547863  2 N  d -2       
+     5      0.199181  1 N  d -2              37      0.199181  2 N  d -2       
+ 
+ Vector   58  Occ=0.000000D+00  E= 2.338959D+00  Symmetry=b1u
+              MO Center= -8.3D-16,  4.6D-17,  2.8D-14, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    27      0.915776  1 N  d  2              59     -0.915776  2 N  d  2       
+    32     -0.836176  1 N  d  2              64      0.836176  2 N  d  2       
+     9      0.476856  1 N  d  2              41     -0.476856  2 N  d  2       
+ 
+ Vector   59  Occ=0.000000D+00  E= 2.338959D+00  Symmetry=au
+              MO Center= -2.3D-16,  6.5D-17,  2.7D-14, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    23      0.915776  1 N  d -2              55     -0.915776  2 N  d -2       
+    28     -0.836177  1 N  d -2              60      0.836177  2 N  d -2       
+     5      0.476858  1 N  d -2              37     -0.476858  2 N  d -2       
+ 
+ Vector   60  Occ=0.000000D+00  E= 2.537768D+00  Symmetry=ag
+              MO Center= -1.0D-26, -9.2D-28,  1.3D-12, r^2= 1.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.046180  1 N  s                 43      1.046180  2 N  s          
+    19      0.808556  1 N  pz                25     -0.810869  1 N  d  0       
+    51     -0.808556  2 N  pz                57     -0.810869  2 N  d  0       
+    12     -0.602413  1 N  s                 44     -0.602413  2 N  s          
+    10      0.550209  1 N  s                 42      0.550209  2 N  s          
+ 
+ Vector   61  Occ=0.000000D+00  E= 2.765962D+00  Symmetry=b1u
+              MO Center=  1.1D-26,  8.7D-28, -1.1D-12, r^2= 3.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12     32.612449  1 N  s                 44    -32.612449  2 N  s          
+    13     30.772125  1 N  s                 45    -30.772125  2 N  s          
+    19    -17.680029  1 N  pz                51    -17.680029  2 N  pz         
+    22     -7.322874  1 N  pz                54     -7.322874  2 N  pz         
+     1      5.234312  1 N  s                 33     -5.234312  2 N  s          
+ 
+ Vector   62  Occ=0.000000D+00  E= 2.823659D+00  Symmetry=b3g
+              MO Center=  4.7D-16, -3.2D-16,  7.1D-16, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      3.114231  1 N  py                53     -3.114231  2 N  py         
+    29      1.373728  1 N  d -1              61      1.373728  2 N  d -1       
+    24     -1.203778  1 N  d -1              56     -1.203778  2 N  d -1       
+     6     -1.074610  1 N  d -1              18     -1.078653  1 N  py         
+    38     -1.074610  2 N  d -1              50      1.078653  2 N  py         
+ 
+ Vector   63  Occ=0.000000D+00  E= 2.823659D+00  Symmetry=b2g
+              MO Center= -2.5D-15, -1.0D-16,  1.7D-15, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      3.114231  1 N  px                52     -3.114231  2 N  px         
+    31     -1.373728  1 N  d  1              63     -1.373728  2 N  d  1       
+    26      1.203778  1 N  d  1              58      1.203778  2 N  d  1       
+     8      1.074610  1 N  d  1              17     -1.078653  1 N  px         
+    40      1.074610  2 N  d  1              49      1.078653  2 N  px         
+ 
+ Vector   64  Occ=0.000000D+00  E= 3.000501D+00  Symmetry=b1u
+              MO Center=  7.4D-29, -3.8D-31, -4.9D-13, r^2= 1.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13     25.344697  1 N  s                 45    -25.344697  2 N  s          
+     1     13.230224  1 N  s                 33    -13.230224  2 N  s          
+    12      8.608491  1 N  s                 44     -8.608491  2 N  s          
+    22     -6.536249  1 N  pz                54     -6.536249  2 N  pz         
+    19     -5.184062  1 N  pz                51     -5.184062  2 N  pz         
+ 
+
+ center of mass
+ --------------
+ x =   0.00000000 y =   0.00000000 z =   0.00000000
+
+ moments of inertia (a.u.)
+ ------------------
+          30.116955926815           0.000000000000           0.000000000000
+           0.000000000000          30.116955926815           0.000000000000
+           0.000000000000           0.000000000000           0.000000000000
+ 
+     Multipole analysis of the density
+     ---------------------------------
+ 
+     L   x y z        total         alpha         beta         nuclear
+     -   - - -        -----         -----         ----         -------
+     0   0 0 0     -0.000000     -7.000000     -7.000000     14.000000
+ 
+     1   1 0 0     -0.000000     -0.000000     -0.000000      0.000000
+     1   0 1 0      0.000000      0.000000      0.000000      0.000000
+     1   0 0 1      0.000000      0.000000      0.000000      0.000000
+ 
+     2   2 0 0     -7.631630     -3.815815     -3.815815      0.000000
+     2   1 1 0     -0.000000     -0.000000     -0.000000      0.000000
+     2   1 0 1      0.000000      0.000000      0.000000      0.000000
+     2   0 2 0     -7.631630     -3.815815     -3.815815      0.000000
+     2   0 1 1     -0.000000     -0.000000     -0.000000      0.000000
+     2   0 0 2     -8.791168    -11.923172    -11.923172     15.055177
+ 
+
+ Parallel integral file used      12 records with       0 large values
+
+                                NWChem TDDFT Module
+                                -------------------
+ 
+ 
+            General Information
+            -------------------
+           No. of orbitals :     128
+            Alpha orbitals :      64
+             Beta orbitals :      64
+        Alpha frozen cores :       0
+         Beta frozen cores :       0
+     Alpha frozen virtuals :       0
+      Beta frozen virtuals :       0
+         Spin multiplicity :       1
+    Number of AO functions :      64
+        Use of symmetry is : off
+      Symmetry adaption is : on 
+         Schwarz screening :  0.10D-07
+ 
+              XC Information
+              --------------
+                  NCAP Method XC Functional
+               NCAP GGA Exchange Functional   1.00          
+         Perdew 1981 Correlation Functional   1.00 local    
+         Perdew 1986 Correlation Functional   1.00 non-local
+ 
+             TDDFT Information
+             -----------------
+          Calculation type : TDDFT             
+         Wavefunction type : Restricted singlets & triplets
+          No. of electrons :      14
+           Alpha electrons :       7
+            Beta electrons :       7
+              No. of roots :      12
+          Max subspacesize :    6400
+            Max iterations :     100
+               Target root :       1
+           Target symmetry : none
+      Symmetry restriction : off
+                 Algorithm : Optimal
+        Davidson threshold :  0.10D-03
+ 
+            Memory Information
+            ------------------
+          Available GA space size is          26210304 doubles
+          Available MA space size is          26212116 doubles
+          Length of a trial vector is          399
+          Algorithm : Incore multiple tensor contraction
+          Estimated peak GA usage is          10633576 doubles
+          Estimated peak MA usage is            102000 doubles
+ 
+   12 smallest eigenvalue differences (eV) 
+--------------------------------------------------------
+  No. Spin  Occ  Vir  Irrep   E(Occ)    E(Vir)   E(Diff)
+--------------------------------------------------------
+    1    1    7    8 b3g      -0.378    -0.070     8.371
+    2    1    7    9 b2g      -0.378    -0.070     8.371
+    3    1    5    8 au       -0.428    -0.070     9.727
+    4    1    6    8 b1u      -0.428    -0.070     9.727
+    5    1    5    9 b1u      -0.428    -0.070     9.727
+    6    1    6    9 au       -0.428    -0.070     9.727
+    7    1    7   10 b1u      -0.378     0.023    10.915
+    8    1    7   11 ag       -0.378     0.051    11.669
+    9    1    4    8 b2u      -0.499    -0.070    11.677
+   10    1    4    9 b3u      -0.499    -0.070    11.677
+   11    1    5   10 b2g      -0.428     0.023    12.271
+   12    1    6   10 b3g      -0.428     0.023    12.271
+--------------------------------------------------------
+
+  Entering Davidson iterations
+  Restricted singlet excited states
+
+  Iter   NTrls   NConv    DeltaV     DeltaE      Time   
+  ----  ------  ------  ---------  ---------  --------- 
+    1     12       1     0.69E+00   0.10+100        1.9
+    2     23       1     0.11E+00   0.18E+00        1.6
+    3     45       1     0.59E-01   0.45E-01        2.8
+    4     67       1     0.15E-01   0.74E-02        2.9
+    5     89       1     0.45E-02   0.16E-03        2.8
+    6    111       5     0.21E-02   0.56E-05        2.8
+    7    125       8     0.21E+00   0.11E-01        2.0
+    8    133       9     0.11E+00   0.18E-01        1.4
+    9    139      10     0.95E-02   0.29E-02        1.2
+   10    143      10     0.37E-02   0.59E-04        1.0
+   11    147      10     0.17E-02   0.53E-05        1.0
+   12    151      10     0.76E-03   0.63E-06        1.0
+   13    155      11     0.37E-03   0.90E-07        1.0
+   14    157      11     0.18E-03   0.17E-07        0.8
+   15    159      11     0.12E-03   0.28E-08        0.8
+   16    161      12     0.71E-04   0.12E-08        0.8
+  ----  ------  ------  ---------  ---------  --------- 
+  Convergence criterion met
+ 
+  Ground state ag       -109.570921016575 a.u.
+ 
+  ----------------------------------------------------------------------------
+  Root   1 singlet b2g            0.336034878 a.u.                9.1440 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.00000   Y -0.00000   Z  0.00000
+     Transition Moments   XX -0.00000  XY -0.00000  XZ -1.47234
+     Transition Moments   YY  0.00000  YZ  0.00000  ZZ  0.00000
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000004380
+     Magnetic Dipole                               0.0000070962
+     Total Oscillator Strength                     0.0000075342
+ 
+     Occ.    7  ag  ---  Virt.    9  b2g  0.99798 X
+  ----------------------------------------------------------------------------
+  Root   2 singlet b3g            0.336034879 a.u.                9.1440 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.00000   Y  0.00000   Z  0.00000
+     Transition Moments   XX  0.00000  XY -0.00000  XZ  0.00000
+     Transition Moments   YY -0.00000  YZ  1.47234  ZZ  0.00000
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000004380
+     Magnetic Dipole                               0.0000070962
+     Total Oscillator Strength                     0.0000075342
+ 
+     Occ.    7  ag  ---  Virt.    8  b3g -0.99798 X
+  ----------------------------------------------------------------------------
+  Root   3 singlet au             0.357473387 a.u.                9.7273 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.00000   Y -0.00000   Z  0.00000
+     Transition Moments   XX -0.00000  XY -0.00000  XZ -0.00000
+     Transition Moments   YY -0.00000  YZ -0.00000  ZZ -0.00000
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000000000
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0000000000
+ 
+     Occ.    5  b3u ---  Virt.    8  b3g  0.70711 X
+     Occ.    6  b2u ---  Virt.    9  b2g -0.70711 X
+  ----------------------------------------------------------------------------
+  Root   4 singlet b1u            0.370676919 a.u.               10.0866 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.00000   Y -0.00000   Z  0.00000
+     Transition Moments   XX -0.00000  XY -0.00000  XZ  0.00000
+     Transition Moments   YY  0.00000  YZ  0.00000  ZZ -0.00000
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000000000
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0000000000
+ 
+     Occ.    5  b3u ---  Virt.    9  b2g  0.70696 X
+     Occ.    6  b2u ---  Virt.    8  b3g -0.70696 X
+  ----------------------------------------------------------------------------
+  Root   5 singlet au             0.370676943 a.u.               10.0866 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X  0.00000   Y -0.00000   Z  0.00000
+     Transition Moments   XX  0.00000  XY -0.00000  XZ -0.00000
+     Transition Moments   YY  0.00000  YZ -0.00000  ZZ -0.00000
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000000000
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0000000000
+ 
+     Occ.    5  b3u ---  Virt.    8  b3g  0.70696 X
+     Occ.    6  b2u ---  Virt.    9  b2g  0.70696 X
+  ----------------------------------------------------------------------------
+  Root   6 singlet b1u            0.393931295 a.u.               10.7194 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.00000   Y  0.00000   Z -0.14965
+     Transition Moments   XX -0.00000  XY  0.00000  XZ -0.00000
+     Transition Moments   YY  0.00000  YZ  0.00000  ZZ  0.00000
+     Dipole Oscillator Strength                    0.0058816790
+     Electric Quadrupole                           0.0000000000
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0058816790
+ 
+     Occ.    7  ag  ---  Virt.   10  b1u -0.99624 X
+     Occ.    7  ag  ---  Virt.   15  b1u  0.07452 X
+  ----------------------------------------------------------------------------
+  Root   7 singlet ag             0.423575534 a.u.               11.5261 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X  0.00000   Y  0.00000   Z -0.00000
+     Transition Moments   XX  0.71780  XY -0.00000  XZ -0.00000
+     Transition Moments   YY  0.71780  YZ  0.00000  ZZ  1.13684
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000000237
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0000000237
+ 
+     Occ.    7  ag  ---  Virt.   11  ag  -0.91001 X
+     Occ.    7  ag  ---  Virt.   14  ag  -0.39600 X
+     Occ.    7  ag  ---  Virt.   18  ag   0.09584 X
+  ----------------------------------------------------------------------------
+  Root   8 singlet ag             0.438016980 a.u.               11.9191 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X  0.00000   Y  0.00000   Z  0.00000
+     Transition Moments   XX  0.54555  XY  0.00000  XZ  0.00000
+     Transition Moments   YY  0.54555  YZ  0.00000  ZZ -0.68440
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000002257
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0000002257
+ 
+     Occ.    7  ag  ---  Virt.   11  ag  -0.39366 X
+     Occ.    7  ag  ---  Virt.   14  ag   0.91649 X
+  ----------------------------------------------------------------------------
+  Root   9 singlet b3u            0.440615314 a.u.               11.9898 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.41166   Y -0.00040   Z -0.00000
+     Transition Moments   XX  0.00000  XY  0.00000  XZ -0.00000
+     Transition Moments   YY -0.00000  YZ -0.00000  ZZ -0.00000
+     Dipole Oscillator Strength                    0.0497783814
+     Electric Quadrupole                           0.0000000000
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0497783814
+ 
+     Occ.    5  b3u ---  Virt.   11  ag   0.16747 X
+     Occ.    7  ag  ---  Virt.   13  b3u  0.98346 X
+  ----------------------------------------------------------------------------
+  Root  10 singlet b2u            0.440615315 a.u.               11.9898 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.00040   Y  0.41166   Z  0.00000
+     Transition Moments   XX  0.00000  XY -0.00000  XZ  0.00000
+     Transition Moments   YY -0.00000  YZ  0.00000  ZZ  0.00000
+     Dipole Oscillator Strength                    0.0497789205
+     Electric Quadrupole                           0.0000000000
+     Magnetic Dipole                               0.0000000000
+     Total Oscillator Strength                     0.0497789205
+ 
+     Occ.    6  b2u ---  Virt.   11  ag  -0.16747 X
+     Occ.    7  ag  ---  Virt.   12  b2u -0.98346 X
+  ----------------------------------------------------------------------------
+  Root  11 singlet b2g            0.447872207 a.u.               12.1872 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X -0.00000   Y -0.00000   Z  0.00000
+     Transition Moments   XX -0.00000  XY -0.00000  XZ  0.08484
+     Transition Moments   YY  0.00000  YZ -0.00000  ZZ  0.00000
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000000034
+     Magnetic Dipole                               0.0000000018
+     Total Oscillator Strength                     0.0000000053
+ 
+     Occ.    5  b3u ---  Virt.   10  b1u  0.99458 X
+     Occ.    7  ag  ---  Virt.   16  b2g -0.09890 X
+  ----------------------------------------------------------------------------
+  Root  12 singlet b3g            0.447872207 a.u.               12.1872 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments    X  0.00000   Y -0.00000   Z  0.00000
+     Transition Moments   XX -0.00000  XY  0.00000  XZ  0.00000
+     Transition Moments   YY  0.00000  YZ  0.08483  ZZ -0.00000
+     Dipole Oscillator Strength                    0.0000000000
+     Electric Quadrupole                           0.0000000034
+     Magnetic Dipole                               0.0000000018
+     Total Oscillator Strength                     0.0000000053
+ 
+     Occ.    6  b2u ---  Virt.   10  b1u  0.99458 X
+     Occ.    7  ag  ---  Virt.   17  b3g -0.09890 X
+ 
+              Target root =      1
+          Target symmetry = none
+      Ground state energy =   -109.570921016575
+        Excitation energy =      0.336034878417
+     Excited state energy =   -109.234886138158
+ 
+  stored tddft:energy   -109.234886138158     
+ 
+   12 smallest eigenvalue differences (eV) 
+--------------------------------------------------------
+  No. Spin  Occ  Vir  Irrep   E(Occ)    E(Vir)   E(Diff)
+--------------------------------------------------------
+    1    1    7    8 b3g      -0.378    -0.070     8.371
+    2    1    7    9 b2g      -0.378    -0.070     8.371
+    3    1    5    8 au       -0.428    -0.070     9.727
+    4    1    6    8 b1u      -0.428    -0.070     9.727
+    5    1    5    9 b1u      -0.428    -0.070     9.727
+    6    1    6    9 au       -0.428    -0.070     9.727
+    7    1    7   10 b1u      -0.378     0.023    10.915
+    8    1    7   11 ag       -0.378     0.051    11.669
+    9    1    4    8 b2u      -0.499    -0.070    11.677
+   10    1    4    9 b3u      -0.499    -0.070    11.677
+   11    1    5   10 b2g      -0.428     0.023    12.271
+   12    1    6   10 b3g      -0.428     0.023    12.271
+--------------------------------------------------------
+
+  Entering Davidson iterations
+  Restricted triplet excited states
+
+  Iter   NTrls   NConv    DeltaV     DeltaE      Time   
+  ----  ------  ------  ---------  ---------  --------- 
+    1     12       1     0.13E+00   0.10+100        1.7
+    2     23       1     0.32E-01   0.66E-02        1.6
+    3     45       1     0.40E-01   0.70E-02        2.8
+    4     67       1     0.11E-01   0.39E-02        2.9
+    5     89       1     0.35E-02   0.64E-04        2.8
+    6    111       6     0.18E-02   0.32E-05        2.8
+    7    123       7     0.64E-01   0.39E-03        1.8
+    8    133       9     0.47E-02   0.68E-02        1.6
+    9    139      11     0.94E-03   0.10E-04        1.2
+   10    141      11     0.37E-03   0.12E-06        0.7
+   11    143      12     0.98E-04   0.11E-07        0.7
+  ----  ------  ------  ---------  ---------  --------- 
+  Convergence criterion met
+ 
+  Ground state ag       -109.570921016575 a.u.
+ 
+  ----------------------------------------------------------------------------
+  Root   1 triplet b3g            0.277217990 a.u.                7.5435 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    7  ag  ---  Virt.    8  b3g -1.00080 X
+     Occ.    7  ag  ---  Virt.    8  b3g -0.05206 Y
+  ----------------------------------------------------------------------------
+  Root   2 triplet b2g            0.277217991 a.u.                7.5435 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    7  ag  ---  Virt.    9  b2g  1.00080 X
+     Occ.    7  ag  ---  Virt.    9  b2g  0.05206 Y
+  ----------------------------------------------------------------------------
+  Root   3 triplet b1u            0.284449763 a.u.                7.7403 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    5  b3u ---  Virt.    9  b2g -0.70939 X
+     Occ.    5  b3u ---  Virt.    9  b2g -0.08070 Y
+     Occ.    6  b2u ---  Virt.    8  b3g -0.70939 X
+     Occ.    6  b2u ---  Virt.    8  b3g -0.08070 Y
+  ----------------------------------------------------------------------------
+  Root   4 triplet b1u            0.310003039 a.u.                8.4356 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    5  b3u ---  Virt.    9  b2g -0.70775 X
+     Occ.    5  b3u ---  Virt.    9  b2g -0.05033 Y
+     Occ.    6  b2u ---  Virt.    8  b3g  0.70775 X
+     Occ.    6  b2u ---  Virt.    8  b3g  0.05033 Y
+  ----------------------------------------------------------------------------
+  Root   5 triplet au             0.310003058 a.u.                8.4356 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    5  b3u ---  Virt.    8  b3g  0.70775 X
+     Occ.    5  b3u ---  Virt.    8  b3g  0.05033 Y
+     Occ.    6  b2u ---  Virt.    9  b2g  0.70775 X
+     Occ.    6  b2u ---  Virt.    9  b2g  0.05033 Y
+  ----------------------------------------------------------------------------
+  Root   6 triplet au             0.357473387 a.u.                9.7273 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    5  b3u ---  Virt.    8  b3g  0.70711 X
+     Occ.    6  b2u ---  Virt.    9  b2g -0.70711 X
+  ----------------------------------------------------------------------------
+  Root   7 triplet b2u            0.391074923 a.u.               10.6417 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    4  b1u ---  Virt.    8  b3g -0.99631 X
+     Occ.    6  b2u ---  Virt.   11  ag   0.06912 X
+  ----------------------------------------------------------------------------
+  Root   8 triplet b3u            0.391074924 a.u.               10.6417 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    4  b1u ---  Virt.    9  b2g  0.99631 X
+     Occ.    5  b3u ---  Virt.   11  ag  -0.06912 X
+  ----------------------------------------------------------------------------
+  Root   9 triplet b1u            0.394136015 a.u.               10.7250 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    7  ag  ---  Virt.   10  b1u  0.99628 X
+     Occ.    7  ag  ---  Virt.   15  b1u -0.07589 X
+  ----------------------------------------------------------------------------
+  Root  10 triplet ag             0.412853286 a.u.               11.2343 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    5  b3u ---  Virt.   13  b3u -0.05912 X
+     Occ.    6  b2u ---  Virt.   12  b2u -0.05912 X
+     Occ.    7  ag  ---  Virt.   11  ag  -0.97911 X
+     Occ.    7  ag  ---  Virt.   14  ag  -0.17909 X
+  ----------------------------------------------------------------------------
+  Root  11 triplet ag             0.437038210 a.u.               11.8924 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    4  b1u ---  Virt.   10  b1u  0.05162 X
+     Occ.    7  ag  ---  Virt.   11  ag  -0.17670 X
+     Occ.    7  ag  ---  Virt.   14  ag   0.98201 X
+  ----------------------------------------------------------------------------
+  Root  12 triplet b2u            0.440766163 a.u.               11.9939 eV 
+  ----------------------------------------------------------------------------
+     Transition Moments                    Spin forbidden
+     Oscillator Strength                   Spin forbidden
+ 
+     Occ.    6  b2u ---  Virt.   11  ag   0.19644 X
+     Occ.    7  ag  ---  Virt.   12  b2u  0.97772 X
+ 
+              Target root =      1
+          Target symmetry = none
+      Ground state energy =   -109.570921016575
+        Excitation energy =      0.277217990262
+     Excited state energy =   -109.293703026314
+ 
+  stored tddft:energy   -109.293703026314     
+
+ Task  times  cpu:       48.4s     wall:       49.5s
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+ Summary of allocated global arrays
+-----------------------------------
+  No active global arrays
+
+
+
+                         GA Statistics for process    0
+                         ------------------------------
+
+       create   destroy   get      put      acc     scatter   gather  read&inc
+calls: 2883     2883     1.56e+06 7.11e+05 1.94e+05 1360        0      413     
+number of processes/call 1.39e+02 1.34e+02 6.41e+00 0.00e+00 0.00e+00
+bytes total:             3.76e+09 8.68e+08 1.03e+09 3.28e+04 0.00e+00 3.30e+03
+bytes remote:            0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00
+Max memory consumed for GA by this process: 66605888 bytes
+ 
+ 
+ 
+                                     CITATION
+                                     --------
+                Please cite the following reference when publishing
+                           results obtained with NWChem:
+ 
+                 M. Valiev, E.J. Bylaska, N. Govind, K. Kowalski,
+              T.P. Straatsma, H.J.J. van Dam, D. Wang, J. Nieplocha,
+                        E. Apra, T.L. Windus, W.A. de Jong
+                 "NWChem: a comprehensive and scalable open-source
+                  solution for large scale molecular simulations"
+                      Comput. Phys. Commun. 181, 1477 (2010)
+                           doi:10.1016/j.cpc.2010.04.018
+ 
+                                      AUTHORS
+                                      -------
+          E. Apra, E. J. Bylaska, W. A. de Jong, N. Govind, K. Kowalski,
+       T. P. Straatsma, M. Valiev, H. J. J. van Dam, D. Wang, T. L. Windus,
+        J. Hammond, J. Autschbach, K. Bhaskaran-Nair, J. Brabec, K. Lopata,
+    S. A. Fischer, S. Krishnamoorthy, M. Jacquelin, W. Ma, M. Klemm, O. Villa,
+      Y. Chen, V. Anisimov, F. Aquino, S. Hirata, M. T. Hackler, V. Konjkov,
+            D. Mejia-Rodriguez, T. Risthaus, M. Malagoli, A. Marenich,
+   A. Otero-de-la-Roza, J. Mullin, P. Nichols, R. Peverati, J. Pittner, Y. Zhao,
+        P.-D. Fan, A. Fonari, M. J. Williamson, R. J. Harrison, J. R. Rehr,
+      M. Dupuis, D. Silverstein, D. M. A. Smith, J. Nieplocha, V. Tipparaju,
+    M. Krishnan, B. E. Van Kuiken, A. Vazquez-Mayagoitia, L. Jensen, M. Swart,
+      Q. Wu, T. Van Voorhis, A. A. Auer, M. Nooijen, L. D. Crosby, E. Brown,
+      G. Cisneros, G. I. Fann, H. Fruchtl, J. Garza, K. Hirao, R. A. Kendall,
+      J. A. Nichols, K. Tsemekhman, K. Wolinski, J. Anchell, D. E. Bernholdt,
+      P. Borowski, T. Clark, D. Clerc, H. Dachsel, M. J. O. Deegan, K. Dyall,
+    D. Elwood, E. Glendening, M. Gutowski, A. C. Hess, J. Jaffe, B. G. Johnson,
+     J. Ju, R. Kobayashi, R. Kutteh, Z. Lin, R. Littlefield, X. Long, B. Meng,
+      T. Nakajima, S. Niu, L. Pollack, M. Rosing, K. Glaesemann, G. Sandrone,
+      M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe, A. T. Wong, Z. Zhang.
+
+ Total times  cpu:       48.4s     wall:       50.3s
+MA_summarize_allocated_blocks: starting scan ...
+MA_summarize_allocated_blocks: scan completed: 0 heap blocks, 0 stack blocks
+MA usage statistics:
+
+	allocation statistics:
+					      heap	     stack
+					      ----	     -----
+	current number of blocks	         0	         0
+	maximum number of blocks	        22	        53
+	current total bytes		         0	         0
+	maximum total bytes		   8504880	  22512392
+	maximum total K-bytes		      8505	     22513
+	maximum total M-bytes		         9	        23

--- a/QA/tests/dft_regscan/dft_regscan.nw
+++ b/QA/tests/dft_regscan/dft_regscan.nw
@@ -1,0 +1,21 @@
+start c2h4_pbe
+GEOMETRY 
+C 	0.0000 	0.0000 	0.6695
+C 	0.0000 	0.0000 -0.6695
+H 	0.0000 	0.9289 	1.2321
+H 	0.0000 -0.9289 	1.2321
+H 	0.0000 	0.9289 -1.2321
+H 	0.0000 -0.9289 -1.2321
+ symmetry d2h
+END  
+BASIS SPHERICAL  
+ * library aug-cc-pvdz
+END  
+DFT  
+ XC regscan
+END  
+task dft
+dft
+ grid xfine
+end
+task dft

--- a/QA/tests/dft_regscan/dft_regscan.out
+++ b/QA/tests/dft_regscan/dft_regscan.out
@@ -1,0 +1,2400 @@
+ argument  1 = dft_regscan.nw
+                                         
+                                         
+ 
+ 
+              Northwest Computational Chemistry Package (NWChem) 6.8
+              ------------------------------------------------------
+ 
+ 
+                    Environmental Molecular Sciences Laboratory
+                       Pacific Northwest National Laboratory
+                                Richland, WA 99352
+ 
+                              Copyright (c) 1994-2018
+                       Pacific Northwest National Laboratory
+                            Battelle Memorial Institute
+ 
+             NWChem is an open-source computational chemistry package
+                        distributed under the terms of the
+                      Educational Community License (ECL) 2.0
+             A copy of the license is included with this distribution
+                              in the LICENSE.TXT file
+ 
+                                  ACKNOWLEDGMENT
+                                  --------------
+
+            This software and its documentation were developed at the
+            EMSL at Pacific Northwest National Laboratory, a multiprogram
+            national laboratory, operated for the U.S. Department of Energy
+            by Battelle under Contract Number DE-AC05-76RL01830. Support
+            for this work was provided by the Department of Energy Office
+            of Biological and Environmental Research, Office of Basic
+            Energy Sciences, and the Office of Advanced Scientific Computing.
+
+
+           Job information
+           ---------------
+
+    hostname        = ubuntu-SVT13115FLS
+    program         = /home/dmejiar/Software/nwchemgit/nwchem/bin/LINUX64/nwchem
+    date            = Tue Jun  4 14:55:08 2019
+
+    compiled        = Mon_Jun_03_16:15:07_2019
+    source          = /home/dmejiar/Software/nwchemgit/nwchem
+    nwchem branch   = Development
+    nwchem revision = nwchem_on_git-899-g10985772d
+    ga revision     = 5.7.0
+    use scalapack   = F
+    input           = dft_regscan.nw
+    prefix          = c2h4_pbe.
+    data base       = ./c2h4_pbe.db
+    status          = startup
+    nproc           =        1
+    time left       =     -1s
+
+
+
+           Memory information
+           ------------------
+
+    heap     =   13107200 doubles =    100.0 Mbytes
+    stack    =   13107197 doubles =    100.0 Mbytes
+    global   =   26214400 doubles =    200.0 Mbytes (distinct from heap & stack)
+    total    =   52428797 doubles =    400.0 Mbytes
+    verify   = yes
+    hardfail = no 
+
+
+           Directory information
+           ---------------------
+ 
+  0 permanent = .
+  0 scratch   = .
+ 
+ 
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+
+ Scaling coordinates for geometry "geometry" by  1.889725989
+ (inverse scale =  0.529177249)
+
+ Turning off AUTOSYM since
+ SYMMETRY directive was detected!
+ 
+
+          ------
+          auto-z
+          ------
+  no constraints, skipping   0.000000000000000E+000
+  no constraints, skipping   0.000000000000000E+000
+ 
+ 
+                             Geometry "geometry" -> ""
+                             -------------------------
+ 
+ Output coordinates in angstroms (scale by  1.889725989 to convert to a.u.)
+ 
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 C                    6.0000     0.00000000     0.00000000     0.66950000
+    2 C                    6.0000     0.00000000     0.00000000    -0.66950000
+    3 H                    1.0000     0.00000000     0.92890000     1.23210000
+    4 H                    1.0000     0.00000000    -0.92890000     1.23210000
+    5 H                    1.0000     0.00000000     0.92890000    -1.23210000
+    6 H                    1.0000     0.00000000    -0.92890000    -1.23210000
+ 
+      Atomic Mass 
+      ----------- 
+ 
+      C                 12.000000
+      H                  1.007825
+ 
+
+ Effective nuclear repulsion energy (a.u.)      33.2650928750
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.0000000000
+ 
+      Symmetry information
+      --------------------
+ 
+ Group name             D2h       
+ Group number             26
+ Group order               8
+ No. of unique centers     2
+ 
+      Symmetry unique atoms
+ 
+     1    3
+ 
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+ 
+      Type          Name      I     J     K     L     M      Value
+      ----------- --------  ----- ----- ----- ----- ----- ----------
+    1 Stretch                  1     2                       1.33900
+    2 Stretch                  1     3                       1.08599
+    3 Stretch                  1     4                       1.08599
+    4 Stretch                  2     5                       1.08599
+    5 Stretch                  2     6                       1.08599
+    6 Bend                     1     2     5               121.20172
+    7 Bend                     1     2     6               121.20172
+    8 Bend                     2     1     3               121.20172
+    9 Bend                     2     1     4               121.20172
+   10 Bend                     3     1     4               117.59656
+   11 Bend                     5     2     6               117.59656
+   12 Torsion                  3     1     2     5           0.00000
+   13 Torsion                  3     1     2     6         180.00000
+   14 Torsion                  4     1     2     5         180.00000
+   15 Torsion                  4     1     2     6           0.00000
+ 
+ 
+            XYZ format geometry
+            -------------------
+     6
+ geometry
+ C                     0.00000000     0.00000000     0.66950000
+ C                     0.00000000     0.00000000    -0.66950000
+ H                     0.00000000     0.92890000     1.23210000
+ H                     0.00000000    -0.92890000     1.23210000
+ H                     0.00000000     0.92890000    -1.23210000
+ H                     0.00000000    -0.92890000    -1.23210000
+ 
+ ==============================================================================
+                                internuclear distances
+ ------------------------------------------------------------------------------
+       center one      |      center two      | atomic units |  angstroms
+ ------------------------------------------------------------------------------
+    2 C                |   1 C                |     2.53034  |     1.33900
+    3 H                |   1 C                |     2.05222  |     1.08599
+    4 H                |   1 C                |     2.05222  |     1.08599
+    5 H                |   2 C                |     2.05222  |     1.08599
+    6 H                |   2 C                |     2.05222  |     1.08599
+ ------------------------------------------------------------------------------
+                         number of included internuclear distances:          5
+ ==============================================================================
+
+
+
+ ==============================================================================
+                                 internuclear angles
+ ------------------------------------------------------------------------------
+        center 1       |       center 2       |       center 3       |  degrees
+ ------------------------------------------------------------------------------
+    2 C                |   1 C                |   3 H                |   121.20
+    2 C                |   1 C                |   4 H                |   121.20
+    3 H                |   1 C                |   4 H                |   117.60
+    1 C                |   2 C                |   5 H                |   121.20
+    1 C                |   2 C                |   6 H                |   121.20
+    5 H                |   2 C                |   6 H                |   117.60
+ ------------------------------------------------------------------------------
+                            number of included internuclear angles:          6
+ ==============================================================================
+
+
+
+
+
+ Summary of "ao basis" -> "" (spherical)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ *                        aug-cc-pvdz                 on all atoms 
+
+
+ 
+                                 NWChem DFT Module
+                                 -----------------
+ 
+ 
+                      Basis "ao basis" -> "ao basis" (spherical)
+                      -----
+  C (Carbon)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  6.66500000E+03  0.000692
+  1 S  1.00000000E+03  0.005329
+  1 S  2.28000000E+02  0.027077
+  1 S  6.47100000E+01  0.101718
+  1 S  2.10600000E+01  0.274740
+  1 S  7.49500000E+00  0.448564
+  1 S  2.79700000E+00  0.285074
+  1 S  5.21500000E-01  0.015204
+ 
+  2 S  6.66500000E+03 -0.000146
+  2 S  1.00000000E+03 -0.001154
+  2 S  2.28000000E+02 -0.005725
+  2 S  6.47100000E+01 -0.023312
+  2 S  2.10600000E+01 -0.063955
+  2 S  7.49500000E+00 -0.149981
+  2 S  2.79700000E+00 -0.127262
+  2 S  5.21500000E-01  0.544529
+ 
+  3 S  1.59600000E-01  1.000000
+ 
+  4 S  4.69000000E-02  1.000000
+ 
+  5 P  9.43900000E+00  0.038109
+  5 P  2.00200000E+00  0.209480
+  5 P  5.45600000E-01  0.508557
+ 
+  6 P  1.51700000E-01  1.000000
+ 
+  7 P  4.04100000E-02  1.000000
+ 
+  8 D  5.50000000E-01  1.000000
+ 
+  9 D  1.51000000E-01  1.000000
+ 
+  H (Hydrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  1.30100000E+01  0.019685
+  1 S  1.96200000E+00  0.137977
+  1 S  4.44600000E-01  0.478148
+ 
+  2 S  1.22000000E-01  1.000000
+ 
+  3 S  2.97400000E-02  1.000000
+ 
+  4 P  7.27000000E-01  1.000000
+ 
+  5 P  1.41000000E-01  1.000000
+ 
+
+
+ Summary of "ao basis" -> "ao basis" (spherical)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                        aug-cc-pvdz                9       23   4s3p2d
+ H                        aug-cc-pvdz                5        9   3s2p
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (spherical)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                        aug-cc-pvdz                9       23   4s3p2d
+ H                        aug-cc-pvdz                5        9   3s2p
+
+
+      Symmetry analysis of basis
+      --------------------------
+ 
+        ag         18
+        au          4
+        b1g         4
+        b1u        18
+        b2g         7
+        b2u        12
+        b3g        12
+        b3u         7
+ 
+  Caching 1-el integrals 
+ 
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     6
+          No. of electrons :    16
+           Alpha electrons :     8
+            Beta electrons :     8
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  30
+          AO basis - number of functions:    82
+                     number of shells:    38
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+ 
+              XC Information
+              --------------
+                      regSCAN Method XC Functional
+               regSCAN metaGGA Exchange Functional  1.000          
+                     regSCAN Correlation Potential  1.000          
+ 
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          C                   0.70       49          12.0       434
+          H                   0.35       45          14.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+ 
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         30 iters            30 iters 
+
+ 
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+ 
+      Superposition of Atomic Density Guess
+      -------------------------------------
+ 
+ Sum of atomic energies:         -77.33138240
+ 
+      Non-variational initial energy
+      ------------------------------
+
+ Total energy =     -78.441520
+ 1-e energy   =    -167.752829
+ 2-e energy   =      56.046216
+ HOMO         =      -0.345674
+ LUMO         =      -0.010774
+ 
+ 
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+ 
+  Numbering of irreducible representations: 
+ 
+     1 ag          2 au          3 b1g         4 b1u         5 b2g     
+     6 b2u         7 b3g         8 b3u     
+ 
+  Orbital symmetries:
+ 
+     1 ag          2 b1u         3 ag          4 b1u         5 b2u     
+     6 ag          7 b3g         8 b3u         9 b2g        10 ag      
+    11 b1u        12 b2u        13 b3g        14 b3u        15 ag      
+    16 b1u        17 b2g        18 ag      
+ 
+   Time after variat. SCF:      0.4
+   Time prior to 1st pass:      0.4
+
+ Integral file          = ./c2h4_pbe.aoints.0
+ Record size in doubles =  65536        No. of integs per rec  =  43688
+ Max. records in memory =     31        Max. records in file   =  99479
+ No. of bits per label  =      8        No. of bits per value  =     64
+
+
+ #quartets = 8.755D+04 #integrals = 9.248D+05 #direct =  0.0% #cached =100.0%
+
+
+ Grid_pts file          = ./c2h4_pbe.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =     16        Max. recs in file   =    530518
+
+
+           Memory utilization after 1st SCF pass: 
+           Heap Space remaining (MW):       10.87            10867704
+          Stack Space remaining (MW):       13.11            13106596
+
+   convergence    iter        energy       DeltaE   RMS-Dens  Diis-err    time
+ ---------------- ----- ----------------- --------- --------- ---------  ------
+ d= 0,ls=0.0,diis     1    -78.5493480311 -1.12D+02  1.43D-02  1.44D-01     1.0
+ d= 0,ls=0.0,diis     2    -78.5631061228 -1.38D-02  2.25D-03  8.84D-03     1.2
+ d= 0,ls=0.0,diis     3    -78.5637065923 -6.00D-04  9.89D-04  4.43D-03     1.4
+ d= 0,ls=0.0,diis     4    -78.5643004169 -5.94D-04  2.25D-04  1.28D-04     1.5
+ d= 0,ls=0.0,diis     5    -78.5643192619 -1.88D-05  1.29D-05  5.32D-07     1.7
+ d= 0,ls=0.0,diis     6    -78.5643193371 -7.51D-08  1.82D-06  1.80D-09     1.8
+
+
+         Total DFT energy =      -78.564319337082
+      One electron energy =     -170.051904446632
+           Coulomb energy =       70.478389747319
+    Exchange-Corr. energy =      -12.255897512720
+ Nuclear repulsion energy =       33.265092874952
+
+ Numeric. integr. density =       16.000003128107
+
+     Total iterative time =      1.4s
+
+
+ 
+                  Occupations of the irreducible representations
+                  ----------------------------------------------
+ 
+                     irrep           alpha         beta
+                     --------     --------     --------
+                     ag                3.0          3.0
+                     au                0.0          0.0
+                     b1g               0.0          0.0
+                     b1u               2.0          2.0
+                     b2g               0.0          0.0
+                     b2u               1.0          1.0
+                     b3g               1.0          1.0
+                     b3u               1.0          1.0
+ 
+ 
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+ 
+ Vector    1  Occ=2.000000D+00  E=-1.004972D+01  Symmetry=ag
+              MO Center=  3.9D-35, -9.5D-20,  1.4D-16, r^2= 4.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.713163  1 C  s                 24      0.713163  2 C  s          
+     3     -0.032658  1 C  s                 26     -0.032658  2 C  s          
+ 
+ Vector    2  Occ=2.000000D+00  E=-1.004904D+01  Symmetry=b1u
+              MO Center=  2.1D-17, -1.5D-17, -4.8D-17, r^2= 4.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.714090  1 C  s                 24     -0.714090  2 C  s          
+     3     -0.070287  1 C  s                 26      0.070287  2 C  s          
+     4     -0.035791  1 C  s                 27      0.035791  2 C  s          
+    10      0.025760  1 C  pz                33      0.025760  2 C  pz         
+ 
+ Vector    3  Occ=2.000000D+00  E=-7.297292D-01  Symmetry=ag
+              MO Center=  1.4D-17, -1.2D-16,  2.1D-15, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.301760  1 C  s                 25      0.301760  2 C  s          
+     3      0.158973  1 C  s                 26      0.158973  2 C  s          
+    47      0.113202  3 H  s                 56      0.113202  4 H  s          
+    65      0.113202  5 H  s                 74      0.113202  6 H  s          
+     7     -0.106780  1 C  pz                30      0.106780  2 C  pz         
+ 
+ Vector    4  Occ=2.000000D+00  E=-5.509709D-01  Symmetry=b1u
+              MO Center=  1.2D-30, -2.5D-17, -1.1D-15, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.439268  1 C  s                 26     -0.439268  2 C  s          
+     4     -0.333490  1 C  s                 27      0.333490  2 C  s          
+     2      0.247486  1 C  s                 10     -0.246828  1 C  pz         
+    25     -0.247486  2 C  s                 33     -0.246828  2 C  pz         
+    47      0.200816  3 H  s                 48      0.201017  3 H  s          
+ 
+ Vector    5  Occ=2.000000D+00  E=-4.395830D-01  Symmetry=b2u
+              MO Center= -1.5D-16, -1.8D-15,  8.0D-15, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      0.328197  1 C  py                29      0.328197  2 C  py         
+    47      0.216952  3 H  s                 56     -0.216952  4 H  s          
+    65      0.216952  5 H  s                 74     -0.216952  6 H  s          
+    48      0.203691  3 H  s                 57     -0.203691  4 H  s          
+    66      0.203691  5 H  s                 75     -0.203691  6 H  s          
+ 
+ Vector    6  Occ=2.000000D+00  E=-3.868537D-01  Symmetry=ag
+              MO Center=  3.4D-31,  1.1D-15, -5.9D-17, r^2= 1.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      0.417564  1 C  pz                30     -0.417564  2 C  pz         
+    47      0.173796  3 H  s                 56      0.173796  4 H  s          
+    65      0.173796  5 H  s                 74      0.173796  6 H  s          
+     3     -0.162394  1 C  s                 26     -0.162394  2 C  s          
+    48      0.147242  3 H  s                 57      0.147242  4 H  s          
+ 
+ Vector    7  Occ=2.000000D+00  E=-3.266230D-01  Symmetry=b3g
+              MO Center=  6.0D-32,  2.6D-16, -8.1D-15, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      0.439301  3 H  s                 57     -0.439301  4 H  s          
+    66     -0.439301  5 H  s                 75      0.439301  6 H  s          
+     6      0.304100  1 C  py                29     -0.304100  2 C  py         
+    47      0.271304  3 H  s                 56     -0.271304  4 H  s          
+    65     -0.271304  5 H  s                 74      0.271304  6 H  s          
+ 
+ Vector    8  Occ=2.000000D+00  E=-2.553887D-01  Symmetry=b3u
+              MO Center= -1.2D-15, -3.0D-16,  2.4D-15, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.408584  1 C  px                28      0.408584  2 C  px         
+     8      0.248639  1 C  px                31      0.248639  2 C  px         
+    11      0.026523  1 C  px                34      0.026523  2 C  px         
+ 
+ Vector    9  Occ=0.000000D+00  E=-3.158099D-02  Symmetry=b2g
+              MO Center= -1.6D-15, -6.7D-16, -1.8D-15, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.425681  1 C  px                28     -0.425681  2 C  px         
+     8      0.402173  1 C  px                31     -0.402173  2 C  px         
+    11      0.380478  1 C  px                34     -0.380478  2 C  px         
+    17     -0.035230  1 C  d  1              40     -0.035230  2 C  d  1       
+    22     -0.032163  1 C  d  1              45     -0.032163  2 C  d  1       
+ 
+ Vector   10  Occ=0.000000D+00  E= 1.757508D-02  Symmetry=ag
+              MO Center=  5.6D-16, -9.0D-17,  1.6D-15, r^2= 1.4D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      1.351959  1 C  s                 27      1.351959  2 C  s          
+    49     -0.754799  3 H  s                 58     -0.754799  4 H  s          
+    67     -0.754799  5 H  s                 76     -0.754799  6 H  s          
+     3      0.575269  1 C  s                 26      0.575269  2 C  s          
+    48     -0.453507  3 H  s                 57     -0.453507  4 H  s          
+ 
+ Vector   11  Occ=0.000000D+00  E= 3.623294D-02  Symmetry=b1u
+              MO Center=  1.5D-15, -3.2D-13, -1.2D-14, r^2= 1.9D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      1.720765  3 H  s                 58      1.720765  4 H  s          
+    67     -1.720765  5 H  s                 76     -1.720765  6 H  s          
+     4     -1.018908  1 C  s                 27      1.018908  2 C  s          
+     3     -0.890665  1 C  s                 26      0.890665  2 C  s          
+    13     -0.768694  1 C  pz                36     -0.768694  2 C  pz         
+ 
+ Vector   12  Occ=0.000000D+00  E= 3.862152D-02  Symmetry=b2u
+              MO Center=  1.9D-16,  8.2D-15,  2.0D-13, r^2= 1.8D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      2.142673  3 H  s                 58     -2.142673  4 H  s          
+    67      2.142673  5 H  s                 76     -2.142673  6 H  s          
+    12     -0.883099  1 C  py                35     -0.883099  2 C  py         
+    48      0.645535  3 H  s                 57     -0.645535  4 H  s          
+    66      0.645535  5 H  s                 75     -0.645535  6 H  s          
+ 
+ Vector   13  Occ=0.000000D+00  E= 6.703962D-02  Symmetry=b3g
+              MO Center= -6.2D-30,  3.3D-13, -1.8D-13, r^2= 2.7D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      6.378724  3 H  s                 58     -6.378724  4 H  s          
+    67     -6.378724  5 H  s                 76      6.378724  6 H  s          
+    12     -4.638580  1 C  py                35      4.638580  2 C  py         
+    48      1.290086  3 H  s                 57     -1.290086  4 H  s          
+    66     -1.290086  5 H  s                 75      1.290086  6 H  s          
+ 
+ Vector   14  Occ=0.000000D+00  E= 8.307545D-02  Symmetry=b3u
+              MO Center= -7.0D-15,  5.8D-16,  2.8D-16, r^2= 1.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      0.618527  1 C  px                34      0.618527  2 C  px         
+     5     -0.156249  1 C  px                28     -0.156249  2 C  px         
+     8     -0.129934  1 C  px                31     -0.129934  2 C  px         
+    53     -0.063376  3 H  px                62     -0.063376  4 H  px         
+    71     -0.063376  5 H  px                80     -0.063376  6 H  px         
+ 
+ Vector   15  Occ=0.000000D+00  E= 9.666557D-02  Symmetry=ag
+              MO Center=  2.1D-15, -5.3D-15, -1.1D-14, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      1.734782  1 C  pz                36     -1.734782  2 C  pz         
+     4      0.489183  1 C  s                 27      0.489183  2 C  s          
+    49     -0.104786  3 H  s                 58     -0.104786  4 H  s          
+    67     -0.104786  5 H  s                 76     -0.104786  6 H  s          
+    55     -0.101001  3 H  pz                64     -0.101001  4 H  pz         
+ 
+ Vector   16  Occ=0.000000D+00  E= 1.173148D-01  Symmetry=b1u
+              MO Center= -3.4D-16,  4.0D-13,  2.5D-13, r^2= 2.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     15.211243  1 C  s                 27    -15.211243  2 C  s          
+    13     -8.096150  1 C  pz                36     -8.096150  2 C  pz         
+    49      4.662503  3 H  s                 58      4.662503  4 H  s          
+    67     -4.662503  5 H  s                 76     -4.662503  6 H  s          
+    10     -1.130528  1 C  pz                33     -1.130528  2 C  pz         
+ 
+ Vector   17  Occ=0.000000D+00  E= 1.255768D-01  Symmetry=b2u
+              MO Center= -2.0D-16, -7.7D-13, -6.5D-14, r^2= 1.5D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      3.171118  3 H  s                 58     -3.171118  4 H  s          
+    67      3.171118  5 H  s                 76     -3.171118  6 H  s          
+    12     -2.137371  1 C  py                35     -2.137371  2 C  py         
+    48      1.050145  3 H  s                 57     -1.050145  4 H  s          
+    66      1.050145  5 H  s                 75     -1.050145  6 H  s          
+ 
+ Vector   18  Occ=0.000000D+00  E= 1.269288D-01  Symmetry=b2g
+              MO Center=  1.7D-15, -1.3D-15,  1.6D-15, r^2= 1.3D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      2.348870  1 C  px                34     -2.348870  2 C  px         
+     5     -0.203383  1 C  px                28      0.203383  2 C  px         
+     8     -0.145870  1 C  px                31      0.145870  2 C  px         
+    53     -0.138944  3 H  px                62     -0.138944  4 H  px         
+    71      0.138944  5 H  px                80      0.138944  6 H  px         
+ 
+ Vector   19  Occ=0.000000D+00  E= 1.286742D-01  Symmetry=ag
+              MO Center=  9.3D-17,  8.1D-13, -4.9D-13, r^2= 1.5D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      4.014930  1 C  s                 27      4.014930  2 C  s          
+    49     -1.331404  3 H  s                 58     -1.331404  4 H  s          
+    67     -1.331404  5 H  s                 76     -1.331404  6 H  s          
+    13      1.264861  1 C  pz                36     -1.264861  2 C  pz         
+    48     -1.081198  3 H  s                 57     -1.081198  4 H  s          
+ 
+ Vector   20  Occ=0.000000D+00  E= 1.458492D-01  Symmetry=ag
+              MO Center=  5.2D-15,  3.3D-14,  4.7D-13, r^2= 6.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      2.444754  1 C  s                 27      2.444754  2 C  s          
+    48     -1.686972  3 H  s                 57     -1.686972  4 H  s          
+    66     -1.686972  5 H  s                 75     -1.686972  6 H  s          
+     3      1.412969  1 C  s                 26      1.412969  2 C  s          
+    49     -0.478693  3 H  s                 58     -0.478693  4 H  s          
+ 
+ Vector   21  Occ=0.000000D+00  E= 1.709663D-01  Symmetry=b1u
+              MO Center=  1.6D-17,  1.7D-12,  9.8D-13, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     27.670701  1 C  s                 27    -27.670701  2 C  s          
+    13     -8.677985  1 C  pz                36     -8.677985  2 C  pz         
+    49      2.223453  3 H  s                 58      2.223453  4 H  s          
+    67     -2.223453  5 H  s                 76     -2.223453  6 H  s          
+    48     -1.831312  3 H  s                 57     -1.831312  4 H  s          
+ 
+ Vector   22  Occ=0.000000D+00  E= 1.823443D-01  Symmetry=b3g
+              MO Center= -4.3D-16, -1.9D-12,  3.3D-12, r^2= 1.6D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      7.981540  1 C  py                35     -7.981540  2 C  py         
+    49     -6.664718  3 H  s                 58      6.664718  4 H  s          
+    67      6.664718  5 H  s                 76     -6.664718  6 H  s          
+    48     -1.798689  3 H  s                 57      1.798689  4 H  s          
+    66      1.798689  5 H  s                 75     -1.798689  6 H  s          
+ 
+ Vector   23  Occ=0.000000D+00  E= 1.826138D-01  Symmetry=b2u
+              MO Center=  3.3D-16,  1.4D-13, -3.1D-12, r^2= 7.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49     -1.884291  3 H  s                 58      1.884291  4 H  s          
+    67     -1.884291  5 H  s                 76      1.884291  6 H  s          
+    12      1.805324  1 C  py                35      1.805324  2 C  py         
+    48     -1.755916  3 H  s                 57      1.755916  4 H  s          
+    66     -1.755916  5 H  s                 75      1.755916  6 H  s          
+ 
+ Vector   24  Occ=0.000000D+00  E= 2.330045D-01  Symmetry=b1g
+              MO Center= -7.7D-16, -1.1D-14,  5.2D-15, r^2= 4.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53      0.492423  3 H  px                62     -0.492423  4 H  px         
+    71      0.492423  5 H  px                80     -0.492423  6 H  px         
+    19      0.077142  1 C  d -2              42      0.077142  2 C  d -2       
+    14      0.048422  1 C  d -2              37      0.048422  2 C  d -2       
+ 
+ Vector   25  Occ=0.000000D+00  E= 2.374752D-01  Symmetry=b1u
+              MO Center= -1.1D-15,  1.0D-12, -9.2D-13, r^2= 9.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     28.502721  1 C  s                 27    -28.502721  2 C  s          
+    13     -6.829131  1 C  pz                36     -6.829131  2 C  pz         
+    10      4.503240  1 C  pz                33      4.503240  2 C  pz         
+    48     -4.432141  3 H  s                 57     -4.432141  4 H  s          
+    66      4.432141  5 H  s                 75      4.432141  6 H  s          
+ 
+ Vector   26  Occ=0.000000D+00  E= 3.046884D-01  Symmetry=b1u
+              MO Center= -4.5D-16, -3.9D-13, -1.1D-13, r^2= 8.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     10.921825  1 C  s                 27    -10.921825  2 C  s          
+    13     -5.618747  1 C  pz                36     -5.618747  2 C  pz         
+    10     -3.494442  1 C  pz                33     -3.494442  2 C  pz         
+    49      2.608927  3 H  s                 58      2.608927  4 H  s          
+    67     -2.608927  5 H  s                 76     -2.608927  6 H  s          
+ 
+ Vector   27  Occ=0.000000D+00  E= 3.152823D-01  Symmetry=ag
+              MO Center=  1.2D-16, -4.7D-15,  2.4D-13, r^2= 8.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      1.807416  1 C  pz                36     -1.807416  2 C  pz         
+     4      0.860280  1 C  s                 27      0.860280  2 C  s          
+    55     -0.805084  3 H  pz                64     -0.805084  4 H  pz         
+    73      0.805084  5 H  pz                82      0.805084  6 H  pz         
+    10      0.541037  1 C  pz                33     -0.541037  2 C  pz         
+ 
+ Vector   28  Occ=0.000000D+00  E= 3.391141D-01  Symmetry=au
+              MO Center=  6.0D-16,  1.0D-15, -4.0D-15, r^2= 6.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53      1.048879  3 H  px                62     -1.048879  4 H  px         
+    71     -1.048879  5 H  px                80      1.048879  6 H  px         
+    19     -0.569649  1 C  d -2              42      0.569649  2 C  d -2       
+    14      0.053103  1 C  d -2              37     -0.053103  2 C  d -2       
+    50      0.025623  3 H  px                59     -0.025623  4 H  px         
+ 
+ Vector   29  Occ=0.000000D+00  E= 3.563484D-01  Symmetry=b3u
+              MO Center=  5.7D-16,  2.3D-14, -6.4D-14, r^2= 6.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53      0.809948  3 H  px                62      0.809948  4 H  px         
+    71      0.809948  5 H  px                80      0.809948  6 H  px         
+     8     -0.557551  1 C  px                31     -0.557551  2 C  px         
+    11     -0.433232  1 C  px                34     -0.433232  2 C  px         
+     5     -0.159505  1 C  px                28     -0.159505  2 C  px         
+ 
+ Vector   30  Occ=0.000000D+00  E= 3.631491D-01  Symmetry=b3g
+              MO Center=  5.4D-28, -8.9D-13, -5.0D-14, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      9.060053  1 C  py                35     -9.060053  2 C  py         
+    49     -5.911195  3 H  s                 58      5.911195  4 H  s          
+    67      5.911195  5 H  s                 76     -5.911195  6 H  s          
+    48     -3.795551  3 H  s                 57      3.795551  4 H  s          
+    66      3.795551  5 H  s                 75     -3.795551  6 H  s          
+ 
+ Vector   31  Occ=0.000000D+00  E= 3.843413D-01  Symmetry=b2u
+              MO Center= -5.0D-18,  3.0D-14, -7.4D-14, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      3.242838  3 H  s                 57     -3.242838  4 H  s          
+    66      3.242838  5 H  s                 75     -3.242838  6 H  s          
+    49      2.491776  3 H  s                 58     -2.491776  4 H  s          
+    67      2.491776  5 H  s                 76     -2.491776  6 H  s          
+    12     -2.479131  1 C  py                35     -2.479131  2 C  py         
+ 
+ Vector   32  Occ=0.000000D+00  E= 4.387489D-01  Symmetry=ag
+              MO Center= -1.8D-15, -1.2D-13,  2.6D-12, r^2= 8.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      5.011710  1 C  s                 27      5.011710  2 C  s          
+    48     -4.252892  3 H  s                 57     -4.252892  4 H  s          
+    66     -4.252892  5 H  s                 75     -4.252892  6 H  s          
+     3      4.171486  1 C  s                 26      4.171486  2 C  s          
+    10      1.382847  1 C  pz                33     -1.382847  2 C  pz         
+ 
+ Vector   33  Occ=0.000000D+00  E= 4.455634D-01  Symmetry=b2g
+              MO Center= -3.5D-15,  4.6D-15,  3.5D-14, r^2= 7.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      1.574479  1 C  px                31     -1.574479  2 C  px         
+    11      1.544950  1 C  px                34     -1.544950  2 C  px         
+    53     -0.986127  3 H  px                62     -0.986127  4 H  px         
+    71      0.986127  5 H  px                80      0.986127  6 H  px         
+     5      0.341922  1 C  px                28     -0.341922  2 C  px         
+ 
+ Vector   34  Occ=0.000000D+00  E= 4.881042D-01  Symmetry=b3g
+              MO Center=  5.3D-28,  1.1D-14, -5.0D-14, r^2= 7.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      2.467521  1 C  py                32     -2.467521  2 C  py         
+    20     -2.336116  1 C  d -1              43     -2.336116  2 C  d -1       
+    48      1.477995  3 H  s                 57     -1.477995  4 H  s          
+    66     -1.477995  5 H  s                 75      1.477995  6 H  s          
+    54     -1.302635  3 H  py                63     -1.302635  4 H  py         
+ 
+ Vector   35  Occ=0.000000D+00  E= 4.888167D-01  Symmetry=b2u
+              MO Center=  5.8D-16,  7.8D-13,  3.5D-14, r^2= 7.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      5.378548  3 H  s                 57     -5.378548  4 H  s          
+    66      5.378548  5 H  s                 75     -5.378548  6 H  s          
+     9     -3.073086  1 C  py                32     -3.073086  2 C  py         
+    54     -1.644126  3 H  py                63     -1.644126  4 H  py         
+    72     -1.644126  5 H  py                81     -1.644126  6 H  py         
+ 
+ Vector   36  Occ=0.000000D+00  E= 4.979937D-01  Symmetry=b3u
+              MO Center=  1.5D-15,  4.1D-15, -1.2D-13, r^2= 4.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      1.163740  1 C  px                31      1.163740  2 C  px         
+    22     -1.114713  1 C  d  1              45      1.114713  2 C  d  1       
+    53     -0.817863  3 H  px                62     -0.817863  4 H  px         
+    71     -0.817863  5 H  px                80     -0.817863  6 H  px         
+    11      0.203783  1 C  px                34      0.203783  2 C  px         
+ 
+ Vector   37  Occ=0.000000D+00  E= 5.152537D-01  Symmetry=b1u
+              MO Center=  2.0D-15,  2.0D-14, -2.4D-12, r^2= 7.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     16.688948  1 C  s                 27    -16.688948  2 C  s          
+    10      7.489563  1 C  pz                33      7.489563  2 C  pz         
+    48     -7.263635  3 H  s                 57     -7.263635  4 H  s          
+    66      7.263635  5 H  s                 75      7.263635  6 H  s          
+    13     -1.897780  1 C  pz                36     -1.897780  2 C  pz         
+ 
+ Vector   38  Occ=0.000000D+00  E= 5.240234D-01  Symmetry=ag
+              MO Center= -1.1D-15, -7.2D-14, -1.0D-12, r^2= 5.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      4.895160  1 C  s                 26      4.895160  2 C  s          
+    48     -2.506455  3 H  s                 57     -2.506455  4 H  s          
+    66     -2.506455  5 H  s                 75     -2.506455  6 H  s          
+    21     -2.369671  1 C  d  0              44     -2.369671  2 C  d  0       
+    55      1.661500  3 H  pz                64      1.661500  4 H  pz         
+ 
+ Vector   39  Occ=0.000000D+00  E= 5.425144D-01  Symmetry=ag
+              MO Center= -2.5D-17, -2.2D-14, -2.6D-13, r^2= 7.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      5.317166  1 C  s                 26      5.317166  2 C  s          
+    48     -2.504508  3 H  s                 57     -2.504508  4 H  s          
+    66     -2.504508  5 H  s                 75     -2.504508  6 H  s          
+    54      1.678996  3 H  py                63     -1.678996  4 H  py         
+    72      1.678996  5 H  py                81     -1.678996  6 H  py         
+ 
+ Vector   40  Occ=0.000000D+00  E= 5.501595D-01  Symmetry=b2u
+              MO Center=  1.2D-16, -7.6D-13,  1.2D-14, r^2= 7.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      5.538300  3 H  s                 57     -5.538300  4 H  s          
+    66      5.538300  5 H  s                 75     -5.538300  6 H  s          
+     9     -3.263863  1 C  py                32     -3.263863  2 C  py         
+    54     -2.505172  3 H  py                63     -2.505172  4 H  py         
+    72     -2.505172  5 H  py                81     -2.505172  6 H  py         
+ 
+ Vector   41  Occ=0.000000D+00  E= 5.701576D-01  Symmetry=b1g
+              MO Center= -8.5D-17,  1.1D-14,  2.2D-14, r^2= 5.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53     -1.353729  3 H  px                62      1.353729  4 H  px         
+    71     -1.353729  5 H  px                80      1.353729  6 H  px         
+    19      1.310249  1 C  d -2              42      1.310249  2 C  d -2       
+    14      0.031427  1 C  d -2              37      0.031427  2 C  d -2       
+ 
+ Vector   42  Occ=0.000000D+00  E= 5.713740D-01  Symmetry=b1u
+              MO Center=  2.8D-16,  3.8D-14,  3.5D-13, r^2= 6.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     14.341219  1 C  s                 26    -14.341219  2 C  s          
+    10    -10.546170  1 C  pz                33    -10.546170  2 C  pz         
+    48      3.229550  3 H  s                 57      3.229550  4 H  s          
+    66     -3.229550  5 H  s                 75     -3.229550  6 H  s          
+    21      3.052184  1 C  d  0              44     -3.052184  2 C  d  0       
+ 
+ Vector   43  Occ=0.000000D+00  E= 6.104744D-01  Symmetry=b3g
+              MO Center= -6.5D-16,  2.1D-12,  1.8D-13, r^2= 7.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     12.077222  3 H  s                 57    -12.077222  4 H  s          
+    66    -12.077222  5 H  s                 75     12.077222  6 H  s          
+     9     -7.399778  1 C  py                32      7.399778  2 C  py         
+    54     -3.850129  3 H  py                63     -3.850129  4 H  py         
+    72      3.850129  5 H  py                81      3.850129  6 H  py         
+ 
+ Vector   44  Occ=0.000000D+00  E= 6.140619D-01  Symmetry=b1u
+              MO Center=  6.2D-17,  3.9D-13, -2.5D-13, r^2= 6.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     24.121630  1 C  s                 27    -24.121630  2 C  s          
+    13     -7.193418  1 C  pz                36     -7.193418  2 C  pz         
+    48     -2.409230  3 H  s                 57     -2.409230  4 H  s          
+    66      2.409230  5 H  s                 75      2.409230  6 H  s          
+     3      2.185208  1 C  s                 26     -2.185208  2 C  s          
+ 
+ Vector   45  Occ=0.000000D+00  E= 6.474839D-01  Symmetry=b2g
+              MO Center=  1.4D-15,  1.7D-13,  2.0D-13, r^2= 5.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      3.189584  1 C  d  1              45      3.189584  2 C  d  1       
+     8      2.078473  1 C  px                31     -2.078473  2 C  px         
+    53      1.203900  3 H  px                62      1.203900  4 H  px         
+    71     -1.203900  5 H  px                80     -1.203900  6 H  px         
+     5      0.152835  1 C  px                28     -0.152835  2 C  px         
+ 
+ Vector   46  Occ=0.000000D+00  E= 6.929235D-01  Symmetry=b3u
+              MO Center=  7.2D-16, -2.8D-14, -7.4D-14, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      1.646574  1 C  px                31      1.646574  2 C  px         
+    53     -0.681958  3 H  px                62     -0.681958  4 H  px         
+    71     -0.681958  5 H  px                80     -0.681958  6 H  px         
+     5     -0.674288  1 C  px                28     -0.674288  2 C  px         
+    22     -0.348956  1 C  d  1              45      0.348956  2 C  d  1       
+ 
+ Vector   47  Occ=0.000000D+00  E= 7.299733D-01  Symmetry=b1u
+              MO Center=  1.3D-16, -3.6D-12,  4.1D-13, r^2= 7.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10     17.651160  1 C  pz                33     17.651160  2 C  pz         
+    48    -10.768530  3 H  s                 57    -10.768530  4 H  s          
+    66     10.768530  5 H  s                 75     10.768530  6 H  s          
+     3     -9.652706  1 C  s                 26      9.652706  2 C  s          
+    21     -5.331484  1 C  d  0              44      5.331484  2 C  d  0       
+ 
+ Vector   48  Occ=0.000000D+00  E= 7.335733D-01  Symmetry=b3g
+              MO Center= -3.4D-16,  1.1D-12,  2.5D-13, r^2= 7.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     -6.755462  3 H  s                 57      6.755462  4 H  s          
+    66      6.755462  5 H  s                 75     -6.755462  6 H  s          
+    12      6.505566  1 C  py                35     -6.505566  2 C  py         
+    20      6.027937  1 C  d -1              43      6.027937  2 C  d -1       
+    49     -3.715914  3 H  s                 58      3.715914  4 H  s          
+ 
+ Vector   49  Occ=0.000000D+00  E= 7.539523D-01  Symmetry=au
+              MO Center=  1.7D-15, -2.3D-13, -2.2D-14, r^2= 5.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      3.267518  1 C  d -2              42     -3.267518  2 C  d -2       
+    53     -1.972217  3 H  px                62      1.972217  4 H  px         
+    71      1.972217  5 H  px                80     -1.972217  6 H  px         
+    50      0.049407  3 H  px                59     -0.049407  4 H  px         
+    68     -0.049407  5 H  px                77      0.049407  6 H  px         
+ 
+ Vector   50  Occ=0.000000D+00  E= 8.295461D-01  Symmetry=ag
+              MO Center=  2.8D-16, -7.9D-14,  4.0D-14, r^2= 5.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10      2.267468  1 C  pz                33     -2.267468  2 C  pz         
+    55     -1.105167  3 H  pz                64     -1.105167  4 H  pz         
+    73      1.105167  5 H  pz                82      1.105167  6 H  pz         
+    13      1.042145  1 C  pz                36     -1.042145  2 C  pz         
+     3      0.895515  1 C  s                 26      0.895515  2 C  s          
+ 
+ Vector   51  Occ=0.000000D+00  E= 9.104318D-01  Symmetry=b2g
+              MO Center= -6.3D-16,  5.5D-14,  2.8D-14, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      4.587755  1 C  px                31     -4.587755  2 C  px         
+    22      1.585048  1 C  d  1              45      1.585048  2 C  d  1       
+     5     -0.685801  1 C  px                28      0.685801  2 C  px         
+    53     -0.534963  3 H  px                62     -0.534963  4 H  px         
+    71      0.534963  5 H  px                80      0.534963  6 H  px         
+ 
+ Vector   52  Occ=0.000000D+00  E= 1.002306D+00  Symmetry=b2u
+              MO Center=  3.0D-17,  2.3D-13, -1.1D-12, r^2= 4.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      7.410872  3 H  s                 57     -7.410872  4 H  s          
+    66      7.410872  5 H  s                 75     -7.410872  6 H  s          
+     9     -5.625169  1 C  py                32     -5.625169  2 C  py         
+    55     -1.868205  3 H  pz                64      1.868205  4 H  pz         
+    73      1.868205  5 H  pz                82     -1.868205  6 H  pz         
+ 
+ Vector   53  Occ=0.000000D+00  E= 1.036030D+00  Symmetry=b1u
+              MO Center=  3.2D-16, -2.5D-13, -9.0D-14, r^2= 5.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10     12.839851  1 C  pz                33     12.839851  2 C  pz         
+    48     -7.022647  3 H  s                 57     -7.022647  4 H  s          
+    66      7.022647  5 H  s                 75      7.022647  6 H  s          
+    54      2.647445  3 H  py                63     -2.647445  4 H  py         
+    72     -2.647445  5 H  py                81      2.647445  6 H  py         
+ 
+ Vector   54  Occ=0.000000D+00  E= 1.114058D+00  Symmetry=b3g
+              MO Center= -1.6D-15,  2.0D-13,  8.4D-13, r^2= 5.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9     12.589317  1 C  py                32    -12.589317  2 C  py         
+    20     -7.462016  1 C  d -1              43     -7.462016  2 C  d -1       
+    55      2.389089  3 H  pz                64     -2.389089  4 H  pz         
+    73      2.389089  5 H  pz                82     -2.389089  6 H  pz         
+    12      1.352436  1 C  py                35     -1.352436  2 C  py         
+ 
+ Vector   55  Occ=0.000000D+00  E= 1.255457D+00  Symmetry=ag
+              MO Center= -2.0D-16, -6.4D-14,  3.3D-13, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      6.662852  1 C  s                 26      6.662852  2 C  s          
+    21     -3.242803  1 C  d  0              44     -3.242803  2 C  d  0       
+    48     -2.865652  3 H  s                 57     -2.865652  4 H  s          
+    66     -2.865652  5 H  s                 75     -2.865652  6 H  s          
+    10      2.527584  1 C  pz                33     -2.527584  2 C  pz         
+ 
+ Vector   56  Occ=0.000000D+00  E= 1.278048D+00  Symmetry=b2u
+              MO Center=  2.0D-15, -4.1D-14, -2.4D-13, r^2= 4.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      4.656645  3 H  s                 57     -4.656645  4 H  s          
+    66      4.656645  5 H  s                 75     -4.656645  6 H  s          
+     9     -4.156870  1 C  py                32     -4.156870  2 C  py         
+    20     -2.846620  1 C  d -1              43      2.846620  2 C  d -1       
+    54     -1.147351  3 H  py                63     -1.147351  4 H  py         
+ 
+ Vector   57  Occ=0.000000D+00  E= 1.279762D+00  Symmetry=b3u
+              MO Center=  8.8D-18, -5.8D-15, -1.1D-14, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      0.615157  1 C  d  1              40     -0.615157  2 C  d  1       
+    22     -0.599910  1 C  d  1              45      0.599910  2 C  d  1       
+     8      0.388763  1 C  px                31      0.388763  2 C  px         
+    50     -0.189508  3 H  px                59     -0.189508  4 H  px         
+    68     -0.189508  5 H  px                77     -0.189508  6 H  px         
+ 
+ Vector   58  Occ=0.000000D+00  E= 1.298631D+00  Symmetry=b1g
+              MO Center= -2.0D-15,  6.1D-15,  3.2D-16, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      0.681177  1 C  d -2              42      0.681177  2 C  d -2       
+    14     -0.562998  1 C  d -2              37     -0.562998  2 C  d -2       
+    53     -0.282188  3 H  px                62      0.282188  4 H  px         
+    71     -0.282188  5 H  px                80      0.282188  6 H  px         
+    50     -0.272435  3 H  px                59      0.272435  4 H  px         
+ 
+ Vector   59  Occ=0.000000D+00  E= 1.449240D+00  Symmetry=b1u
+              MO Center=  4.8D-16,  2.5D-13,  6.7D-15, r^2= 4.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10    -17.455180  1 C  pz                33    -17.455180  2 C  pz         
+     3     16.583563  1 C  s                 26    -16.583563  2 C  s          
+     4    -14.788453  1 C  s                 27     14.788453  2 C  s          
+    48      8.276046  3 H  s                 57      8.276046  4 H  s          
+    66     -8.276046  5 H  s                 75     -8.276046  6 H  s          
+ 
+ Vector   60  Occ=0.000000D+00  E= 1.498190D+00  Symmetry=ag
+              MO Center=  7.2D-17, -7.2D-14, -8.2D-13, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      6.298086  1 C  s                 26      6.298086  2 C  s          
+    48     -4.091172  3 H  s                 57     -4.091172  4 H  s          
+    66     -4.091172  5 H  s                 75     -4.091172  6 H  s          
+     4      3.087018  1 C  s                 27      3.087018  2 C  s          
+    10      1.709947  1 C  pz                33     -1.709947  2 C  pz         
+ 
+ Vector   61  Occ=0.000000D+00  E= 1.564885D+00  Symmetry=b3g
+              MO Center=  7.3D-16, -2.3D-13,  3.3D-14, r^2= 5.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     13.982483  3 H  s                 57    -13.982483  4 H  s          
+    66    -13.982483  5 H  s                 75     13.982483  6 H  s          
+    20     -6.710889  1 C  d -1              43     -6.710889  2 C  d -1       
+    12     -5.640149  1 C  py                35      5.640149  2 C  py         
+     9     -4.385682  1 C  py                32      4.385682  2 C  py         
+ 
+ Vector   62  Occ=0.000000D+00  E= 1.594410D+00  Symmetry=au
+              MO Center=  2.0D-16,  1.3D-14,  2.7D-15, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      2.579996  1 C  d -2              42     -2.579996  2 C  d -2       
+    53     -1.067428  3 H  px                62      1.067428  4 H  px         
+    71      1.067428  5 H  px                80     -1.067428  6 H  px         
+    14     -0.622461  1 C  d -2              37      0.622461  2 C  d -2       
+    50     -0.352049  3 H  px                59      0.352049  4 H  px         
+ 
+ Vector   63  Occ=0.000000D+00  E= 1.613964D+00  Symmetry=ag
+              MO Center=  1.6D-17,  9.8D-15,  1.9D-13, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      3.111539  1 C  s                 26      3.111539  2 C  s          
+    10      2.080893  1 C  pz                33     -2.080893  2 C  pz         
+    48     -1.325268  3 H  s                 57     -1.325268  4 H  s          
+    66     -1.325268  5 H  s                 75     -1.325268  6 H  s          
+    54      0.743756  3 H  py                63     -0.743756  4 H  py         
+ 
+ Vector   64  Occ=0.000000D+00  E= 1.635942D+00  Symmetry=b2g
+              MO Center=  6.8D-17, -8.0D-15,  2.0D-14, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      0.597561  1 C  px                34     -0.597561  2 C  px         
+    17     -0.482562  1 C  d  1              40     -0.482562  2 C  d  1       
+    50      0.471032  3 H  px                59      0.471032  4 H  px         
+    68     -0.471032  5 H  px                77     -0.471032  6 H  px         
+    22      0.324729  1 C  d  1              45      0.324729  2 C  d  1       
+ 
+ Vector   65  Occ=0.000000D+00  E= 1.719398D+00  Symmetry=b2u
+              MO Center=  9.5D-18, -2.4D-14,  1.3D-14, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      4.250927  3 H  s                 57     -4.250927  4 H  s          
+    66      4.250927  5 H  s                 75     -4.250927  6 H  s          
+     9     -3.426133  1 C  py                32     -3.426133  2 C  py         
+    54     -1.568344  3 H  py                63     -1.568344  4 H  py         
+    72     -1.568344  5 H  py                81     -1.568344  6 H  py         
+ 
+ Vector   66  Occ=0.000000D+00  E= 1.792848D+00  Symmetry=ag
+              MO Center= -3.7D-16,  1.6D-14,  1.7D-12, r^2= 3.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      8.527129  1 C  s                 26      8.527129  2 C  s          
+    48     -4.015541  3 H  s                 57     -4.015541  4 H  s          
+    66     -4.015541  5 H  s                 75     -4.015541  6 H  s          
+     4      2.084138  1 C  s                 27      2.084138  2 C  s          
+    10      2.060114  1 C  pz                33     -2.060114  2 C  pz         
+ 
+ Vector   67  Occ=0.000000D+00  E= 1.836355D+00  Symmetry=b1u
+              MO Center= -4.4D-16,  3.1D-13, -2.0D-12, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10    -20.168645  1 C  pz                33    -20.168645  2 C  pz         
+     3     18.963401  1 C  s                 26    -18.963401  2 C  s          
+    48      7.146087  3 H  s                 57      7.146087  4 H  s          
+    66     -7.146087  5 H  s                 75     -7.146087  6 H  s          
+    21      4.411406  1 C  d  0              44     -4.411406  2 C  d  0       
+ 
+ Vector   68  Occ=0.000000D+00  E= 1.845884D+00  Symmetry=b3u
+              MO Center=  4.1D-16,  2.3D-14, -1.9D-14, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    50      0.588270  3 H  px                59      0.588270  4 H  px         
+    68      0.588270  5 H  px                77      0.588270  6 H  px         
+    53     -0.422478  3 H  px                62     -0.422478  4 H  px         
+    71     -0.422478  5 H  px                80     -0.422478  6 H  px         
+    17      0.405705  1 C  d  1              40     -0.405705  2 C  d  1       
+ 
+ Vector   69  Occ=0.000000D+00  E= 1.896239D+00  Symmetry=b3g
+              MO Center= -1.7D-16,  5.9D-12, -4.4D-13, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9     10.821640  1 C  py                32    -10.821640  2 C  py         
+    20     -4.689396  1 C  d -1              43     -4.689396  2 C  d -1       
+    48     -3.276271  3 H  s                 57      3.276271  4 H  s          
+    66      3.276271  5 H  s                 75     -3.276271  6 H  s          
+    55      1.803197  3 H  pz                64     -1.803197  4 H  pz         
+ 
+ Vector   70  Occ=0.000000D+00  E= 1.897846D+00  Symmetry=b1u
+              MO Center= -2.1D-17, -6.1D-12,  4.6D-13, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     10.646927  1 C  s                 26    -10.646927  2 C  s          
+     4      9.278055  1 C  s                 27     -9.278055  2 C  s          
+    48     -4.032566  3 H  s                 57     -4.032566  4 H  s          
+    66      4.032566  5 H  s                 75      4.032566  6 H  s          
+    13     -1.842146  1 C  pz                36     -1.842146  2 C  pz         
+ 
+ Vector   71  Occ=0.000000D+00  E= 1.908342D+00  Symmetry=b2u
+              MO Center= -4.0D-17, -3.1D-16,  4.4D-13, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      4.807799  3 H  s                 57     -4.807799  4 H  s          
+    66      4.807799  5 H  s                 75     -4.807799  6 H  s          
+     9     -4.326308  1 C  py                32     -4.326308  2 C  py         
+    20     -1.479787  1 C  d -1              43      1.479787  2 C  d -1       
+    54     -1.311420  3 H  py                63     -1.311420  4 H  py         
+ 
+ Vector   72  Occ=0.000000D+00  E= 1.913276D+00  Symmetry=b1g
+              MO Center=  2.3D-18, -2.2D-14, -9.3D-15, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.709640  1 C  d -2              37      0.709640  2 C  d -2       
+    53      0.607642  3 H  px                62     -0.607642  4 H  px         
+    71      0.607642  5 H  px                80     -0.607642  6 H  px         
+    50     -0.570597  3 H  px                59      0.570597  4 H  px         
+    68     -0.570597  5 H  px                77      0.570597  6 H  px         
+ 
+ Vector   73  Occ=0.000000D+00  E= 2.135819D+00  Symmetry=b2g
+              MO Center= -3.0D-16,  1.0D-14,  9.9D-15, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.127359  1 C  d  1              40      1.127359  2 C  d  1       
+    22     -1.097364  1 C  d  1              45     -1.097364  2 C  d  1       
+    53     -0.541111  3 H  px                62     -0.541111  4 H  px         
+    71      0.541111  5 H  px                80      0.541111  6 H  px         
+     8     -0.493238  1 C  px                31      0.493238  2 C  px         
+ 
+ Vector   74  Occ=0.000000D+00  E= 2.199665D+00  Symmetry=au
+              MO Center=  9.9D-18, -1.0D-14,  6.2D-15, r^2= 2.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.855270  1 C  d -2              37     -0.855270  2 C  d -2       
+    50     -0.590716  3 H  px                59      0.590716  4 H  px         
+    68      0.590716  5 H  px                77     -0.590716  6 H  px         
+    53      0.385829  3 H  px                62     -0.385829  4 H  px         
+    71     -0.385829  5 H  px                80      0.385829  6 H  px         
+ 
+ Vector   75  Occ=0.000000D+00  E= 2.230352D+00  Symmetry=b1u
+              MO Center=  1.9D-16,  1.6D-13,  9.8D-14, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     19.643565  1 C  s                 26    -19.643565  2 C  s          
+    10    -12.889765  1 C  pz                33    -12.889765  2 C  pz         
+     4      7.052375  1 C  s                 27     -7.052375  2 C  s          
+    13     -1.988696  1 C  pz                36     -1.988696  2 C  pz         
+     2     -1.843193  1 C  s                 25      1.843193  2 C  s          
+ 
+ Vector   76  Occ=0.000000D+00  E= 2.355060D+00  Symmetry=ag
+              MO Center= -1.3D-18, -1.8D-14,  2.8D-14, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      1.140083  1 C  s                 26      1.140083  2 C  s          
+    21      0.700449  1 C  d  0              44      0.700449  2 C  d  0       
+     7      0.647310  1 C  pz                30     -0.647310  2 C  pz         
+    51      0.645199  3 H  py                60     -0.645199  4 H  py         
+    69      0.645199  5 H  py                78     -0.645199  6 H  py         
+ 
+ Vector   77  Occ=0.000000D+00  E= 2.434176D+00  Symmetry=b3g
+              MO Center= -5.5D-17, -2.4D-13,  1.8D-14, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      6.661052  1 C  py                32     -6.661052  2 C  py         
+    20     -6.180672  1 C  d -1              43     -6.180672  2 C  d -1       
+    48      2.947310  3 H  s                 57     -2.947310  4 H  s          
+    66     -2.947310  5 H  s                 75      2.947310  6 H  s          
+    54     -1.061797  3 H  py                63     -1.061797  4 H  py         
+ 
+ Vector   78  Occ=0.000000D+00  E= 2.533327D+00  Symmetry=b1u
+              MO Center=  1.1D-16, -1.0D-14, -6.3D-15, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     11.395700  1 C  s                 26    -11.395700  2 C  s          
+    10     -9.552272  1 C  pz                33     -9.552272  2 C  pz         
+    48      2.556337  3 H  s                 57      2.556337  4 H  s          
+    66     -2.556337  5 H  s                 75     -2.556337  6 H  s          
+    21      1.776824  1 C  d  0              44     -1.776824  2 C  d  0       
+ 
+ Vector   79  Occ=0.000000D+00  E= 2.546681D+00  Symmetry=ag
+              MO Center= -6.3D-18, -4.1D-16, -2.4D-14, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      1.241399  1 C  s                 25      1.241399  2 C  s          
+     3     -1.006236  1 C  s                 26     -1.006236  2 C  s          
+    52      0.663502  3 H  pz                61      0.663502  4 H  pz         
+    70     -0.663502  5 H  pz                79     -0.663502  6 H  pz         
+    18     -0.635910  1 C  d  2              41     -0.635910  2 C  d  2       
+ 
+ Vector   80  Occ=0.000000D+00  E= 2.595334D+00  Symmetry=b2u
+              MO Center=  4.2D-18,  4.6D-15, -3.1D-14, r^2= 2.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     -1.637545  3 H  s                 57      1.637545  4 H  s          
+    66     -1.637545  5 H  s                 75      1.637545  6 H  s          
+     9      1.494830  1 C  py                32      1.494830  2 C  py         
+     6      1.000746  1 C  py                29      1.000746  2 C  py         
+    15      0.901046  1 C  d -1              38     -0.901046  2 C  d -1       
+ 
+ Vector   81  Occ=0.000000D+00  E= 3.175878D+00  Symmetry=b1u
+              MO Center= -1.0D-17,  2.8D-14, -1.1D-13, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     23.778557  1 C  s                 26    -23.778557  2 C  s          
+    10    -14.412214  1 C  pz                33    -14.412214  2 C  pz         
+     4      4.127605  1 C  s                 27     -4.127605  2 C  s          
+    21      3.490459  1 C  d  0              44     -3.490459  2 C  d  0       
+    48      2.170255  3 H  s                 57      2.170255  4 H  s          
+ 
+ Vector   82  Occ=0.000000D+00  E= 3.188326D+00  Symmetry=b3g
+              MO Center=  4.0D-17,  1.2D-15,  1.1D-15, r^2= 2.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      2.803457  3 H  s                 57     -2.803457  4 H  s          
+    66     -2.803457  5 H  s                 75      2.803457  6 H  s          
+    15     -1.913221  1 C  d -1              38     -1.913221  2 C  d -1       
+     9     -1.754546  1 C  py                32      1.754546  2 C  py         
+    12     -1.427980  1 C  py                35      1.427980  2 C  py         
+ 
+
+ center of mass
+ --------------
+ x =   0.00000000 y =   0.00000000 z =   0.00000000
+
+ moments of inertia (a.u.)
+ ------------------
+          72.691697552106           0.000000000000           0.000000000000
+           0.000000000000          60.270006716700           0.000000000000
+           0.000000000000           0.000000000000          12.421690835407
+ 
+     Multipole analysis of the density
+     ---------------------------------
+ 
+     L   x y z        total         alpha         beta         nuclear
+     -   - - -        -----         -----         ----         -------
+     0   0 0 0     -0.000000     -8.000000     -8.000000     16.000000
+ 
+     1   1 0 0     -0.000000     -0.000000     -0.000000      0.000000
+     1   0 1 0      0.000000      0.000000      0.000000      0.000000
+     1   0 0 1     -0.000000     -0.000000     -0.000000      0.000000
+ 
+     2   2 0 0    -11.646481     -5.823241     -5.823241      0.000000
+     2   1 1 0     -0.000000     -0.000000     -0.000000      0.000000
+     2   1 0 1      0.000000      0.000000      0.000000      0.000000
+     2   0 2 0     -9.117409    -10.721328    -10.721328     12.325246
+     2   0 1 1     -0.000000     -0.000000     -0.000000      0.000000
+     2   0 0 2     -9.176407    -25.034412    -25.034412     40.892417
+ 
+
+ Parallel integral file used      22 records with       0 large values
+
+
+ Task  times  cpu:        1.6s     wall:        1.7s
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+ 
+                                 NWChem DFT Module
+                                 -----------------
+ 
+ 
+
+
+ Summary of "ao basis" -> "ao basis" (spherical)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                        aug-cc-pvdz                9       23   4s3p2d
+ H                        aug-cc-pvdz                5        9   3s2p
+
+
+      Symmetry analysis of basis
+      --------------------------
+ 
+        ag         18
+        au          4
+        b1g         4
+        b1u        18
+        b2g         7
+        b2u        12
+        b3g        12
+        b3u         7
+ 
+  Caching 1-el integrals 
+ 
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     6
+          No. of electrons :    16
+           Alpha electrons :     8
+            Beta electrons :     8
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  30
+          AO basis - number of functions:    82
+                     number of shells:    38
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+ 
+              XC Information
+              --------------
+                      regSCAN Method XC Functional
+               regSCAN metaGGA Exchange Functional  1.000          
+                     regSCAN Correlation Potential  1.000          
+ 
+             Grid Information
+             ----------------
+          Grid used for XC integration:  xfine     
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          C                   0.70      100          12.0      1454
+          H                   0.35      100          14.0      1202
+          Grid pruning is: on 
+          Number of quadrature shells:   200
+          Spatial weights used:  Erf1
+ 
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         30 iters            30 iters 
+
+ 
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+ Loading old vectors from job with title :
+
+
+
+ 
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+ 
+  Numbering of irreducible representations: 
+ 
+     1 ag          2 au          3 b1g         4 b1u         5 b2g     
+     6 b2u         7 b3g         8 b3u     
+ 
+  Orbital symmetries:
+ 
+     1 ag          2 b1u         3 ag          4 b1u         5 b2u     
+     6 ag          7 b3g         8 b3u         9 b2g        10 ag      
+    11 b1u        12 b2u        13 b3g        14 b3u        15 ag      
+    16 b1u        17 b2u        18 b2g     
+ 
+   Time after variat. SCF:      1.9
+   Time prior to 1st pass:      1.9
+
+ Integral file          = ./c2h4_pbe.aoints.0
+ Record size in doubles =  65536        No. of integs per rec  =  43688
+ Max. records in memory =     31        Max. records in file   =  99477
+ No. of bits per label  =      8        No. of bits per value  =     64
+
+
+ #quartets = 8.755D+04 #integrals = 9.248D+05 #direct =  0.0% #cached =100.0%
+
+
+ Grid_pts file          = ./c2h4_pbe.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =    106        Max. recs in file   =    530508
+
+
+           Memory utilization after 1st SCF pass: 
+           Heap Space remaining (MW):        9.76             9761696
+          Stack Space remaining (MW):       13.11            13106596
+
+   convergence    iter        energy       DeltaE   RMS-Dens  Diis-err    time
+ ---------------- ----- ----------------- --------- --------- ---------  ------
+ d= 0,ls=0.0,diis     1    -78.5641377467 -1.12D+02  2.40D-05  2.35D-07     3.1
+ d= 0,ls=0.0,diis     2    -78.5641377650 -1.83D-08  4.40D-06  2.81D-08     3.8
+
+
+         Total DFT energy =      -78.564137764975
+      One electron energy =     -170.052833665212
+           Coulomb energy =       70.479432219223
+    Exchange-Corr. energy =      -12.255829193939
+ Nuclear repulsion energy =       33.265092874952
+
+ Numeric. integr. density =       16.000000015593
+
+     Total iterative time =      1.9s
+
+
+ 
+                  Occupations of the irreducible representations
+                  ----------------------------------------------
+ 
+                     irrep           alpha         beta
+                     --------     --------     --------
+                     ag                3.0          3.0
+                     au                0.0          0.0
+                     b1g               0.0          0.0
+                     b1u               2.0          2.0
+                     b2g               0.0          0.0
+                     b2u               1.0          1.0
+                     b3g               1.0          1.0
+                     b3u               1.0          1.0
+ 
+ 
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+ 
+ Vector    1  Occ=2.000000D+00  E=-1.004936D+01  Symmetry=ag
+              MO Center= -5.6D-21, -1.2D-17, -3.1D-12, r^2= 4.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.713164  1 C  s                 24      0.713164  2 C  s          
+     3     -0.032690  1 C  s                 26     -0.032690  2 C  s          
+ 
+ Vector    2  Occ=2.000000D+00  E=-1.004869D+01  Symmetry=b1u
+              MO Center= -3.0D-18, -2.2D-17,  3.1D-12, r^2= 4.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.714094  1 C  s                 24     -0.714094  2 C  s          
+     3     -0.070474  1 C  s                 26      0.070474  2 C  s          
+     4     -0.035829  1 C  s                 27      0.035829  2 C  s          
+    10      0.025888  1 C  pz                33      0.025888  2 C  pz         
+ 
+ Vector    3  Occ=2.000000D+00  E=-7.297268D-01  Symmetry=ag
+              MO Center= -1.6D-17,  2.2D-16, -5.5D-16, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.301785  1 C  s                 25      0.301785  2 C  s          
+     3      0.159001  1 C  s                 26      0.159001  2 C  s          
+    47      0.113194  3 H  s                 56      0.113194  4 H  s          
+    65      0.113194  5 H  s                 74      0.113194  6 H  s          
+     7     -0.106811  1 C  pz                30      0.106811  2 C  pz         
+ 
+ Vector    4  Occ=2.000000D+00  E=-5.509514D-01  Symmetry=b1u
+              MO Center=  1.2D-30,  1.0D-17,  5.1D-16, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.439433  1 C  s                 26     -0.439433  2 C  s          
+     4     -0.333376  1 C  s                 27      0.333376  2 C  s          
+     2      0.247489  1 C  s                 10     -0.246962  1 C  pz         
+    25     -0.247489  2 C  s                 33     -0.246962  2 C  pz         
+    47      0.200816  3 H  s                 48      0.201052  3 H  s          
+ 
+ Vector    5  Occ=2.000000D+00  E=-4.395477D-01  Symmetry=b2u
+              MO Center= -1.0D-16,  4.2D-16, -3.7D-15, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      0.328179  1 C  py                29      0.328179  2 C  py         
+    47      0.216959  3 H  s                 56     -0.216959  4 H  s          
+    65      0.216959  5 H  s                 74     -0.216959  6 H  s          
+    48      0.203713  3 H  s                 57     -0.203713  4 H  s          
+    66      0.203713  5 H  s                 75     -0.203713  6 H  s          
+ 
+ Vector    6  Occ=2.000000D+00  E=-3.868399D-01  Symmetry=ag
+              MO Center= -1.3D-16, -8.4D-16,  1.2D-15, r^2= 1.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      0.417568  1 C  pz                30     -0.417568  2 C  pz         
+    47      0.173804  3 H  s                 56      0.173804  4 H  s          
+    65      0.173804  5 H  s                 74      0.173804  6 H  s          
+     3     -0.162410  1 C  s                 26     -0.162410  2 C  s          
+    48      0.147256  3 H  s                 57      0.147256  4 H  s          
+ 
+ Vector    7  Occ=2.000000D+00  E=-3.265942D-01  Symmetry=b3g
+              MO Center=  5.3D-31, -2.7D-16,  3.8D-15, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      0.439343  3 H  s                 57     -0.439343  4 H  s          
+    66     -0.439343  5 H  s                 75      0.439343  6 H  s          
+     6      0.304080  1 C  py                29     -0.304080  2 C  py         
+    47      0.271310  3 H  s                 56     -0.271310  4 H  s          
+    65     -0.271310  5 H  s                 74      0.271310  6 H  s          
+ 
+ Vector    8  Occ=2.000000D+00  E=-2.554043D-01  Symmetry=b3u
+              MO Center=  3.4D-17,  2.0D-18, -5.9D-17, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.408636  1 C  px                28      0.408636  2 C  px         
+     8      0.248585  1 C  px                31      0.248585  2 C  px         
+    11      0.026518  1 C  px                34      0.026518  2 C  px         
+ 
+ Vector    9  Occ=0.000000D+00  E=-3.160870D-02  Symmetry=b2g
+              MO Center= -2.6D-15, -5.5D-16,  1.2D-15, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.425759  1 C  px                28     -0.425759  2 C  px         
+     8      0.402084  1 C  px                31     -0.402084  2 C  px         
+    11      0.380403  1 C  px                34     -0.380403  2 C  px         
+    17     -0.035231  1 C  d  1              40     -0.035231  2 C  d  1       
+    22     -0.032161  1 C  d  1              45     -0.032161  2 C  d  1       
+ 
+ Vector   10  Occ=0.000000D+00  E= 1.755675D-02  Symmetry=ag
+              MO Center= -4.7D-30, -8.6D-16,  1.6D-15, r^2= 1.4D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      1.352350  1 C  s                 27      1.352350  2 C  s          
+    49     -0.754981  3 H  s                 58     -0.754981  4 H  s          
+    67     -0.754981  5 H  s                 76     -0.754981  6 H  s          
+     3      0.574933  1 C  s                 26      0.574933  2 C  s          
+    48     -0.453341  3 H  s                 57     -0.453341  4 H  s          
+ 
+ Vector   11  Occ=0.000000D+00  E= 3.621439D-02  Symmetry=b1u
+              MO Center=  6.6D-16, -3.3D-16,  2.9D-15, r^2= 1.9D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      1.721295  3 H  s                 58      1.721295  4 H  s          
+    67     -1.721295  5 H  s                 76     -1.721295  6 H  s          
+     4     -1.014878  1 C  s                 27      1.014878  2 C  s          
+     3     -0.890454  1 C  s                 26      0.890454  2 C  s          
+    13     -0.770040  1 C  pz                36     -0.770040  2 C  pz         
+ 
+ Vector   12  Occ=0.000000D+00  E= 3.860332D-02  Symmetry=b2u
+              MO Center=  3.1D-17, -6.3D-15,  7.2D-14, r^2= 1.8D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      2.142811  3 H  s                 58     -2.142811  4 H  s          
+    67      2.142811  5 H  s                 76     -2.142811  6 H  s          
+    12     -0.883097  1 C  py                35     -0.883097  2 C  py         
+    48      0.645175  3 H  s                 57     -0.645175  4 H  s          
+    66      0.645175  5 H  s                 75     -0.645175  6 H  s          
+ 
+ Vector   13  Occ=0.000000D+00  E= 6.701909D-02  Symmetry=b3g
+              MO Center= -3.9D-17,  2.9D-13, -1.6D-13, r^2= 2.7D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      6.376659  3 H  s                 58     -6.376659  4 H  s          
+    67     -6.376659  5 H  s                 76      6.376659  6 H  s          
+    12     -4.635789  1 C  py                35      4.635789  2 C  py         
+    48      1.288677  3 H  s                 57     -1.288677  4 H  s          
+    66     -1.288677  5 H  s                 75      1.288677  6 H  s          
+ 
+ Vector   14  Occ=0.000000D+00  E= 8.303672D-02  Symmetry=b3u
+              MO Center= -5.3D-15, -4.9D-16, -1.1D-14, r^2= 1.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      0.618570  1 C  px                34      0.618570  2 C  px         
+     5     -0.156221  1 C  px                28     -0.156221  2 C  px         
+     8     -0.129850  1 C  px                31     -0.129850  2 C  px         
+    53     -0.063465  3 H  px                62     -0.063465  4 H  px         
+    71     -0.063465  5 H  px                80     -0.063465  6 H  px         
+ 
+ Vector   15  Occ=0.000000D+00  E= 9.665151D-02  Symmetry=ag
+              MO Center=  2.3D-15, -9.4D-15, -1.3D-13, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      1.735087  1 C  pz                36     -1.735087  2 C  pz         
+     4      0.489537  1 C  s                 27      0.489537  2 C  s          
+    49     -0.104951  3 H  s                 58     -0.104951  4 H  s          
+    67     -0.104951  5 H  s                 76     -0.104951  6 H  s          
+    55     -0.101062  3 H  pz                64     -0.101062  4 H  pz         
+ 
+ Vector   16  Occ=0.000000D+00  E= 1.173090D-01  Symmetry=b1u
+              MO Center= -8.8D-16, -7.5D-14,  1.2D-11, r^2= 2.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     15.215522  1 C  s                 27    -15.215522  2 C  s          
+    13     -8.097164  1 C  pz                36     -8.097164  2 C  pz         
+    49      4.662504  3 H  s                 58      4.662504  4 H  s          
+    67     -4.662504  5 H  s                 76     -4.662504  6 H  s          
+    10     -1.130388  1 C  pz                33     -1.130388  2 C  pz         
+ 
+ Vector   17  Occ=0.000000D+00  E= 1.255842D-01  Symmetry=b2u
+              MO Center=  4.1D-28,  1.4D-14,  7.4D-14, r^2= 1.5D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      3.171083  3 H  s                 58     -3.171083  4 H  s          
+    67      3.171083  5 H  s                 76     -3.171083  6 H  s          
+    12     -2.137510  1 C  py                35     -2.137510  2 C  py         
+    48      1.050311  3 H  s                 57     -1.050311  4 H  s          
+    66      1.050311  5 H  s                 75     -1.050311  6 H  s          
+ 
+ Vector   18  Occ=0.000000D+00  E= 1.269024D-01  Symmetry=b2g
+              MO Center=  3.2D-15, -1.6D-16,  1.2D-14, r^2= 1.3D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      2.348899  1 C  px                34     -2.348899  2 C  px         
+     5     -0.203382  1 C  px                28      0.203382  2 C  px         
+     8     -0.145670  1 C  px                31      0.145670  2 C  px         
+    53     -0.138947  3 H  px                62     -0.138947  4 H  px         
+    71      0.138947  5 H  px                80      0.138947  6 H  px         
+ 
+ Vector   19  Occ=0.000000D+00  E= 1.286656D-01  Symmetry=ag
+              MO Center=  9.7D-16, -1.6D-14, -1.1D-11, r^2= 1.5D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      4.013960  1 C  s                 27      4.013960  2 C  s          
+    49     -1.331127  3 H  s                 58     -1.331127  4 H  s          
+    67     -1.331127  5 H  s                 76     -1.331127  6 H  s          
+    13      1.264612  1 C  pz                36     -1.264612  2 C  pz         
+    48     -1.080566  3 H  s                 57     -1.080566  4 H  s          
+ 
+ Vector   20  Occ=0.000000D+00  E= 1.458533D-01  Symmetry=ag
+              MO Center=  2.3D-15,  1.3D-14, -4.5D-13, r^2= 6.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      2.445883  1 C  s                 27      2.445883  2 C  s          
+    48     -1.687475  3 H  s                 57     -1.687475  4 H  s          
+    66     -1.687475  5 H  s                 75     -1.687475  6 H  s          
+     3      1.413417  1 C  s                 26      1.413417  2 C  s          
+    49     -0.479026  3 H  s                 58     -0.479026  4 H  s          
+ 
+ Vector   21  Occ=0.000000D+00  E= 1.709630D-01  Symmetry=b1u
+              MO Center=  1.9D-16, -1.9D-14, -2.7D-15, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     27.674433  1 C  s                 27    -27.674433  2 C  s          
+    13     -8.678491  1 C  pz                36     -8.678491  2 C  pz         
+    49      2.223252  3 H  s                 58      2.223252  4 H  s          
+    67     -2.223252  5 H  s                 76     -2.223252  6 H  s          
+    48     -1.832241  3 H  s                 57     -1.832241  4 H  s          
+ 
+ Vector   22  Occ=0.000000D+00  E= 1.823396D-01  Symmetry=b3g
+              MO Center=  1.8D-29, -2.3D-13,  1.1D-14, r^2= 1.6D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      7.984462  1 C  py                35     -7.984462  2 C  py         
+    49     -6.667173  3 H  s                 58      6.667173  4 H  s          
+    67      6.667173  5 H  s                 76     -6.667173  6 H  s          
+    48     -1.800243  3 H  s                 57      1.800243  4 H  s          
+    66      1.800243  5 H  s                 75     -1.800243  6 H  s          
+ 
+ Vector   23  Occ=0.000000D+00  E= 1.826133D-01  Symmetry=b2u
+              MO Center=  1.6D-15,  1.1D-13,  7.7D-14, r^2= 7.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49     -1.884198  3 H  s                 58      1.884198  4 H  s          
+    67     -1.884198  5 H  s                 76      1.884198  6 H  s          
+    12      1.805281  1 C  py                35      1.805281  2 C  py         
+    48     -1.756197  3 H  s                 57      1.756197  4 H  s          
+    66     -1.756197  5 H  s                 75      1.756197  6 H  s          
+ 
+ Vector   24  Occ=0.000000D+00  E= 2.330155D-01  Symmetry=b1g
+              MO Center= -1.9D-15, -1.0D-14,  7.2D-15, r^2= 4.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53      0.492468  3 H  px                62     -0.492468  4 H  px         
+    71      0.492468  5 H  px                80     -0.492468  6 H  px         
+    19      0.077099  1 C  d -2              42      0.077099  2 C  d -2       
+    14      0.048421  1 C  d -2              37      0.048421  2 C  d -2       
+ 
+ Vector   25  Occ=0.000000D+00  E= 2.374526D-01  Symmetry=b1u
+              MO Center= -2.3D-16, -4.1D-15, -1.6D-13, r^2= 9.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     28.497939  1 C  s                 27    -28.497939  2 C  s          
+    13     -6.826823  1 C  pz                36     -6.826823  2 C  pz         
+    10      4.504317  1 C  pz                33      4.504317  2 C  pz         
+    48     -4.432838  3 H  s                 57     -4.432838  4 H  s          
+    66      4.432838  5 H  s                 75      4.432838  6 H  s          
+ 
+ Vector   26  Occ=0.000000D+00  E= 3.046885D-01  Symmetry=b1u
+              MO Center= -2.4D-16, -5.4D-14,  2.3D-14, r^2= 8.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     10.923914  1 C  s                 27    -10.923914  2 C  s          
+    13     -5.619256  1 C  pz                36     -5.619256  2 C  pz         
+    10     -3.493690  1 C  pz                33     -3.493690  2 C  pz         
+    49      2.609057  3 H  s                 58      2.609057  4 H  s          
+    67     -2.609057  5 H  s                 76     -2.609057  6 H  s          
+ 
+ Vector   27  Occ=0.000000D+00  E= 3.152747D-01  Symmetry=ag
+              MO Center=  9.5D-17, -5.9D-14,  5.7D-14, r^2= 8.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      1.807199  1 C  pz                36     -1.807199  2 C  pz         
+     4      0.859594  1 C  s                 27      0.859594  2 C  s          
+    55     -0.805159  3 H  pz                64     -0.805159  4 H  pz         
+    73      0.805159  5 H  pz                82      0.805159  6 H  pz         
+    10      0.540831  1 C  pz                33     -0.540831  2 C  pz         
+ 
+ Vector   28  Occ=0.000000D+00  E= 3.391155D-01  Symmetry=au
+              MO Center= -4.1D-17, -7.8D-16, -7.1D-15, r^2= 6.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53      1.048940  3 H  px                62     -1.048940  4 H  px         
+    71     -1.048940  5 H  px                80      1.048940  6 H  px         
+    19     -0.569754  1 C  d -2              42      0.569754  2 C  d -2       
+    14      0.053103  1 C  d -2              37     -0.053103  2 C  d -2       
+    50      0.025622  3 H  px                59     -0.025622  4 H  px         
+ 
+ Vector   29  Occ=0.000000D+00  E= 3.563365D-01  Symmetry=b3u
+              MO Center=  6.1D-16,  2.1D-14, -3.8D-14, r^2= 6.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53      0.810019  3 H  px                62      0.810019  4 H  px         
+    71      0.810019  5 H  px                80      0.810019  6 H  px         
+     8     -0.557627  1 C  px                31     -0.557627  2 C  px         
+    11     -0.433214  1 C  px                34     -0.433214  2 C  px         
+     5     -0.159576  1 C  px                28     -0.159576  2 C  px         
+ 
+ Vector   30  Occ=0.000000D+00  E= 3.631079D-01  Symmetry=b3g
+              MO Center= -6.7D-29,  9.2D-14, -6.4D-14, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      9.059990  1 C  py                35     -9.059990  2 C  py         
+    49     -5.911258  3 H  s                 58      5.911258  4 H  s          
+    67      5.911258  5 H  s                 76     -5.911258  6 H  s          
+    48     -3.797058  3 H  s                 57      3.797058  4 H  s          
+    66      3.797058  5 H  s                 75     -3.797058  6 H  s          
+ 
+ Vector   31  Occ=0.000000D+00  E= 3.843360D-01  Symmetry=b2u
+              MO Center= -6.8D-17, -6.3D-14, -1.2D-13, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      3.242778  3 H  s                 57     -3.242778  4 H  s          
+    66      3.242778  5 H  s                 75     -3.242778  6 H  s          
+    49      2.491756  3 H  s                 58     -2.491756  4 H  s          
+    67      2.491756  5 H  s                 76     -2.491756  6 H  s          
+    12     -2.479075  1 C  py                35     -2.479075  2 C  py         
+ 
+ Vector   32  Occ=0.000000D+00  E= 4.387320D-01  Symmetry=ag
+              MO Center= -2.0D-15,  2.5D-14, -2.8D-13, r^2= 8.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      5.011947  1 C  s                 27      5.011947  2 C  s          
+    48     -4.253223  3 H  s                 57     -4.253223  4 H  s          
+    66     -4.253223  5 H  s                 75     -4.253223  6 H  s          
+     3      4.172112  1 C  s                 26      4.172112  2 C  s          
+    10      1.382976  1 C  pz                33     -1.382976  2 C  pz         
+ 
+ Vector   33  Occ=0.000000D+00  E= 4.455415D-01  Symmetry=b2g
+              MO Center=  9.9D-16,  4.2D-15,  1.1D-14, r^2= 7.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      1.574264  1 C  px                31     -1.574264  2 C  px         
+    11      1.544921  1 C  px                34     -1.544921  2 C  px         
+    53     -0.986056  3 H  px                62     -0.986056  4 H  px         
+    71      0.986056  5 H  px                80      0.986056  6 H  px         
+     5      0.341938  1 C  px                28     -0.341938  2 C  px         
+ 
+ Vector   34  Occ=0.000000D+00  E= 4.880936D-01  Symmetry=b3g
+              MO Center= -7.5D-28, -3.9D-15,  1.5D-13, r^2= 7.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      2.468208  1 C  py                32     -2.468208  2 C  py         
+    20     -2.336658  1 C  d -1              43     -2.336658  2 C  d -1       
+    48      1.478133  3 H  s                 57     -1.478133  4 H  s          
+    66     -1.478133  5 H  s                 75      1.478133  6 H  s          
+    54     -1.302659  3 H  py                63     -1.302659  4 H  py         
+ 
+ Vector   35  Occ=0.000000D+00  E= 4.888153D-01  Symmetry=b2u
+              MO Center=  7.9D-16,  7.0D-13, -1.7D-13, r^2= 7.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      5.379090  3 H  s                 57     -5.379090  4 H  s          
+    66      5.379090  5 H  s                 75     -5.379090  6 H  s          
+     9     -3.073458  1 C  py                32     -3.073458  2 C  py         
+    54     -1.644366  3 H  py                63     -1.644366  4 H  py         
+    72     -1.644366  5 H  py                81     -1.644366  6 H  py         
+ 
+ Vector   36  Occ=0.000000D+00  E= 4.979942D-01  Symmetry=b3u
+              MO Center=  1.7D-15,  4.2D-15, -1.1D-13, r^2= 4.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      1.163504  1 C  px                31      1.163504  2 C  px         
+    22     -1.114682  1 C  d  1              45      1.114682  2 C  d  1       
+    53     -0.817685  3 H  px                62     -0.817685  4 H  px         
+    71     -0.817685  5 H  px                80     -0.817685  6 H  px         
+    11      0.203718  1 C  px                34      0.203718  2 C  px         
+ 
+ Vector   37  Occ=0.000000D+00  E= 5.152550D-01  Symmetry=b1u
+              MO Center= -3.4D-15,  5.6D-13, -1.0D-12, r^2= 7.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     16.685853  1 C  s                 27    -16.685853  2 C  s          
+    10      7.490872  1 C  pz                33      7.490872  2 C  pz         
+    48     -7.263924  3 H  s                 57     -7.263924  4 H  s          
+    66      7.263924  5 H  s                 75      7.263924  6 H  s          
+    13     -1.896806  1 C  pz                36     -1.896806  2 C  pz         
+ 
+ Vector   38  Occ=0.000000D+00  E= 5.240209D-01  Symmetry=ag
+              MO Center= -1.4D-15,  2.8D-16, -6.1D-13, r^2= 5.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      4.894225  1 C  s                 26      4.894225  2 C  s          
+    48     -2.505792  3 H  s                 57     -2.505792  4 H  s          
+    66     -2.505792  5 H  s                 75     -2.505792  6 H  s          
+    21     -2.369742  1 C  d  0              44     -2.369742  2 C  d  0       
+    55      1.661427  3 H  pz                64      1.661427  4 H  pz         
+ 
+ Vector   39  Occ=0.000000D+00  E= 5.425171D-01  Symmetry=ag
+              MO Center= -7.0D-17,  5.6D-14,  4.2D-13, r^2= 7.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      5.317816  1 C  s                 26      5.317816  2 C  s          
+    48     -2.504900  3 H  s                 57     -2.504900  4 H  s          
+    66     -2.504900  5 H  s                 75     -2.504900  6 H  s          
+    54      1.678980  3 H  py                63     -1.678980  4 H  py         
+    72      1.678980  5 H  py                81     -1.678980  6 H  py         
+ 
+ Vector   40  Occ=0.000000D+00  E= 5.501649D-01  Symmetry=b2u
+              MO Center= -6.6D-15, -8.4D-13,  6.7D-13, r^2= 7.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      5.538147  3 H  s                 57     -5.538147  4 H  s          
+    66      5.538147  5 H  s                 75     -5.538147  6 H  s          
+     9     -3.263810  1 C  py                32     -3.263810  2 C  py         
+    54     -2.505085  3 H  py                63     -2.505085  4 H  py         
+    72     -2.505085  5 H  py                81     -2.505085  6 H  py         
+ 
+ Vector   41  Occ=0.000000D+00  E= 5.701623D-01  Symmetry=b1g
+              MO Center=  5.8D-15,  8.9D-15,  1.5D-15, r^2= 5.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    53     -1.353719  3 H  px                62      1.353719  4 H  px         
+    71     -1.353719  5 H  px                80      1.353719  6 H  px         
+    19      1.310259  1 C  d -2              42      1.310259  2 C  d -2       
+    14      0.031420  1 C  d -2              37      0.031420  2 C  d -2       
+ 
+ Vector   42  Occ=0.000000D+00  E= 5.713650D-01  Symmetry=b1u
+              MO Center=  1.8D-15, -3.3D-12,  8.5D-13, r^2= 6.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     14.341945  1 C  s                 26    -14.341945  2 C  s          
+    10    -10.545632  1 C  pz                33    -10.545632  2 C  pz         
+    48      3.228041  3 H  s                 57      3.228041  4 H  s          
+    66     -3.228041  5 H  s                 75     -3.228041  6 H  s          
+    21      3.051976  1 C  d  0              44     -3.051976  2 C  d  0       
+ 
+ Vector   43  Occ=0.000000D+00  E= 6.104609D-01  Symmetry=b3g
+              MO Center= -5.5D-16,  5.5D-12, -6.7D-13, r^2= 7.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     12.077856  3 H  s                 57    -12.077856  4 H  s          
+    66    -12.077856  5 H  s                 75     12.077856  6 H  s          
+     9     -7.400124  1 C  py                32      7.400124  2 C  py         
+    54     -3.850269  3 H  py                63     -3.850269  4 H  py         
+    72      3.850269  5 H  py                81      3.850269  6 H  py         
+ 
+ Vector   44  Occ=0.000000D+00  E= 6.140536D-01  Symmetry=b1u
+              MO Center= -1.1D-16, -3.1D-13, -1.9D-13, r^2= 6.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4     24.122625  1 C  s                 27    -24.122625  2 C  s          
+    13     -7.193459  1 C  pz                36     -7.193459  2 C  pz         
+    48     -2.411007  3 H  s                 57     -2.411007  4 H  s          
+    66      2.411007  5 H  s                 75      2.411007  6 H  s          
+     3      2.181138  1 C  s                 26     -2.181138  2 C  s          
+ 
+ Vector   45  Occ=0.000000D+00  E= 6.474857D-01  Symmetry=b2g
+              MO Center=  7.4D-17, -4.4D-16,  1.2D-13, r^2= 5.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      3.189470  1 C  d  1              45      3.189470  2 C  d  1       
+     8      2.078102  1 C  px                31     -2.078102  2 C  px         
+    53      1.203973  3 H  px                62      1.203973  4 H  px         
+    71     -1.203973  5 H  px                80     -1.203973  6 H  px         
+     5      0.152862  1 C  px                28     -0.152862  2 C  px         
+ 
+ Vector   46  Occ=0.000000D+00  E= 6.928828D-01  Symmetry=b3u
+              MO Center=  7.2D-16, -2.6D-14, -2.1D-14, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      1.646749  1 C  px                31      1.646749  2 C  px         
+    53     -0.682089  3 H  px                62     -0.682089  4 H  px         
+    71     -0.682089  5 H  px                80     -0.682089  6 H  px         
+     5     -0.674255  1 C  px                28     -0.674255  2 C  px         
+    22     -0.349088  1 C  d  1              45      0.349088  2 C  d  1       
+ 
+ Vector   47  Occ=0.000000D+00  E= 7.299630D-01  Symmetry=b1u
+              MO Center=  1.1D-15, -3.4D-12,  5.9D-13, r^2= 7.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10     17.650579  1 C  pz                33     17.650579  2 C  pz         
+    48    -10.767944  3 H  s                 57    -10.767944  4 H  s          
+    66     10.767944  5 H  s                 75     10.767944  6 H  s          
+     3     -9.652441  1 C  s                 26      9.652441  2 C  s          
+    21     -5.331318  1 C  d  0              44      5.331318  2 C  d  0       
+ 
+ Vector   48  Occ=0.000000D+00  E= 7.335674D-01  Symmetry=b3g
+              MO Center= -2.4D-27,  4.5D-13,  4.3D-13, r^2= 7.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     -6.754147  3 H  s                 57      6.754147  4 H  s          
+    66      6.754147  5 H  s                 75     -6.754147  6 H  s          
+    12      6.504435  1 C  py                35     -6.504435  2 C  py         
+    20      6.027742  1 C  d -1              43      6.027742  2 C  d -1       
+    49     -3.715198  3 H  s                 58      3.715198  4 H  s          
+ 
+ Vector   49  Occ=0.000000D+00  E= 7.539542D-01  Symmetry=au
+              MO Center=  1.2D-15, -6.8D-14, -1.2D-15, r^2= 5.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      3.267525  1 C  d -2              42     -3.267525  2 C  d -2       
+    53     -1.972198  3 H  px                62      1.972198  4 H  px         
+    71      1.972198  5 H  px                80     -1.972198  6 H  px         
+    50      0.049409  3 H  px                59     -0.049409  4 H  px         
+    68     -0.049409  5 H  px                77      0.049409  6 H  px         
+ 
+ Vector   50  Occ=0.000000D+00  E= 8.295353D-01  Symmetry=ag
+              MO Center=  3.4D-16, -7.8D-14,  1.2D-13, r^2= 5.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10      2.267467  1 C  pz                33     -2.267467  2 C  pz         
+    55     -1.105120  3 H  pz                64     -1.105120  4 H  pz         
+    73      1.105120  5 H  pz                82      1.105120  6 H  pz         
+    13      1.042119  1 C  pz                36     -1.042119  2 C  pz         
+     3      0.895491  1 C  s                 26      0.895491  2 C  s          
+ 
+ Vector   51  Occ=0.000000D+00  E= 9.103955D-01  Symmetry=b2g
+              MO Center= -7.9D-16,  5.9D-14,  2.5D-14, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      4.588020  1 C  px                31     -4.588020  2 C  px         
+    22      1.585289  1 C  d  1              45      1.585289  2 C  d  1       
+     5     -0.685751  1 C  px                28      0.685751  2 C  px         
+    53     -0.534940  3 H  px                62     -0.534940  4 H  px         
+    71      0.534940  5 H  px                80      0.534940  6 H  px         
+ 
+ Vector   52  Occ=0.000000D+00  E= 1.002306D+00  Symmetry=b2u
+              MO Center=  3.2D-16,  1.4D-13, -8.7D-14, r^2= 4.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      7.410588  3 H  s                 57     -7.410588  4 H  s          
+    66      7.410588  5 H  s                 75     -7.410588  6 H  s          
+     9     -5.624983  1 C  py                32     -5.624983  2 C  py         
+    55     -1.868175  3 H  pz                64      1.868175  4 H  pz         
+    73      1.868175  5 H  pz                82     -1.868175  6 H  pz         
+ 
+ Vector   53  Occ=0.000000D+00  E= 1.036009D+00  Symmetry=b1u
+              MO Center=  1.1D-16, -7.3D-14, -3.2D-13, r^2= 5.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10     12.840416  1 C  pz                33     12.840416  2 C  pz         
+    48     -7.022655  3 H  s                 57     -7.022655  4 H  s          
+    66      7.022655  5 H  s                 75      7.022655  6 H  s          
+    54      2.647445  3 H  py                63     -2.647445  4 H  py         
+    72     -2.647445  5 H  py                81      2.647445  6 H  py         
+ 
+ Vector   54  Occ=0.000000D+00  E= 1.114036D+00  Symmetry=b3g
+              MO Center= -1.5D-15,  1.7D-13, -3.7D-14, r^2= 5.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9     12.589195  1 C  py                32    -12.589195  2 C  py         
+    20     -7.462239  1 C  d -1              43     -7.462239  2 C  d -1       
+    55      2.388995  3 H  pz                64     -2.388995  4 H  pz         
+    73      2.388995  5 H  pz                82     -2.388995  6 H  pz         
+    12      1.351874  1 C  py                35     -1.351874  2 C  py         
+ 
+ Vector   55  Occ=0.000000D+00  E= 1.255451D+00  Symmetry=ag
+              MO Center=  2.8D-16, -1.5D-12, -2.8D-13, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      6.662917  1 C  s                 26      6.662917  2 C  s          
+    21     -3.242781  1 C  d  0              44     -3.242781  2 C  d  0       
+    48     -2.865679  3 H  s                 57     -2.865679  4 H  s          
+    66     -2.865679  5 H  s                 75     -2.865679  6 H  s          
+    10      2.527617  1 C  pz                33     -2.527617  2 C  pz         
+ 
+ Vector   56  Occ=0.000000D+00  E= 1.278048D+00  Symmetry=b2u
+              MO Center= -6.3D-17,  1.3D-12, -8.0D-14, r^2= 4.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      4.656927  3 H  s                 57     -4.656927  4 H  s          
+    66      4.656927  5 H  s                 75     -4.656927  6 H  s          
+     9     -4.157115  1 C  py                32     -4.157115  2 C  py         
+    20     -2.846630  1 C  d -1              43      2.846630  2 C  d -1       
+    54     -1.147422  3 H  py                63     -1.147422  4 H  py         
+ 
+ Vector   57  Occ=0.000000D+00  E= 1.279786D+00  Symmetry=b3u
+              MO Center= -4.4D-16,  6.2D-16, -1.3D-14, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      0.615161  1 C  d  1              40     -0.615161  2 C  d  1       
+    22     -0.599898  1 C  d  1              45      0.599898  2 C  d  1       
+     8      0.388712  1 C  px                31      0.388712  2 C  px         
+    50     -0.189506  3 H  px                59     -0.189506  4 H  px         
+    68     -0.189506  5 H  px                77     -0.189506  6 H  px         
+ 
+ Vector   58  Occ=0.000000D+00  E= 1.298651D+00  Symmetry=b1g
+              MO Center=  1.1D-16, -7.8D-16, -2.0D-15, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      0.681166  1 C  d -2              42      0.681166  2 C  d -2       
+    14     -0.562992  1 C  d -2              37     -0.562992  2 C  d -2       
+    53     -0.282176  3 H  px                62      0.282176  4 H  px         
+    71     -0.282176  5 H  px                80      0.282176  6 H  px         
+    50     -0.272439  3 H  px                59      0.272439  4 H  px         
+ 
+ Vector   59  Occ=0.000000D+00  E= 1.449252D+00  Symmetry=b1u
+              MO Center=  1.9D-16,  2.4D-13,  5.6D-13, r^2= 4.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10    -17.455706  1 C  pz                33    -17.455706  2 C  pz         
+     3     16.584232  1 C  s                 26    -16.584232  2 C  s          
+     4    -14.788221  1 C  s                 27     14.788221  2 C  s          
+    48      8.276163  3 H  s                 57      8.276163  4 H  s          
+    66     -8.276163  5 H  s                 75     -8.276163  6 H  s          
+ 
+ Vector   60  Occ=0.000000D+00  E= 1.498205D+00  Symmetry=ag
+              MO Center=  2.3D-17,  9.8D-14, -2.1D-13, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      6.298001  1 C  s                 26      6.298001  2 C  s          
+    48     -4.091078  3 H  s                 57     -4.091078  4 H  s          
+    66     -4.091078  5 H  s                 75     -4.091078  6 H  s          
+     4      3.086987  1 C  s                 27      3.086987  2 C  s          
+    10      1.709975  1 C  pz                33     -1.709975  2 C  pz         
+ 
+ Vector   61  Occ=0.000000D+00  E= 1.564883D+00  Symmetry=b3g
+              MO Center=  8.0D-16, -3.6D-14, -6.5D-14, r^2= 5.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     13.982214  3 H  s                 57    -13.982214  4 H  s          
+    66    -13.982214  5 H  s                 75     13.982214  6 H  s          
+    20     -6.710716  1 C  d -1              43     -6.710716  2 C  d -1       
+    12     -5.639915  1 C  py                35      5.639915  2 C  py         
+     9     -4.385745  1 C  py                32      4.385745  2 C  py         
+ 
+ Vector   62  Occ=0.000000D+00  E= 1.594426D+00  Symmetry=au
+              MO Center= -1.8D-17,  1.3D-14,  7.5D-15, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      2.579965  1 C  d -2              42     -2.579965  2 C  d -2       
+    53     -1.067406  3 H  px                62      1.067406  4 H  px         
+    71      1.067406  5 H  px                80     -1.067406  6 H  px         
+    14     -0.622457  1 C  d -2              37      0.622457  2 C  d -2       
+    50     -0.352052  3 H  px                59      0.352052  4 H  px         
+ 
+ Vector   63  Occ=0.000000D+00  E= 1.613983D+00  Symmetry=ag
+              MO Center=  1.6D-17,  2.7D-14, -2.9D-14, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      3.111192  1 C  s                 26      3.111192  2 C  s          
+    10      2.080774  1 C  pz                33     -2.080774  2 C  pz         
+    48     -1.325106  3 H  s                 57     -1.325106  4 H  s          
+    66     -1.325106  5 H  s                 75     -1.325106  6 H  s          
+    54      0.743719  3 H  py                63     -0.743719  4 H  py         
+ 
+ Vector   64  Occ=0.000000D+00  E= 1.635951D+00  Symmetry=b2g
+              MO Center=  3.0D-16, -7.4D-15,  1.5D-14, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      0.597551  1 C  px                34     -0.597551  2 C  px         
+    17     -0.482547  1 C  d  1              40     -0.482547  2 C  d  1       
+    50      0.471040  3 H  px                59      0.471040  4 H  px         
+    68     -0.471040  5 H  px                77     -0.471040  6 H  px         
+    22      0.324665  1 C  d  1              45      0.324665  2 C  d  1       
+ 
+ Vector   65  Occ=0.000000D+00  E= 1.719409D+00  Symmetry=b2u
+              MO Center= -7.9D-18,  9.3D-14, -3.0D-13, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      4.250754  3 H  s                 57     -4.250754  4 H  s          
+    66      4.250754  5 H  s                 75     -4.250754  6 H  s          
+     9     -3.426000  1 C  py                32     -3.426000  2 C  py         
+    54     -1.568296  3 H  py                63     -1.568296  4 H  py         
+    72     -1.568296  5 H  py                81     -1.568296  6 H  py         
+ 
+ Vector   66  Occ=0.000000D+00  E= 1.792850D+00  Symmetry=ag
+              MO Center= -2.7D-17, -1.0D-13, -1.6D-13, r^2= 3.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      8.527135  1 C  s                 26      8.527135  2 C  s          
+    48     -4.015509  3 H  s                 57     -4.015509  4 H  s          
+    66     -4.015509  5 H  s                 75     -4.015509  6 H  s          
+     4      2.084094  1 C  s                 27      2.084094  2 C  s          
+    10      2.060152  1 C  pz                33     -2.060152  2 C  pz         
+ 
+ Vector   67  Occ=0.000000D+00  E= 1.836375D+00  Symmetry=b1u
+              MO Center= -1.8D-16, -5.8D-14,  2.5D-13, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    10    -20.167548  1 C  pz                33    -20.167548  2 C  pz         
+     3     18.960868  1 C  s                 26    -18.960868  2 C  s          
+    48      7.146256  3 H  s                 57      7.146256  4 H  s          
+    66     -7.146256  5 H  s                 75     -7.146256  6 H  s          
+    21      4.411079  1 C  d  0              44     -4.411079  2 C  d  0       
+ 
+ Vector   68  Occ=0.000000D+00  E= 1.845882D+00  Symmetry=b3u
+              MO Center=  6.4D-17,  2.4D-14, -1.3D-14, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    50      0.588271  3 H  px                59      0.588271  4 H  px         
+    68      0.588271  5 H  px                77      0.588271  6 H  px         
+    53     -0.422463  3 H  px                62     -0.422463  4 H  px         
+    71     -0.422463  5 H  px                80     -0.422463  6 H  px         
+    17      0.405708  1 C  d  1              40     -0.405708  2 C  d  1       
+ 
+ Vector   69  Occ=0.000000D+00  E= 1.896237D+00  Symmetry=b3g
+              MO Center=  1.6D-16,  1.8D-14,  3.3D-13, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9     10.821129  1 C  py                32    -10.821129  2 C  py         
+    20     -4.689177  1 C  d -1              43     -4.689177  2 C  d -1       
+    48     -3.276071  3 H  s                 57      3.276071  4 H  s          
+    66      3.276071  5 H  s                 75     -3.276071  6 H  s          
+    55      1.803096  3 H  pz                64     -1.803096  4 H  pz         
+ 
+ Vector   70  Occ=0.000000D+00  E= 1.897822D+00  Symmetry=b1u
+              MO Center= -1.5D-16, -4.2D-14,  8.0D-14, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     10.646818  1 C  s                 26    -10.646818  2 C  s          
+     4      9.278222  1 C  s                 27     -9.278222  2 C  s          
+    48     -4.032280  3 H  s                 57     -4.032280  4 H  s          
+    66      4.032280  5 H  s                 75      4.032280  6 H  s          
+    13     -1.842132  1 C  pz                36     -1.842132  2 C  pz         
+ 
+ Vector   71  Occ=0.000000D+00  E= 1.908356D+00  Symmetry=b2u
+              MO Center= -4.5D-16,  6.1D-14,  7.4D-14, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      4.807565  3 H  s                 57     -4.807565  4 H  s          
+    66      4.807565  5 H  s                 75     -4.807565  6 H  s          
+     9     -4.326110  1 C  py                32     -4.326110  2 C  py         
+    20     -1.479726  1 C  d -1              43      1.479726  2 C  d -1       
+    54     -1.311361  3 H  py                63     -1.311361  4 H  py         
+ 
+ Vector   72  Occ=0.000000D+00  E= 1.913292D+00  Symmetry=b1g
+              MO Center=  4.8D-16, -2.3D-14, -9.7D-15, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.709645  1 C  d -2              37      0.709645  2 C  d -2       
+    53      0.607633  3 H  px                62     -0.607633  4 H  px         
+    71      0.607633  5 H  px                80     -0.607633  6 H  px         
+    50     -0.570595  3 H  px                59      0.570595  4 H  px         
+    68     -0.570595  5 H  px                77      0.570595  6 H  px         
+ 
+ Vector   73  Occ=0.000000D+00  E= 2.135842D+00  Symmetry=b2g
+              MO Center= -2.1D-16,  2.1D-14,  1.1D-14, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.127367  1 C  d  1              40      1.127367  2 C  d  1       
+    22     -1.097357  1 C  d  1              45     -1.097357  2 C  d  1       
+    53     -0.541102  3 H  px                62     -0.541102  4 H  px         
+    71      0.541102  5 H  px                80      0.541102  6 H  px         
+     8     -0.493237  1 C  px                31      0.493237  2 C  px         
+ 
+ Vector   74  Occ=0.000000D+00  E= 2.199683D+00  Symmetry=au
+              MO Center=  5.2D-17, -2.1D-14,  6.3D-15, r^2= 2.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.855273  1 C  d -2              37     -0.855273  2 C  d -2       
+    50     -0.590714  3 H  px                59      0.590714  4 H  px         
+    68      0.590714  5 H  px                77     -0.590714  6 H  px         
+    53      0.385821  3 H  px                62     -0.385821  4 H  px         
+    71     -0.385821  5 H  px                80      0.385821  6 H  px         
+ 
+ Vector   75  Occ=0.000000D+00  E= 2.230331D+00  Symmetry=b1u
+              MO Center=  1.8D-16,  3.2D-15, -1.5D-14, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     19.645842  1 C  s                 26    -19.645842  2 C  s          
+    10    -12.891430  1 C  pz                33    -12.891430  2 C  pz         
+     4      7.053231  1 C  s                 27     -7.053231  2 C  s          
+    13     -1.988996  1 C  pz                36     -1.988996  2 C  pz         
+     2     -1.843297  1 C  s                 25      1.843297  2 C  s          
+ 
+ Vector   76  Occ=0.000000D+00  E= 2.355065D+00  Symmetry=ag
+              MO Center= -1.1D-18,  3.1D-14, -3.5D-13, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      1.139874  1 C  s                 26      1.139874  2 C  s          
+    21      0.700423  1 C  d  0              44      0.700423  2 C  d  0       
+     7      0.647317  1 C  pz                30     -0.647317  2 C  pz         
+    51      0.645221  3 H  py                60     -0.645221  4 H  py         
+    69      0.645221  5 H  py                78     -0.645221  6 H  py         
+ 
+ Vector   77  Occ=0.000000D+00  E= 2.434156D+00  Symmetry=b3g
+              MO Center= -8.1D-17,  1.9D-13, -2.1D-13, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      6.661212  1 C  py                32     -6.661212  2 C  py         
+    20     -6.180603  1 C  d -1              43     -6.180603  2 C  d -1       
+    48      2.947086  3 H  s                 57     -2.947086  4 H  s          
+    66     -2.947086  5 H  s                 75      2.947086  6 H  s          
+    54     -1.061736  3 H  py                63     -1.061736  4 H  py         
+ 
+ Vector   78  Occ=0.000000D+00  E= 2.533283D+00  Symmetry=b1u
+              MO Center=  7.7D-17, -1.2D-13,  3.0D-13, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     11.393668  1 C  s                 26    -11.393668  2 C  s          
+    10     -9.550836  1 C  pz                33     -9.550836  2 C  pz         
+    48      2.556109  3 H  s                 57      2.556109  4 H  s          
+    66     -2.556109  5 H  s                 75     -2.556109  6 H  s          
+    21      1.776640  1 C  d  0              44     -1.776640  2 C  d  0       
+ 
+ Vector   79  Occ=0.000000D+00  E= 2.546670D+00  Symmetry=ag
+              MO Center= -5.1D-18,  6.6D-14,  1.8D-14, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      1.241399  1 C  s                 25      1.241399  2 C  s          
+     3     -1.006152  1 C  s                 26     -1.006152  2 C  s          
+    52      0.663514  3 H  pz                61      0.663514  4 H  pz         
+    70     -0.663514  5 H  pz                79     -0.663514  6 H  pz         
+    18     -0.635927  1 C  d  2              41     -0.635927  2 C  d  2       
+ 
+ Vector   80  Occ=0.000000D+00  E= 2.595307D+00  Symmetry=b2u
+              MO Center=  5.2D-18, -7.6D-14,  2.0D-13, r^2= 2.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48     -1.637761  3 H  s                 57      1.637761  4 H  s          
+    66     -1.637761  5 H  s                 75      1.637761  6 H  s          
+     9      1.495018  1 C  py                32      1.495018  2 C  py         
+     6      1.000732  1 C  py                29      1.000732  2 C  py         
+    15      0.901062  1 C  d -1              38     -0.901062  2 C  d -1       
+ 
+ Vector   81  Occ=0.000000D+00  E= 3.175872D+00  Symmetry=b1u
+              MO Center=  2.2D-18, -3.7D-14, -4.9D-14, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3     23.779278  1 C  s                 26    -23.779278  2 C  s          
+    10    -14.412758  1 C  pz                33    -14.412758  2 C  pz         
+     4      4.127577  1 C  s                 27     -4.127577  2 C  s          
+    21      3.490514  1 C  d  0              44     -3.490514  2 C  d  0       
+    48      2.170369  3 H  s                 57      2.170369  4 H  s          
+ 
+ Vector   82  Occ=0.000000D+00  E= 3.188337D+00  Symmetry=b3g
+              MO Center=  3.7D-17, -4.7D-15, -4.0D-14, r^2= 2.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      2.803507  3 H  s                 57     -2.803507  4 H  s          
+    66     -2.803507  5 H  s                 75      2.803507  6 H  s          
+    15     -1.913224  1 C  d -1              38     -1.913224  2 C  d -1       
+     9     -1.754476  1 C  py                32      1.754476  2 C  py         
+    12     -1.427957  1 C  py                35      1.427957  2 C  py         
+ 
+
+ center of mass
+ --------------
+ x =   0.00000000 y =   0.00000000 z =   0.00000000
+
+ moments of inertia (a.u.)
+ ------------------
+          72.691697552106           0.000000000000           0.000000000000
+           0.000000000000          60.270006716700           0.000000000000
+           0.000000000000           0.000000000000          12.421690835407
+ 
+     Multipole analysis of the density
+     ---------------------------------
+ 
+     L   x y z        total         alpha         beta         nuclear
+     -   - - -        -----         -----         ----         -------
+     0   0 0 0      0.000000     -8.000000     -8.000000     16.000000
+ 
+     1   1 0 0     -0.000000     -0.000000     -0.000000      0.000000
+     1   0 1 0     -0.000000     -0.000000     -0.000000      0.000000
+     1   0 0 1     -0.000000     -0.000000     -0.000000      0.000000
+ 
+     2   2 0 0    -11.645896     -5.822948     -5.822948      0.000000
+     2   1 1 0      0.000000      0.000000      0.000000      0.000000
+     2   1 0 1      0.000000      0.000000      0.000000      0.000000
+     2   0 2 0     -9.117952    -10.721599    -10.721599     12.325246
+     2   0 1 1      0.000000      0.000000      0.000000      0.000000
+     2   0 0 2     -9.177144    -25.034781    -25.034781     40.892417
+ 
+
+ Parallel integral file used      22 records with       0 large values
+
+
+ Task  times  cpu:        2.0s     wall:        2.0s
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+ Summary of allocated global arrays
+-----------------------------------
+  No active global arrays
+
+
+
+                         GA Statistics for process    0
+                         ------------------------------
+
+       create   destroy   get      put      acc     scatter   gather  read&inc
+calls:  288      288     3.79e+04 1.27e+04 1.38e+04    0        0     1926     
+number of processes/call 4.86e+01 5.18e+01 1.33e+01 0.00e+00 0.00e+00
+bytes total:             5.68e+07 1.71e+07 3.07e+07 0.00e+00 0.00e+00 1.54e+04
+bytes remote:            0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00
+Max memory consumed for GA by this process: 2097888 bytes
+ 
+ 
+ 
+                                     CITATION
+                                     --------
+                Please cite the following reference when publishing
+                           results obtained with NWChem:
+ 
+                 M. Valiev, E.J. Bylaska, N. Govind, K. Kowalski,
+              T.P. Straatsma, H.J.J. van Dam, D. Wang, J. Nieplocha,
+                        E. Apra, T.L. Windus, W.A. de Jong
+                 "NWChem: a comprehensive and scalable open-source
+                  solution for large scale molecular simulations"
+                      Comput. Phys. Commun. 181, 1477 (2010)
+                           doi:10.1016/j.cpc.2010.04.018
+ 
+                                      AUTHORS
+                                      -------
+          E. Apra, E. J. Bylaska, W. A. de Jong, N. Govind, K. Kowalski,
+       T. P. Straatsma, M. Valiev, H. J. J. van Dam, D. Wang, T. L. Windus,
+        J. Hammond, J. Autschbach, K. Bhaskaran-Nair, J. Brabec, K. Lopata,
+    S. A. Fischer, S. Krishnamoorthy, M. Jacquelin, W. Ma, M. Klemm, O. Villa,
+      Y. Chen, V. Anisimov, F. Aquino, S. Hirata, M. T. Hackler, V. Konjkov,
+            D. Mejia-Rodriguez, T. Risthaus, M. Malagoli, A. Marenich,
+   A. Otero-de-la-Roza, J. Mullin, P. Nichols, R. Peverati, J. Pittner, Y. Zhao,
+        P.-D. Fan, A. Fonari, M. J. Williamson, R. J. Harrison, J. R. Rehr,
+      M. Dupuis, D. Silverstein, D. M. A. Smith, J. Nieplocha, V. Tipparaju,
+    M. Krishnan, B. E. Van Kuiken, A. Vazquez-Mayagoitia, L. Jensen, M. Swart,
+      Q. Wu, T. Van Voorhis, A. A. Auer, M. Nooijen, L. D. Crosby, E. Brown,
+      G. Cisneros, G. I. Fann, H. Fruchtl, J. Garza, K. Hirao, R. A. Kendall,
+      J. A. Nichols, K. Tsemekhman, K. Wolinski, J. Anchell, D. E. Bernholdt,
+      P. Borowski, T. Clark, D. Clerc, H. Dachsel, M. J. O. Deegan, K. Dyall,
+    D. Elwood, E. Glendening, M. Gutowski, A. C. Hess, J. Jaffe, B. G. Johnson,
+     J. Ju, R. Kobayashi, R. Kutteh, Z. Lin, R. Littlefield, X. Long, B. Meng,
+      T. Nakajima, S. Niu, L. Pollack, M. Rosing, K. Glaesemann, G. Sandrone,
+      M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe, A. T. Wong, Z. Zhang.
+
+ Total times  cpu:        3.6s     wall:        3.9s
+MA_summarize_allocated_blocks: starting scan ...
+MA_summarize_allocated_blocks: scan completed: 0 heap blocks, 0 stack blocks
+MA usage statistics:
+
+	allocation statistics:
+					      heap	     stack
+					      ----	     -----
+	current number of blocks	         0	         0
+	maximum number of blocks	        22	        57
+	current total bytes		         0	         0
+	maximum total bytes		  26763808	  22513544
+	maximum total K-bytes		     26764	     22514
+	maximum total M-bytes		        27	        23

--- a/src/nwdft/include/cdft.fh
+++ b/src/nwdft/include/cdft.fh
@@ -46,6 +46,7 @@ cc AJL/End
      &     XCFIT, CDFIT, store_wght, ldelley, lcfac, nlcfac, lxfac, 
      &     nlxfac, xccomb, levelshift, damp, diis, direct, oskel, 
      &     oadapt, lssw, lkeeps,trunc_neigh, lb94, cs00, bqdontcare,
+     &     ncap,
 cc AJL/Begin/FDE
      &     frozemb, frozemb_fde, lcfac_fde, nlcfac_fde, lxfac_fde, 
      &     nlxfac_fde, xccomb_fde
@@ -96,7 +97,7 @@ c
      ,     nlcfac(numfunc),lxfac(numfunc), nlxfac(numfunc), 
      ,     xccomb(numfunc), levelshift, damp, diis, 
      &     direct, oskel, oadapt, lssw, lkeeps,trunc_neigh, 
-     &     lb94, cs00, bqdontcare,
+     &     lb94, cs00, bqdontcare, ncap,
 cc AJL/Begin/FDE
      &     frozemb, frozemb_fde, lcfac_fde(numfunc), 
      &     nlcfac_fde(numfunc), lxfac_fde(numfunc), 

--- a/src/nwdft/input_dft/dft_inpana.F
+++ b/src/nwdft/input_dft/dft_inpana.F
@@ -634,6 +634,11 @@ c
                write(LuOut,*)
                write(LuOut,9226) 
      &         '         van Leeuwen-Baerends correction    '
+            else if (ncap) then
+               write(LuOut,*)
+               write(LuOut,9227)
+     &         '  NCAP with derivative discontinuity shift    ',
+     &         delta_ac,'au'
             endif
 c
 c           Print range-separation parameters

--- a/src/nwdft/input_dft/dft_input.F
+++ b/src/nwdft/input_dft/dft_input.F
@@ -30,7 +30,7 @@ c
       integer num_dirs          ! No. of known directives
 cc AJL/Begin/FDE
 c      parameter (num_dirs = 48)
-      parameter (num_dirs = 50)
+      parameter (num_dirs = 51)
 cc AJL/End
       character*12 dirs(num_dirs)
       character*255 test
@@ -88,7 +88,7 @@ c     xps variables
      $         'ecp','grid','vectors','incore','iterations', 
      $         'max_ovl','mulliken','mult','noio','noprint','odft', 
      $         'print','tolerances', 'xc','sym','adapt','sic', 
-     $         'smear','fon','lb94','cs00','cdft','cam','disp',
+     $         'smear','fon','lb94','cs00','ncapdd','cdft','cam','disp',
      $         'dftmp2','molden','noscf','steric','efield','swapab',
      $         'frozemb', 'frozemb_xc', 'frozemb_ts',
      $         'cgmin','nocgmin','tol2e','ri-scf','lock',
@@ -143,7 +143,7 @@ c
 c     
       goto (100,  200,  300,  400,  450,  500,  600,  700,  800,
      $      900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700,
-     $     1800, 1900, 2000, 2100, 2200, 2300, 2400, 2500, 2600, 
+     $     1800, 1900, 2000, 2100, 2200, 2300, 2400, 2500, 2510, 2600, 
      $     2700, 2800, 2900, 3000, 3100, 3200, 3300, 3400, 
      $     3500, 3520, 3530,
      $     3600, 3600, 3700, 3800, 3900, 4000, 4100, 4200, 4300,
@@ -495,6 +495,24 @@ c
       endif
       if (.not.rtdb_put(rtdb,'dft:delta_ac',mt_dbl,1,shift))
      &   call errquit('dft_input: rtdb_put failed', 2500, RTDB_ERR)
+c
+      goto 10
+c
+c     ncap; adds NCAP derivative discontinuity correction to potential
+c             
+ 2510 ncap = .true.
+      if (.not.rtdb_put(rtdb,'dft:ncap', mt_log, 1, ncap))
+     &   call errquit('dft_input: rtdb_put failed', 2510, RTDB_ERR)
+      if (.not.inp_f(shift)) then
+         write(LuOut,*)' e_{homo} for NCAP potential shift not found;',
+     &   ' e_{homo} current for each iteration will be used.'
+         shift = 1.0d99
+      else
+         shift = 0.053805222d0 * 
+     &           (1d0 + dsqrt(1d0 - 2d0*shift/0.053805222d0))
+      endif
+      if (.not.rtdb_put(rtdb,'dft:delta_ac',mt_dbl,1,shift))
+     &   call errquit('dft_input: rtdb_put failed', 2510, RTDB_ERR)
 c
       goto 10
 c

--- a/src/nwdft/input_dft/dft_rdinput.F
+++ b/src/nwdft/input_dft/dft_rdinput.F
@@ -188,6 +188,14 @@ c
      &      mt_log, 1, cs00))
      &      call errquit('dft_rdinput: rtdb_put failed', 10, RTDB_ERR)
       endif
+c
+      if (.not. rtdb_get(rtdb, 'dft:ncap', mt_log, 1,
+     &   ncap))then
+         ncap = .false.
+         if (.not. rtdb_put(rtdb, 'dft:ncap',
+     &      mt_log, 1, ncap))
+     &      call errquit('dft_rdinput: rtdb_put failed', 10, RTDB_ERR)
+      endif
 c     
       if (.not. rtdb_get(rtdb, 'dft:iterations', mt_int, 1,
      &   iterations))then
@@ -595,6 +603,7 @@ c
       cname(67)='            SCAN-L Correlation Potential'
       cname(68)='            revM06 Correlation Potential'
       cname(69)='          revM06-L Correlation Potential'
+      cname(71)='           regSCAN Correlation Potential'
 c
 c     Exchange functional name defaults.
 c
@@ -661,7 +670,8 @@ c
       xname(68)='              revM06 Exchange Functional'
       xname(69)='            revM06-L Exchange Functional'
       xname(70)='                LB94 Exchange Functional'
-
+      xname(71)='     regSCAN metaGGA Exchange Functional'
+      xname(72)='            NCAP GGA Exchange Functional'
 c
 c     Exchange-Correlation combination functional name defaults.
 c
@@ -728,6 +738,8 @@ c
       xcname(68)='             revM06 Method XC Functional'
       xcname(69)='           revM06-L Method XC Functional'
       xcname(70)='              SCAN0 Method XC Functional'
+      xcname(71)='            regSCAN Method XC Functional'
+      xcname(72)='               NCAP Method XC Functional'
 c     
 c     place character XC parameters in rtdb
 c     

--- a/src/nwdft/input_dft/xc_inp.F
+++ b/src/nwdft/input_dft/xc_inp.F
@@ -137,7 +137,7 @@ c     xperde86 ==> 9520
 c
 c
       integer num_dirs, ind, mlen, iline, n
-      parameter (num_dirs=148)
+      parameter (num_dirs=151)
 c
       character*15 dirs(num_dirs)
       character*255 test
@@ -187,7 +187,8 @@ c
      &     'b3pw91','pbe96','dldf','srhfexch','hse03',
      &     's12g','s12h','cam-s12g','cam-s12h',
      &     'becke86b','xperdew86','xmvs15','cvpbe09','mvs',
-     &     'hle16', 'scan', 'scanl','scan0','lb94'/
+     &     'hle16', 'scan', 'scanl','scan0','lb94', 'regscan',
+     &     'xncap', 'ncap' /
 c     becke97-d, ssb-d
       logical disp, dumdirect
       integer ivdw
@@ -257,7 +258,8 @@ c
      &  8200,4800,8300,8400,8500,8510,8520,8530,4600,4700,4701,8531,
      &  8532,8533,8534,9300,9310,9320,4610,4620,4630,4640,
      &  9510,9520,4115,2109,4124,3101,
-     &  9610,9620,9630,9494,1999) ind
+     &  9610,9620,9630,9494,9640,
+     &  9710,9720,1999) ind
       call errquit('xc_inp: unimplemented directive', ind, INPUT_ERR)
 c     
 c     acm; adiabatic connection method
@@ -1699,6 +1701,17 @@ c
       nlxfac(1) = .true.
       goto 10
 c
+c regularized SCAN meta GGA
+c
+9640  xccomb(71) = .true.
+       lcfac(71) = .true.
+      nlcfac(71) = .true.
+        cfac(71) = 1.0d0
+       lxfac(71) = .true.
+      nlxfac(71) = .true.
+        xfac(71) = 1.0d0
+      goto 10
+c
 c SCAN-L laplacian-dependent mGGA
 c
 9620  xccomb(67) = .true.
@@ -1708,6 +1721,23 @@ c
        lxfac(67) = .true.
       nlxfac(67) = .true.
         xfac(67) = 1.0d0
+      goto 10
+c
+c NCAP functional
+c
+9710   lxfac(72) = .true.
+      nlxfac(72) = .true.
+        xfac(72) = 1.0d0
+      goto 10
+
+9720  xccomb(72) = .true.
+      cfac(3) = 1d0
+      lcfac(3) = .true.
+      cfac(4) = 1d0
+      nlcfac(4) = .true.
+      lxfac(72) = .true.
+      nlxfac(72) = .true.
+      xfac(72) = 1.0d0
       goto 10
 c
 c lb94 Vxc function

--- a/src/nwdft/lr_tddft/tddft_init.F
+++ b/src/nwdft/lr_tddft/tddft_init.F
@@ -80,7 +80,8 @@ c
       integer mult             ! Ground state spin multiplicity
       logical lb94             ! LB94 asymptotic correction
       logical cs00             ! CS00 asymptotic correction
-      double precision shift   ! Shift for CS00
+      logical ncap             ! NCAP derivative discontinuity
+      double precision shift   ! Shift for CS00 or NCAP
 C     character*80 vector      ! CI vector filename
 c
       character*3 onoff1,onoff2
@@ -211,6 +212,8 @@ c --------------
      1  call errquit('tddft_init: failed to read lb94',0, RTDB_ERR)
       if (.not.rtdb_get(rtdb,'dft:cs00',mt_log,1,cs00))
      1  call errquit('tddft_init: failed to read cs00',0, RTDB_ERR)
+      if (.not.rtdb_get(rtdb,'dft:ncap',mt_log,1,ncap))
+     1  call errquit('tddft_init: failed to read ncap',0, RTDB_ERR)
       if (.not.rtdb_get(rtdb,'dft:delta_ac',mt_dbl,1,shift))
      1  call errquit('tddft_init: failed to read delta_ac',0, RTDB_ERR)
 c -----------
@@ -652,6 +655,11 @@ c
           write(LuOut,*)
           write(LuOut,9330)
      1    '         van Leeuwen-Baerends correction    '
+        else if (ncap) then
+          write(LuOut,*)
+          write(LuOut,9320)
+     1    '  NCAP with derivative discontinuity shift   ',
+     2    shift,'au'
         endif ! cs00
       endif ! nodezero
 c

--- a/src/nwdft/lr_tddft_grad/tddft_grad_init.F
+++ b/src/nwdft/lr_tddft_grad/tddft_grad_init.F
@@ -75,6 +75,7 @@ c
 c
       logical cs00
       logical lb94
+      logical ncap
       integer iAOacc
 c
       logical osinglet
@@ -191,6 +192,8 @@ c     get XC functionals
      1  call errquit(pname//'failed to read lb94',0, RTDB_ERR)
       if (.not.rtdb_get(rtdb,'dft:cs00',mt_log,1,cs00))
      1  call errquit(pname//'failed to read cs00',0, RTDB_ERR)
+      if (.not.rtdb_get(rtdb,'dft:ncap',mt_log,1,ncap))
+     1  call errquit(pname//'failed to read ncap',0, RTDB_ERR)
       if (.not.rtdb_get(rtdb,'dft:delta_ac',mt_dbl,1,shift))
      1  call errquit(pname//'failed to read delta_ac',0, RTDB_ERR)
       if (.not.rtdb_get(rtdb,'dft:cam_exch',mt_log,1,cam_exch))

--- a/src/nwdft/xc/GNUmakefile
+++ b/src/nwdft/xc/GNUmakefile
@@ -55,7 +55,8 @@ HEADERS = xc.fh xc_vdw.fh xc_params.fh xc_hcth.fh
 	steric_energy.o\
 	xc_3rd_deriv.o xc_xpw86.o xc_xb86b.o xc_xdm.o \
 	ts_eval_fnl.o ts_tf.o ts_vw.o xc_xn12.o \
-	xc_xscan.o xc_cscan.o xc_xscanl.o xc_cscanl.o ts_pc.o
+	xc_xscan.o xc_cscan.o xc_xscanl.o xc_cscanl.o ts_pc.o\
+	xc_xncap.o xc_xncap.o
 
      LIBRARY = libnwdft.a
 

--- a/src/nwdft/xc/xc_cscan.F
+++ b/src/nwdft/xc/xc_cscan.F
@@ -30,9 +30,9 @@ c     J. Sun, A. Ruzsinszky, J.P. Perdew
 c     PRL 115, 036402 (2015)
 c     DOI: 10.1103/PhysRevLett.115036402
 
-      Subroutine xc_cscan(tol_rho, cfac, rho, delrho, Amat, Cmat,
-     &                     nq, ipol, Ec, qwght, ldew, func,
-     &                     tau, Mmat)     
+      Subroutine xc_cscan(whichfc, tol_rho, cfac, rho, delrho, Amat, 
+     &                    Cmat, nq, ipol, Ec, qwght, ldew, func,
+     &                    tau, Mmat)     
 c
       implicit none
 c
@@ -41,9 +41,10 @@ c
 c
 c     Input and other parameters
 c
+      character(*) whichfc
       integer ipol, nq
       double precision dummy(1)
-      double precision cfac(*)
+      double precision cfac
       logical ldew
       double precision func(*)
       double precision fac
@@ -81,7 +82,7 @@ c
 c
 c     Intermediate derivatives, results, etc.
 c
-      integer n
+      integer n, ifc
       double precision ntot,n13,n83,tautot
       double precision dn2,p,rs,rs12,drsdn,dpdg,dpdn
       double precision epsc,depscdrs,depscdzeta
@@ -125,6 +126,17 @@ c
       parameter (F4=4d0,F13=1d0/3d0,F23=F13+F13,F43=F13+1d0)
       parameter (F53=F23+1d0,F83=F53+1d0,F14=0.25d0)
       parameter (F8=8d0,F5=5d0,F16=1d0/6d0)
+
+      double precision rRegu(0:7), rRegu1(7), rtemp(0:7)
+      double precision regalpha, dregalpha
+      parameter ( rRegu = (/ 1d0, -0.64d0, -0.4352d0, 
+     &            -1.535685604549d0, 3.061560252175d0,
+     &            -1.915710236206d0, 5.16884468372d-1,
+     &            -5.1848879792d-2 /) )
+      parameter ( rRegu1 = (/ -0.64d0, -2d0*0.4352d0,
+     &            -3d0*1.535685604549d0, 4d0*3.061560252175d0,
+     &            -5d0*1.915710236206d0, 6d0*5.16884468372d-1,
+     &            -7d0*5.1848879792d-2 /) )
 c
 c     ======> BOTH SPIN-RESTRICETED AND UNRESTRICTED <======
 c
@@ -249,31 +261,53 @@ c
          tvw = 0.125d0*dn2/ntot
          alpha = (tautot - tvw)/tueg
          if (alpha.lt.0d0) alpha=0d0
-         oma = 1d0 - alpha
+         if (whichfc.eq.'orig') then
+           regalpha = alpha
+           dregalpha = 1d0
+         else if (whichfc.eq.'regu') then
+           regalpha = alpha**3/(alpha**2 + 1d-3)
+           dregalpha = alpha/(alpha**2 + 1d-3) * 
+     &                 (3d0*alpha - 2d0*regalpha)
+         endif
+         oma = 1d0 - regalpha
          oma2 = oma*oma
 
-         if (alpha.ge.thr1) then
-           exp5 = 0d0
-         else
-           exp5 = dexp(-c1c*alpha/oma)
-         end if
-         if (alpha.le.thr2) then
-           exp6 = 0d0
-         else
-           exp6 = dexp(c2c/oma)
-         end if
-         fca = exp5 - dc*exp6
-
-         if (alpha.ge.thr1.and.alpha.le.thr2) then
-           dfcada = 0d0
-         else
-           dfcada = -(c1c*exp5 + dc*exp6*c2c)/oma2
-         end if
+         if (whichfc.eq.'orig') then
+           if (regalpha.ge.thr1) then
+             exp5 = 0d0
+           else
+             exp5 = dexp(-c1c*regalpha/oma)
+           end if
+           if (regalpha.le.thr2) then
+             exp6 = 0d0
+           else
+             exp6 = dexp(c2c/oma)
+           end if
+           fca = exp5 - dc*exp6
+           if (regalpha.ge.thr1.and.regalpha.le.thr2) then
+             dfcada = 0d0
+           else
+             dfcada = -(c1c*exp5 + dc*exp6*c2c)/oma2
+           end if
+         else if(whichfc.eq.'regu') then
+           if (regalpha.lt.2.5d0) then
+             rtemp(0) = 1d0
+             do ifc=1,7
+               rtemp(ifc) = rtemp(ifc-1)*regalpha
+             enddo
+             fca = dot_product(rRegu,rtemp)
+             dfcada = dot_product(rRegu1, rtemp(0:6))*dregalpha
+           else
+             exp6 = dexp(c2c/oma)
+             fca = -dc*exp6
+             dfcada = -dc*exp6*c2c/oma2*dregalpha
+           endif
+         endif
 c
 c        --------------------------------------------------------------
 c
-         Ec = Ec + ntot*(Ec1 + fca*(Ec0-Ec1))*qwght(n)
-         if (ldew) func(n) = func(n) + ntot*(Ec1 + fca*(Ec0-Ec1))
+         Ec = Ec + cfac*ntot*(Ec1 + fca*(Ec0-Ec1))*qwght(n)
+         if (ldew) func(n) = func(n) + cfac*ntot*(Ec1 + fca*(Ec0-Ec1))
 c
          dalphadn = F13*(F8*tvw - F5*tautot)/(tueg*ntot)
          dalphadg = -0.125d0/(tueg*ntot)
@@ -285,26 +319,28 @@ c
          vcn = Ec1 + fca*(Ec0-Ec1) + 
      &         ntot*(dEc1dn + fca*(dEc0dn-dEc1dn) + dfcadn*(Ec0-Ec1))
 
-         Amat(n,1) = Amat(n,1) + vcn
+         Amat(n,1) = Amat(n,1) + cfac*vcn
 
          dEc1dg = dEc1dp*dpdg
          dEc0dg = dEc0dp*dpdg
          dfcadg = dfcada*dalphadg         
 
-         Cmat(n,D1_GAA) = Cmat(n,D1_GAA) + ntot*(dEc1dg + 
+         Cmat(n,D1_GAA) = Cmat(n,D1_GAA) + cfac*ntot*(dEc1dg + 
      &   fca*(dEc0dg-dEc1dg) + dfcadg*(Ec0-Ec1))
-         Cmat(n,D1_GAB) = Cmat(n,D1_GAB) + ntot*(dEc1dg + 
+         Cmat(n,D1_GAB) = Cmat(n,D1_GAB) + cfac*ntot*(dEc1dg + 
      &   fca*(dEc0dg-dEc1dg) + dfcadg*(Ec0-Ec1))*2d0
 
-         Mmat(n,1) = Mmat(n,1) + 0.5d0*ntot*dfcada*dalphadt*(Ec0-Ec1)
+         Mmat(n,1) = Mmat(n,1) + 0.5d0*cfac*
+     &                           ntot*dfcada*dalphadt*(Ec0-Ec1)
 
          if (ipol.eq.2) then
-           Amat(n,2) = Amat(n,2) + vcn
+           Amat(n,2) = Amat(n,2) + cfac*vcn
 
-           Cmat(n,D1_GBB) = Cmat(n,D1_GBB) + ntot*(dEc1dg +
+           Cmat(n,D1_GBB) = Cmat(n,D1_GBB) + cfac*ntot*(dEc1dg +
      &     fca*(dEc0dg-dEc1dg) + dfcadg*(Ec0-Ec1))
            
-           Mmat(n,2) = Mmat(n,2) + 0.5d0*ntot*dfcada*dalphadt*(Ec0-Ec1)
+           Mmat(n,2) = Mmat(n,2) + 0.5d0*cfac*
+     &                             ntot*dfcada*dalphadt*(Ec0-Ec1)
 
            if (omz.lt.tol_rho) then
              dphidzeta = 0.5d0*F23*(opz**F23/opz)
@@ -335,8 +371,8 @@ c
            vcpol = dEc1dzeta + dfcadzeta*(Ec0-Ec1) + 
      &             fca*(dEc0dzeta-dEc1dzeta)
 
-           Amat(n,1) = Amat(n,1) + omz*vcpol
-           Amat(n,2) = Amat(n,2) - opz*vcpol
+           Amat(n,1) = Amat(n,1) + cfac*omz*vcpol
+           Amat(n,2) = Amat(n,2) - cfac*opz*vcpol
          
          end if
 

--- a/src/nwdft/xc/xc_eval_fnl.F
+++ b/src/nwdft/xc/xc_eval_fnl.F
@@ -826,6 +826,18 @@ c
      &   delta_ac, e_homo)
       else if (lb94) then
          call xc_lb94(tol_rho, xfac(1), rho, delrho, Amat, nq, ipol)
+      else if (ncap) then
+         if (delta_ac.eq.1.0d99) then
+           Amat(1:nq) = Amat(1:nq) - 
+     &     0.053805222d0*(1d0 + dsqrt(1d0 - 2d0*e_homo/0.053805222d0))
+           if (ipol.eq.2) then
+             Amat(nq+1:2*nq) = Amat(nq+1:2*nq) -
+     &       0.053805222d0*(1d0 + dsqrt(1d0 - 2d0*e_homo/0.053805222d0))
+           endif
+         else
+           Amat(1:nq) = Amat(1:nq) - delta_ac
+           if (ipol.eq.2) Amat(nq+1:2*nq) = Amat(nq+1:2*nq) - delta_ac
+         endif
       endif
 c     
 c     PKZB99-COR is special in that the GGA part is
@@ -1601,8 +1613,9 @@ c     SCAN meta GGA
 c
       if (abs(xfac(66)).gt.eps) then
          if(.not. do_2nd) then
-            call xc_xscan(tol_rho, xfac(66), rho, delrho, Amat, Cmat,
-     &                    nq, ipol, Ex, qwght, ldew, func, ttau, Mmat)
+            call xc_xscan('orig', tol_rho, xfac(66), rho, delrho, Amat, 
+     &                    Cmat, nq, ipol, Ex, qwght, ldew, func, ttau, 
+     &                    Mmat)
          else
             call xc_xscan_d2()
          endif
@@ -1610,10 +1623,49 @@ c
 c
       if (abs(cfac(66)).gt.eps) then
          if(.not. do_2nd) then
-            call xc_cscan(tol_rho, cfac(66), rho, delrho, Amat, Cmat,
-     &                    nq, ipol, Ec, qwght, ldew, func, ttau, Mmat)
+            call xc_cscan('orig', tol_rho, cfac(66), rho, delrho, Amat, 
+     &                    Cmat, nq, ipol, Ec, qwght, ldew, func, ttau, 
+     &                    Mmat)
          else
             call xc_cscan_d2()
+         endif
+      endif
+c
+c     regularized SCAN
+c
+      if (abs(xfac(71)).gt.eps) then
+         if(.not. do_2nd) then
+            call xc_xscan('regu', tol_rho, xfac(71), rho, delrho, Amat,
+     &                    Cmat, nq, ipol, Ex, qwght, ldew, func, ttau, 
+     &                    Mmat)
+         else
+            call xc_xscan_d2()
+         endif
+      endif
+c
+      if (abs(cfac(71)).gt.eps) then
+         if(.not. do_2nd) then
+            call xc_cscan('regu', tol_rho, cfac(71), rho, delrho, Amat, 
+     &                    Cmat, nq, ipol, Ec, qwght, ldew, func, ttau, 
+     &                    Mmat)
+         else
+            call xc_cscan_d2()
+         endif
+      endif
+c
+      if (abs(xfac(72)).gt.eps)then
+         if (.not. do_2nd .and..not. do_3rd) then
+            call xc_xncap(tol_rho, xfac(72), rho,
+     &           delrho, Amat, Cmat, nq, ipol,
+     &           Ex, qwght, ldew, func)
+         else if (.not. do_3rd) then
+            call xc_xncap_d2(tol_rho, xfac(72), rho,
+     &           delrho, Amat, Amat2, Cmat, Cmat2, nq, ipol,
+     &           Ex, qwght, ldew, func)
+         else
+            call xc_xncap_d3(tol_rho, xfac(72), rho,
+     &           delrho, Amat, Amat2, Amat3, Cmat, Cmat2, Cmat3,
+     &           nq, ipol, Ex, qwght, ldew, func)
          endif
       endif
 c

--- a/src/nwdft/xc/xc_util.F
+++ b/src/nwdft/xc/xc_util.F
@@ -39,8 +39,8 @@ c
      + cfac(52) + cfac(53) + cfac(54) +
      + xfac(60) + xfac(61) + xfac(62) + xfac(63) + xfac(68) + xfac(69)+
      +     xfac(66) + cfac(66) + xfac(67) + cfac(67) +
-     +     cfac(68)+  cfac(69) + xfac(70) +
-     L     lxdm +
+     +     cfac(68)+  cfac(69) + xfac(70) + xfac(71) + cfac(71) +
+     L     xfac(72) + lxdm +
 cc AJL/Begin/FDE
      + xfac_fde(3) + xfac_fde(4) + xfac_fde(5) + xfac_fde(6) + 
      + xfac_fde(7) +
@@ -189,6 +189,7 @@ cb973     .     xfac(22).ne.0d0.or.
      .     xfac(66).ne.0d0.or.
      .     xfac(68).ne.0d0.or.
      .     xfac(69).ne.0d0.or.
+     .     xfac(71).ne.0d0.or.
 c
 chcth     .     cfac(13).ne.0d0.or.
 cCbecke97     .     cfac(14).ne.0d0.or.
@@ -222,6 +223,7 @@ chp414     .     cfac(21).ne.0d0.or.
      .     cfac(54).ne.0d0.or.
      .     cfac(68).ne.0d0.or.
      .     cfac(69).ne.0d0.or.
+     .     cfac(71).ne.0d0.or.
      .     cfac(36).ne.0d0)
       if (util_module_avail("nwxc")) then
          call nwxc_getvals("nwxc_has_2nd",out1)
@@ -257,6 +259,7 @@ c
      +      cfac(48) + cfac(49) + cfac(50) + cfac(51) +
      +      xfac(66) + cfac(66) + xfac(67) + cfac(67) +
      +      xfac(68) + cfac(68) + xfac(69) + cfac(69) +
+     +      xfac(71) + cfac(71) +
 cc AJL/Begin/FDE
      +      xfac_fde(18) + cfac_fde(25) + xfac_fde(21) + cfac_fde(27) +
      +      xfac_fde(28) + xfac_fde(29) + xfac_fde(33) + xfac_fde(34) + 
@@ -473,6 +476,7 @@ c
      .     xfac(67).ne.0d0.or.  ! SCAN-L
      .     xfac(68).ne.0d0.or.  ! revM06
      .     xfac(69).ne.0d0.or.  ! revM06-L
+     .     xfac(71).ne.0d0.or.  ! regSCAN
 c
      .     cfac(5).ne.0d0.or.   ! PW91
      .     cfac(13).ne.0d0.or.  ! HCTH
@@ -517,7 +521,8 @@ c
      .     cfac(66).ne.0d0.or.  ! SCAN
      .     cfac(67).ne.0d0.or.  ! SCAN-L
      .     cfac(68).ne.0d0.or.  ! revM06
-     .     cfac(69).ne.0d0      ! revM06-L
+     .     cfac(69).ne.0d0.or.  ! revM06-L
+     .     cfac(71).ne.0d0      ! regSCAN
      .                )
 c
       return

--- a/src/nwdft/xc/xc_xncap.F
+++ b/src/nwdft/xc/xc_xncap.F
@@ -1,0 +1,521 @@
+c Copyright 2019 (C) Orbital-free DFT group at University of Florida
+c Licensed under the Educational Community License, Version 2.0 
+c (the "License"); you may not use this file except in compliance with 
+c the License. You may obtain a copy of the License at
+c
+c    http://www.osedu.org/licenses/ECL-2.0
+c
+c Unless required by applicable law or agreed to in writing,
+c software distributed under the License is distributed on an "AS IS"
+c BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+c or implied. See the License for the specific language governing
+c permissions and limitations under the License.
+c
+#include "dft2drv.fh"
+#include "dft3drv.fh"
+c     Nearly correct asymptotic potential (NCAP) functional
+c     (Exchange part only)
+c           GGA
+C         utilizes ingredients:
+c                              rho   -  density
+c                              delrho - gradient of density
+c
+c     Written by:
+c     Daniel Mejia-Rodriguez
+c     QTP, Department of Physics, University of Florida
+c
+c     References:
+c     J. Carmona-Espindola, J.L. Gazquez, A. Vela, S.B. Trickey
+c     JCTC 15, 303 (2019).
+c     DOI: 10.1021/acs.jctc.8b00998
+c
+c
+#if !defined SECOND_DERIV && !defined THIRD_DERIV
+      Subroutine xc_xncap(tol_rho, fac, rho, delrho,
+     &                    Amat, Cmat, nq, ipol, Ex, qwght,ldew,func)
+#elif defined(SECOND_DERIV) && !defined THIRD_DERIV
+      Subroutine xc_xncap_d2(tol_rho, fac, rho, delrho,
+     &                       Amat, Amat2, Cmat, Cmat2, nq, ipol, Ex,
+     &                       qwght,ldew,func)
+#else
+      Subroutine xc_xncap_d3(tol_rho, fac, rho, delrho,
+     &                       Amat, Amat2, Amat3, Cmat, Cmat2, Cmat3, 
+     &                       nq, ipol, Ex, qwght,ldew,func)
+#endif
+c
+      implicit none
+c      
+      double precision fac, Ex
+      integer nq, ipol
+      logical ldew
+      double precision func(*)  ! value of the functional [output]
+c
+c     Charge Density & Its Cube Root
+c
+      double precision rho(nq,ipol*(ipol+1)/2)
+c
+c     Charge Density Gradient
+c
+      double precision delrho(nq,3,ipol)
+c
+c     Quadrature Weights
+c
+      double precision qwght(nq)
+c
+c     Sampling Matrices for the XC Potential & Energy
+c
+      double precision amat(nq,ipol), cmat(nq,*)
+c
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+      double precision Amat2(nq,NCOL_AMAT2), Cmat2(nq,NCOL_CMAT2)
+#endif
+#ifdef THIRD_DERIV
+      double precision Amat3(nq,NCOL_AMAT3), Cmat3(nq,NCOL_CMAT3)
+#endif
+c
+      double precision tol_rho, pi, mu, alpha, beta, zeta
+      double precision ckf, Ax
+      double precision F43, F13, F23, F49
+c
+      parameter(mu=0.2195149727645171d0, beta=0.01808569669d0)
+      parameter(zeta=0.30412141859531383d0)
+
+      parameter (F43=4.d0/3.d0, F13=1.d0/3.d0, F23=2.0d0/3.0d0)
+      parameter (F49=4d0/9d0)
+c
+      integer n
+      double precision rrho, rho43, rho13, gamma, gam12, s, s2, d1s
+      double precision arcsinh, darcsinh, d2arcsinh, d3arcsinh
+      double precision Fx, dFx, d2Fx, d3Fx
+      double precision tansin, dtansin
+      double precision factor, dfactor
+      double precision asymp, dasymp
+      double precision denom, ddenom
+
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+      double precision d2denom, d2asymp, d2tansin, d2factor, d2s, rhom23
+#endif
+#if defined(THIRD_DERIV)
+      double precision d3denom, d3asymp, d3tansin, d3factor, d3s, rhom53
+#endif
+      double precision ops, omz, logops
+
+      arcsinh(s)=dlog(s+dsqrt(1d0+s*s))
+      darcsinh(s)=1d0/dsqrt(1d0+s*s)
+      d2arcsinh(s) = -s/dsqrt(1d0+s*s)**3
+      d3arcsinh(s) = (2d0*s*s - 1d0)/dsqrt(1d0+s*s)**5
+c
+      pi = acos(-1.d0)
+      ckf = (3d0*pi*pi)**F13
+      Ax = -3d0/(4d0*pi)*ckf
+      alpha = 4d0*pi/3d0*beta/mu
+c
+      if (ipol.eq.1 )then
+c
+c        ======> SPIN-RESTRICTED <======
+c
+#ifdef IFCV81
+CDEC$ NOSWP
+#endif
+         do 10 n = 1, nq
+            if (rho(n,1).lt.tol_rho) goto 10
+            rho43 = rho(n,1)**F43
+            rrho = 1d0/rho(n,1)
+            rho13 = rho43*rrho
+            gamma = delrho(n,1,1)*delrho(n,1,1) +
+     &              delrho(n,2,1)*delrho(n,2,1) +
+     &              delrho(n,3,1)*delrho(n,3,1)
+            if (dsqrt(gamma).le.tol_rho**2) goto 10
+
+            s = dsqrt(gamma)/(2d0*ckf*rho43)
+            s2 = s*s
+
+            if (s.lt.1d-8) then
+               Fx = 1d0 + mu*s2 + alpha*zeta*mu*s2*s + 
+     &              mu*(alpha - beta - alpha*zeta - 0.5d0)*s2*s2
+               dFx = 2d0*mu*s + 3d0*alpha*zeta*mu*s2 +
+     &               4d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s2*s
+               d2Fx = 2d0*mu + 6d0*alpha*zeta*mu*s + 
+     &                12d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s2
+               d3Fx = 6d0*alpha*zeta*mu + 
+     &                24d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s
+            else
+              ops = 1d0 + s
+              omz = 1d0 - zeta
+              logops = dlog(ops)
+
+              asymp = 1d0 + alpha*(omz*s*logops + zeta*s)
+              dasymp = alpha*( (s + zeta)/ops + omz*logops )
+
+              if (s.gt.30d0) then
+                tansin = arcsinh(s)
+                dtansin = darcsinh(s)
+              else
+                tansin = dtanh(s)*arcsinh(s)
+                dtansin = arcsinh(s)/dcosh(s)**2 + dtanh(s)*darcsinh(s)
+              endif
+
+              denom = 1d0 + beta*tansin
+              ddenom = beta*dtansin
+
+              factor = tansin/denom
+              dfactor = (dtansin - factor*ddenom)/denom
+
+              Fx = 1d0 + mu*factor*asymp
+              dFx = mu*(dfactor*asymp + factor*dasymp)
+
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+              if (s.gt.30d0) then
+                d2tansin = d2arcsinh(s)
+              else
+                d2tansin = 2d0*darcsinh(s)/dcosh(s)**2 +
+     &                     dtanh(s)*d2arcsinh(s) -
+     &                     2d0*tansin/dcosh(s)**2
+              endif
+              d2asymp = alpha*omz*(2d0 + s)/ops**2
+              d2denom = beta*d2tansin
+              d2factor = (d2tansin - 2d0*dfactor*ddenom -
+     &                    factor*d2denom)/denom
+              d2Fx = mu*(d2factor*asymp + 2d0*dfactor*dasymp +
+     &                   factor*d2asymp)
+
+#endif
+#if defined(THIRD_DERIV)
+              if (s.gt.30d0) then
+                d3tansin = d3arcsinh(s)
+              else
+                d3tansin = 3d0*d2arcsinh(s)/dcosh(s)**2 - 
+     &                     4d0*darcsinh(s)*dtanh(s)/dcosh(s)**2 + 
+     &                     dtanh(s)*d3arcsinh(s) -
+     &                     2d0*dtansin/dcosh(s)**2 +
+     &                     4d0*tansin*dtanh(s)/dcosh(s)**2
+              endif
+              d3asymp = -alpha*omz*(3d0 + s)/ops**3
+              d3denom = beta*d3tansin
+              d3factor = (d3tansin - 3d0*d2factor*ddenom -
+     &                    3d0*dfactor*d2denom - factor*d3denom)/denom
+              d3Fx = mu*(d3factor*asymp + 3d0*d2factor*dasymp +
+     &                   3d0*dfactor*d2asymp + factor*d3asymp)
+#endif
+            endif
+
+            Ex = Ex + Ax*rho43*Fx*qwght(n)*fac
+            if (ldew) func(n) = func(n) + Ax*rho43*Fx*fac
+
+            d1s = 0.5d0*s/gamma
+            Amat(n,1) = Amat(n,1) + F43*Ax*rho13*(Fx - s*dFx)*fac
+            Cmat(n,D1_GAA) = Cmat(n,D1_GAA) + 2d0*Ax*rho43*dFx*d1s*fac
+
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+
+            d2s = -0.5d0*d1s/gamma
+            rhom23 = rho13*rrho
+            Amat2(n,D2_RA_RA) = Amat2(n,D2_RA_RA) + 2d0*F49*Ax*rhom23*
+     &                          (Fx - s*dFx + 4d0*s2*d2Fx)*fac
+
+            Cmat2(n,D2_RA_GAA) = Cmat2(n,D2_RA_GAA) -
+     &                           (F43*Ax*rho13*d2Fx*d1s*s)*4d0*fac
+
+            Cmat2(n,D2_GAA_GAA) = Cmat2(n,D2_GAA_GAA) + Ax*rho43*
+     &                            (d2Fx*d1s**2 + dFx*d2s)*8d0*fac
+#endif
+#ifdef THIRD_DERIV
+            rhom53 = rhom23*rrho
+            d3s = -1.5d0*d2s/gamma
+
+            Amat3(n,D3_RA_RA_RA) = Amat3(n,D3_RA_RA_RA) - 4d0*fac*
+     &      F23*F49*Ax*rhom53*(Fx - s*dFx + 18d0*s2*d2Fx +8d0*s2*s*d3Fx)
+
+            Cmat3(n,D3_RA_RA_GAA) = Cmat3(n,D3_RA_RA_GAA) +
+     &      F49*Ax*rhom23*d1s*s*(7d0*d2Fx + 4d0*d3Fx*s)*8d0*fac
+
+            Cmat3(n,D3_RA_GAA_GAA) = Cmat3(n,D3_RA_GAA_GAA) -
+     &      F43*Ax*rho13*(d2Fx*d1s**2 + d3Fx*d1s**2*s +
+     &                     d2Fx*d2s*s)*16d0*fac
+
+            Cmat3(n,D3_GAA_GAA_GAA) = Cmat3(n,D3_GAA_GAA_GAA) +
+     &      Ax*rho43*(d3Fx*d1s**3 + 3d0*d2Fx*d1s*d2s +
+     &                dFx*d3s)*32d0*fac
+
+#endif
+ 10      continue
+c
+      else
+c
+c        ======> SPIN-UNRESTRICTED <======
+c
+#ifdef IFCV81
+CDEC$ NOSWP
+#endif
+         do 20 n = 1, nq
+            if (rho(n,1).lt.tol_rho) goto 20
+c
+c     Alpha
+c
+            if (rho(n,2).lt.tol_rho) goto 25
+            rho43 = (2d0*rho(n,2))**F43
+            rrho = 0.5d0/rho(n,2)
+            rho13 = rho43*rrho
+c
+            gamma = delrho(n,1,1)*delrho(n,1,1) +
+     &              delrho(n,2,1)*delrho(n,2,1) +
+     &              delrho(n,3,1)*delrho(n,3,1)
+            gam12 = 2d0*dsqrt(gamma)
+            if (gam12.le.tol_rho**2) goto 25
+c
+            s = gam12/(2d0*ckf*rho43)
+            s2 = s*s
+
+            d1s = 0.5d0*s/gamma
+
+            if (s.lt.1d-8) then
+               Fx = 1d0 + mu*s2 + alpha*zeta*mu*s2*s + 
+     &              mu*(alpha - beta - alpha*zeta - 0.5d0)*s2*s2
+               dFx = 2d0*mu*s + 3d0*alpha*zeta*mu*s2 +
+     &               4d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s2*s
+               d2Fx = 2d0*mu + 6d0*alpha*zeta*mu*s + 
+     &                12d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s2
+               d3Fx = 6d0*alpha*zeta*mu + 
+     &                24d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s
+            else
+              ops = 1d0 + s
+              omz = 1d0 - zeta
+              logops = dlog(ops)
+
+              asymp = 1d0 + alpha*(omz*s*logops + zeta*s)
+              dasymp = alpha*( (s + zeta)/ops + omz*logops )
+
+              if (s.gt.30d0) then
+                tansin = arcsinh(s)
+                dtansin = darcsinh(s)
+              else
+                tansin = dtanh(s)*arcsinh(s)
+                dtansin = arcsinh(s)/dcosh(s)**2 + dtanh(s)*darcsinh(s)
+              endif
+
+              denom = 1d0 + beta*tansin
+              ddenom = beta*dtansin
+
+              factor = tansin/denom
+              dfactor = (dtansin - factor*ddenom)/denom
+
+              Fx = 1d0 + mu*factor*asymp
+              dFx = mu*(dfactor*asymp + factor*dasymp)
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+              if (s.gt.30d0) then
+                d2tansin = d2arcsinh(s)
+              else
+                d2tansin = 2d0*darcsinh(s)/dcosh(s)**2 +
+     &                     dtanh(s)*d2arcsinh(s) -
+     &                     2d0*tansin/dcosh(s)**2
+              endif
+              d2asymp = alpha*omz*(2d0 + s)/ops**2
+              d2denom = beta*d2tansin
+              d2factor = (d2tansin - 2d0*dfactor*ddenom -
+     &                    factor*d2denom)/denom
+              d2Fx = mu*(d2factor*asymp + 2d0*dfactor*dasymp +
+     &                   factor*d2asymp)
+#endif
+#if defined(THIRD_DERIV)
+              if (s.gt.30d0) then
+                d3tansin = d3arcsinh(s)
+              else
+                d3tansin = 3d0*d2arcsinh(s)/dcosh(s)**2 - 
+     &                     4d0*darcsinh(s)*dtanh(s)/dcosh(s)**2 + 
+     &                     dtanh(s)*d3arcsinh(s) -
+     &                     2d0*dtansin/dcosh(s)**2 +
+     &                     4d0*tansin*dtanh(s)/dcosh(s)**2
+              endif
+              d3asymp = -alpha*omz*(3d0 + s)/ops**3
+              d3denom = beta*d3tansin
+              d3factor = (d3tansin - 3d0*d2factor*ddenom -
+     &                    3d0*dfactor*d2denom - factor*d3denom)/denom
+              d3Fx = mu*(d3factor*asymp + 3d0*d2factor*dasymp +
+     &                   3d0*dfactor*d2asymp + factor*d3asymp)
+#endif
+            endif
+
+            Ex = Ex + 0.5d0*Ax*rho43*Fx*qwght(n)*fac
+            if (ldew) func(n) = func(n) + 0.5d0*Ax*rho43*Fx*fac
+
+            Amat(n,1) = Amat(n,1) + F43*Ax*rho13*(Fx - s*dFx)*fac
+            Cmat(n,D1_GAA) = Cmat(n,D1_GAA) +
+     &                       0.5d0*Ax*rho43*dFx*d1s*fac
+
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+            d2s = -0.5d0*d1s/gamma
+            rhom23 = rho13*rrho
+            Amat2(n,D2_RA_RA) = Amat2(n,D2_RA_RA) + 2d0*F49*Ax*rhom23*
+     &                          (Fx - s*dFx + 4d0*s2*d2Fx)*fac
+
+            Cmat2(n,D2_RA_GAA) = Cmat2(n,D2_RA_GAA) -
+     &                           (F43*Ax*rho13*d2Fx*d1s*s)*fac
+
+            Cmat2(n,D2_GAA_GAA) = Cmat2(n,D2_GAA_GAA) + fac*Ax*rho43*
+     &                            (d2Fx*d1s**2 + dFx*d2s)*0.5d0
+#endif
+#ifdef THIRD_DERIV
+            rhom53 = rhom23*rrho
+            d3s = -1.5d0*d2s/gamma
+
+            Amat3(n,D3_RA_RA_RA) = Amat3(n,D3_RA_RA_RA) - 4d0*fac*
+     &      F23*F49*Ax*rhom53*(Fx - s*dFx + 18d0*s2*d2Fx +8d0*s2*s*d3Fx)
+
+            Cmat3(n,D3_RA_RA_GAA) = Cmat3(n,D3_RA_RA_GAA) +
+     &      F49*Ax*rhom23*d1s*s*(7d0*d2Fx + 4d0*d3Fx*s)*2d0*fac
+
+            Cmat3(n,D3_RA_GAA_GAA) = Cmat3(n,D3_RA_GAA_GAA) -
+     &      F43*Ax*rho13*(d2Fx*d1s**2 + d3Fx*d1s**2*s +
+     &                     d2Fx*d2s*s)*fac
+
+            Cmat3(n,D3_GAA_GAA_GAA) = Cmat3(n,D3_GAA_GAA_GAA) +
+     &      Ax*rho43*(d3Fx*d1s**3 + 3d0*d2Fx*d1s*d2s +
+     &                dFx*d3s)*0.5d0*fac
+
+#endif
+c
+c     Beta
+c
+ 25         continue
+            if (rho(n,3).lt.tol_rho) goto 20
+            rho43 = (2d0*rho(n,3))**F43
+            rrho = 0.5d0/rho(n,3)
+            rho13 = rho43*rrho
+c
+            gamma = delrho(n,1,2)*delrho(n,1,2) +
+     &              delrho(n,2,2)*delrho(n,2,2) +
+     &              delrho(n,3,2)*delrho(n,3,2)
+            gam12 = 2d0*dsqrt(gamma)
+            if (gam12.le.tol_rho**2) goto 20
+c
+            s = gam12/(2d0*ckf*rho43)
+            s2 = s*s
+
+            d1s = 0.5d0*s/gamma
+
+            if (s.lt.1d-8) then
+               Fx = 1d0 + mu*s2 + alpha*zeta*mu*s2*s + 
+     &              mu*(alpha - beta - alpha*zeta - 0.5d0)*s2*s2
+               dFx = 2d0*mu*s + 3d0*alpha*zeta*mu*s2 +
+     &               4d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s2*s
+               d2Fx = 2d0*mu + 6d0*alpha*zeta*mu*s + 
+     &                12d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s2
+               d3Fx = 6d0*alpha*zeta*mu + 
+     &                24d0*mu*(alpha - beta - alpha*zeta - 0.5d0)*s
+            else
+              ops = 1d0 + s
+              omz = 1d0 - zeta
+              logops = dlog(ops)
+
+              asymp = 1d0 + alpha*(omz*s*logops + zeta*s)
+              dasymp = alpha*( (s + zeta)/ops + omz*logops )
+
+              if (s.gt.30d0) then
+                tansin = arcsinh(s)
+                dtansin = darcsinh(s)
+              else
+                tansin = dtanh(s)*arcsinh(s)
+                dtansin = arcsinh(s)/dcosh(s)**2 + dtanh(s)*darcsinh(s)
+              endif
+
+              denom = 1d0 + beta*tansin
+              ddenom = beta*dtansin
+
+              factor = tansin/denom
+              dfactor = (dtansin - factor*ddenom)/denom
+
+              Fx = 1d0 + mu*factor*asymp
+              dFx = mu*(dfactor*asymp + factor*dasymp)
+
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+              if (s.gt.30d0) then
+                d2tansin = d2arcsinh(s)
+              else
+                d2tansin = 2d0*darcsinh(s)/dcosh(s)**2 +
+     &                     dtanh(s)*d2arcsinh(s) -
+     &                     2d0*tansin/dcosh(s)**2
+              endif
+              d2asymp = alpha*omz*(2d0 + s)/ops**2
+              d2denom = beta*d2tansin
+              d2factor = (d2tansin - 2d0*dfactor*ddenom -
+     &                    factor*d2denom)/denom
+              d2Fx = mu*(d2factor*asymp + 2d0*dfactor*dasymp +
+     &                   factor*d2asymp)
+#endif
+#if defined(THIRD_DERIV)
+
+              if (s.gt.30d0) then
+                d3tansin = d3arcsinh(s)
+              else
+                d3tansin = 3d0*d2arcsinh(s)/dcosh(s)**2 - 
+     &                     4d0*darcsinh(s)*dtanh(s)/dcosh(s)**2 + 
+     &                     dtanh(s)*d3arcsinh(s) -
+     &                     2d0*dtansin/dcosh(s)**2 +
+     &                     4d0*tansin*dtanh(s)/dcosh(s)**2
+              endif
+              d3asymp = -alpha*omz*(3d0 + s)/ops**3
+              d3denom = beta*d3tansin
+              d3factor = (d3tansin - 3d0*d2factor*ddenom -
+     &                    3d0*dfactor*d2denom - factor*d3denom)/denom
+              d3Fx = mu*(d3factor*asymp + 3d0*d2factor*dasymp +
+     &                   3d0*dfactor*d2asymp + factor*d3asymp)
+#endif
+            endif
+
+            Ex = Ex + 0.5d0*Ax*rho43*Fx*qwght(n)*fac
+            if (ldew) func(n) = func(n) + 0.5d0*Ax*rho43*Fx*fac
+
+            Amat(n,2) = Amat(n,2) + F43*Ax*rho13*(Fx - s*dFx)*fac
+            Cmat(n,D1_GBB) = Cmat(n,D1_GBB) + 0.5d0*Ax*rho43*dFx*d1s*fac
+
+#if defined(SECOND_DERIV) || defined(THIRD_DERIV)
+            d2s = -0.5d0*d1s/gamma
+            rhom23 = rho13*rrho
+            Amat2(n,D2_RB_RB) = Amat2(n,D2_RB_RB) + 2d0*F49*Ax*rhom23*
+     &                          (Fx - s*dFx + 4d0*s2*d2Fx)*fac
+
+            Cmat2(n,D2_RB_GBB) = Cmat2(n,D2_RB_GBB) -
+     &                           (F43*Ax*rho13*d2Fx*d1s*s)*fac
+
+            Cmat2(n,D2_GBB_GBB) = Cmat2(n,D2_GBB_GBB) + fac*Ax*rho43*
+     &                            (d2Fx*d1s**2 + dFx*d2s)*0.5d0
+#endif
+#ifdef THIRD_DERIV
+            rhom53 = rhom23*rrho
+            d3s = -1.5d0*d2s/gamma
+
+            Amat3(n,D3_RB_RB_RB) = Amat3(n,D3_RB_RB_RB) - 4d0*fac*
+     &      F23*F49*Ax*rhom53*(Fx - s*dFx + 18d0*s2*d2Fx +8d0*s2*s*d3Fx)
+
+            Cmat3(n,D3_RB_RB_GBB) = Cmat3(n,D3_RB_RB_GBB) +
+     &      F49*Ax*rhom23*d1s*s*(7d0*d2Fx + 4d0*d3Fx*s)*2d0*fac
+
+            Cmat3(n,D3_RB_GBB_GBB) = Cmat3(n,D3_RB_GBB_GBB) -
+     &      F43*Ax*rho13*(d2Fx*d1s**2 + d3Fx*d1s**2*s +
+     &                     d2Fx*d2s*s)*fac
+
+            Cmat3(n,D3_GBB_GBB_GBB) = Cmat3(n,D3_GBB_GBB_GBB) +
+     &      Ax*rho43*(d3Fx*d1s**3 + 3d0*d2Fx*d1s*d2s +
+     &                dFx*d3s)*0.5d0*fac
+#endif
+c
+ 20      continue
+      endif
+c
+      return
+      end
+#ifndef SECOND_DERIV
+#define SECOND_DERIV
+c
+c     Compile source again for the 2nd derivative case
+c
+#include "xc_xncap.F"
+#endif
+#ifndef THIRD_DERIV
+#define THIRD_DERIV
+c
+c     Compile source again for the 3rd derivative case
+c
+#include "xc_xncap.F"
+#endif
+c $Id$

--- a/src/nwdft/xc/xc_xscan.F
+++ b/src/nwdft/xc/xc_xscan.F
@@ -29,11 +29,13 @@ c     J. Sun, A. Ruzsinszky, J.P. Perdew
 c     PRL 115, 036402 (2015)
 c     DOI: 10.1103/PhysRevLett.115036402
 
-      Subroutine xc_xscan(tol_rho, fac,  rho, delrho, 
+      Subroutine xc_xscan(whichfx, tol_rho, fac,  rho, delrho, 
      &                    Amat, Cmat, nq, ipol, Ex, 
      &                    qwght, ldew, func, tau,Mmat)
       implicit none
-c      
+c
+      character*(*) whichfx
+c
       double precision fac, Ex
       integer nq, ipol
       logical ldew
@@ -67,7 +69,7 @@ c
 c     SPIN-RESTRICTED
 c     Ex = Ex[n]
 c
-         call xc_xscan_cs(tol_rho, fac,  rho, delrho, 
+         call xc_xscan_cs(whichfx, tol_rho, fac,  rho, delrho, 
      &                    Amat, Cmat, nq, Ex, 1d0,
      &                    qwght, ldew, func, tau,Mmat)
       else
@@ -78,7 +80,7 @@ c     Ex = Ex[2n_up]/2 + Ex[2n_down]/2
          do ispin=1,2
             if (ispin.eq.1) cmatpos=D1_GAA
             if (ispin.eq.2) cmatpos=D1_GBB
-            call xc_xscan_cs(tol_rho, fac,  
+            call xc_xscan_cs(whichfx, tol_rho, fac,  
      R           rho(1,ispin+1), delrho(1,1,ispin), 
      &           Amat(1,ispin), Cmat(1,cmatpos), 
      &           nq, Ex, 2d0,
@@ -89,11 +91,12 @@ c     Ex = Ex[2n_up]/2 + Ex[2n_down]/2
       endif
       return
       end
-      Subroutine xc_xscan_cs(tol_rho, fac,  rho, delrho, 
+      Subroutine xc_xscan_cs(whichfx, tol_rho, fac,  rho, delrho, 
      &                     Amat, Cmat, nq, Ex, facttwo,
      &                     qwght, ldew, func, tau,Mmat)
       implicit none
-c      
+c
+      character*(*) whichfx
       double precision fac, Ex
       integer nq
       logical ldew
@@ -121,7 +124,7 @@ c
 c
       double precision facttwo, afact2 ! 2 for o.s. 1 for c.s.
 c
-      integer n
+      integer n, ifx
       double precision tol_rho, pi
       double precision rhoval, rrho, rho13, rho43, rho83
       double precision tauN, tauW, tauU
@@ -134,6 +137,8 @@ c
 
       double precision oma, oma2
       double precision exp1, exp2, exp3, exp4, exp5
+      double precision rtemp(0:7), rRegu(0:7), rRegu1(7)
+      double precision regalpha, dregalpha
       double precision x1, x2, x
       double precision H, Hden, Hnum
       double precision G
@@ -164,6 +169,15 @@ c     functional derivatives above FFFFFFFFFFFF
       parameter (rD=1.24d0)
       parameter (rMu=10.0d0/81.0d0)
       parameter (rB3=0.5d0)
+
+      parameter (rRegu = (/ 1d0, -0.667d0, -0.4445555d0, 
+     &                    -6.63086601049291d-1, 1.45129704448975d0,
+     &                    -8.87998041596655d-1, 2.34528941478571d-1,
+     &                    -2.31858433223407d-2/) )
+      parameter (rRegu1 = (/ -0.667d0, -2d0*0.4445555d0,
+     &             -3d0*6.63086601049291d-1, 4d0*1.45129704448975d0,
+     &             -5d0*8.87998041596655d-1, 6d0*2.34528941478571d-1,
+     &             -7d0*2.31858433223407d-2/) )
 
       rB2=dsqrt(5913.d0/405000.d0)
       rB1=(511.d0/13500.d0)/(2.d0*rB2)
@@ -201,7 +215,15 @@ c
 c
             a=(tauN-tauW)/tauU
             if(a.lt.0d0)  a=0d0
-            oma = 1d0 - a
+            if (whichfx.eq.'orig') then
+              regalpha = a
+              dregalpha = 1d0
+            else if (whichfx.eq.'regu') then
+              regalpha = a**3/(a**2 + 1d-3)
+              dregalpha = a/(a**2+1d-3)*(3d0*a - 2d0*regalpha)
+            endif
+
+            oma = 1d0 - regalpha
             oma2 = oma*oma
             
             exp1 = dexp(-rB4/rMu*p)
@@ -222,19 +244,33 @@ c
             endif
             G = 1d0 - exp3
 
-            if (a.ge.thr1) then
-              exp4 = 0d0
-            else
-              exp4 = dexp(-rC1*a/oma)
+c
+c Switching function
+c
+            if (whichfx.eq.'orig') then
+              if (regalpha.ge.thr1) then
+                exp4 = 0d0
+              else
+                exp4 = dexp(-rC1*regalpha/oma)
+              end if
+              if (regalpha.le.thr2) then
+                exp5 = 0d0
+              else
+                exp5 = dexp(rC2/oma)
+              end if
+              Fa = exp4 - rD*exp5
+            else if (whichfx.eq.'regu') then
+              if (regalpha.lt.2.5d0) then
+                rtemp(0) = 1d0
+                do ifx=1,7
+                  rtemp(ifx) = rtemp(ifx-1)*regalpha
+                enddo
+                Fa = dot_product(rRegu,rtemp)
+              else
+                exp5 = dexp(rC2/oma)
+                Fa = -rD*exp5
+              end if
             end if
-
-            if (a.le.thr2) then
-              exp5 = 0d0
-            else
-              exp5 = dexp(rC2/oma)
-            end if
-
-            Fa = exp4 - rD*exp5
 
             Fx = G*(H + Fa*(rH0 - H))
 
@@ -259,17 +295,28 @@ c     functional derivatives FFFFFFFFFFFFFFFFFFFFFFFFFFFF
             dx1dp = rMu + rB4*p*exp1*(2d0 - p*rB4/rMu)
             dx2dp = rB1
             dxdp = dx1dp + 2d0*x2*dx2dp
-            dxda = 2d0*rB2*exp2*x2*(2d0*rB3*oma2 - 1d0)
+            dxda = 2d0*rB2*exp2*x2*(2d0*rB3*oma2 - 1d0)*dregalpha
 
             dHdx = (rK1/Hden)**2
             dHdp = dHdx*dxdp
             dHda = dHdx*dxda
 
-            if ((a.ge.thr1).and.(a.le.thr2)) then
-              dFada = 0d0
-            else
-              dFada = -(rC1*exp4 + rD*exp5*rC2)/oma2
-            end if
+c
+c Switching function
+c
+            if (whichfx.eq.'orig') then
+              if ((regalpha.ge.thr1).and.(regalpha.le.thr2)) then
+                dFada = 0d0
+              else
+                dFada = -(rC1*exp4 + rD*exp5*rC2)/oma2
+              end if
+            else if (whichfx.eq.'regu') then
+              if (regalpha.lt.2.5d0) then
+                dFada = dot_product(rRegu1,rtemp(0:6))*dregalpha
+              else
+                dFada = -rD*exp5*rC2/oma2*dregalpha
+              endif
+            endif
 
             dFxdp = dGdp*(H + Fa*(rH0 - H)) + G*dHdp*(1d0 - Fa)
             dFxda = G*(dHda + dFada*(rH0 - H) - Fa*dHda)


### PR DESCRIPTION
This patch adds NCAP [[J. Chem. Theory Comput. *15*, 303 (2019)]](https://pubs.acs.org/doi/abs/10.1021/acs.jctc.8b00998) and regularized SCAN [[J. Chem. Phys. *150*, 161101 (2019)]](https://aip.scitation.org/doi/abs/10.1063/1.5094646) exchange correlation functionals (options `ncap` and `regscan`, respectively, of the `xc` keyword). Third-order derivatives are available for NCAP.

The new keyword `NCAPDD`, when supplied with a real value (meant to be the HOMO eigenvalue of a previous run) will add the constant shift given in equation (12) of the NCAP manuscript. If no value is specified, the same equation (12) will be used with the *current* HOMO eigenvalue during the SCF (similar to the Zhan, Nichols and Dixon case for the `CS00` keyword).