### PR TITLE
Rename ase_client -> ipi_client

### DIFF
--- a/src/driver/driver_input.F
+++ b/src/driver/driver_input.F
@@ -98,7 +98,7 @@ c
      $                      mt_log,1,diagh))
      $        call errquit('driver_input: rtdb put failed',0, RTDB_ERR)
 c
-c socket ase_client ip:port
+c socket ipi_client ip:port
 c
       else if (inp_compare(.false.,'socket', field)) then
          if (inp_a(f2)) then

--- a/src/driver/socket_driver.F
+++ b/src/driver/socket_driver.F
@@ -90,7 +90,7 @@
 
       if (taskid.eq.MASTER) then
          write(luout,*)
-         write(luout,*) "== ASE TCP Socket Client Driver =="
+         write(luout,*) "== i-PI TCP Socket Client Driver =="
          write(luout,'(" Connected to    = ",A)') socket_ip
          write(luout,'(" Number of atoms =",I8)') nion
          write(luout,*)
@@ -157,7 +157,7 @@
             iter = iter + 1
             if (taskid.eq.MASTER) then
                write(luout,*)
-               write(luout,*) "== ASE TCP Socket Client Computation =="
+               write(luout,*) "== i-PI TCP Socket Client Computation =="
                write(luout,'(" Connected to    = ",A)') socket_ip
                write(luout,'(" Number of atoms =",I8, 
      >                       " (natoms last read =",I8,")")') nion,nion0

--- a/src/nwpw/nwpw_input.F
+++ b/src/nwpw/nwpw_input.F
@@ -2075,7 +2075,7 @@ c
       goto 10
 
 c
-c socket ase_client ip:port
+c socket ipi_client ip:port
 c
  8900 if (inp_a(zone_name)) then
          move = nwpw_parse_boolean(zone_name,.true.)

--- a/src/nwpw/nwpwlib/control/control.F
+++ b/src/nwpw/nwpwlib/control/control.F
@@ -6685,7 +6685,7 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       value = .false.
       call control_socket_type(stype)
-      if (inp_compare(.false.,'ase_client',stype)) value = .true.
+      if (inp_compare(.false.,'ipi_client',stype)) value = .true.
 
       control_runsocket = value
       return

--- a/src/nwpw/pspw/cpsd/runsocket.F
+++ b/src/nwpw/pspw/cpsd/runsocket.F
@@ -117,7 +117,7 @@
 
             if (taskid.eq.MASTER) then
                it = it + 1
-               write(*,*) "== ASE TCP Socket Client Computation =="
+               write(*,*) "== i-PI TCP Socket Client Computation =="
                write(*,'(" Connected to   = ",A)') ipport
                write(*,'(" Iteration      =",I8)') it
                write(*,'(" Iteration Time =",F8.3," seconds")')cpu2-cpu1


### PR DESCRIPTION
This PR changes two comments and only a single line of actual code. The initial Socket implementation by @ebylaska used the keyword `ase_client`, though it should be named `ipi_client`, because the communication protocol was originally developed by the [i-Pi project](https://github.com/i-pi/i-pi).

Edit: I missed some printed references to ASE in my initial commit. The printed output now also refers to i-PI instead.