### PR TITLE
Bugfix for issue #153

### DIFF
--- a/src/tce/include/offl.fh
+++ b/src/tce/include/offl.fh
@@ -4,4 +4,14 @@ C$Id$
 CCC#define ASYNC 1
 c k_a_sort t2sub
 c k_b_sort v2sub
-      integer	triplesx_mxlgth
+      logical triplesx_alloced
+      logical triplesx1_alloced
+      logical t1sub_alloced
+      logical t2sub_alloced
+      logical v2sub_alloced
+      logical triplesx_copyback
+      integer   triplesx_mxlgth
+      common /offl_ccsdt/triplesx_alloced,
+     1 t1sub_alloced,
+     1 t2sub_alloced,
+     1 v2sub_alloced,triplesx_copyback


### PR DESCRIPTION
While working on the new offload code for TCE CCSD(T), I have
removed some of the global variables that aparentely are being
used for MRCC.  This commit reverts these changes and brings
the code back to a compilable state.