### PR TITLE
Add support for i-PI communication over UNIX sockets

### DIFF
--- a/src/driver/driver_input.F
+++ b/src/driver/driver_input.F
@@ -98,7 +98,7 @@ c
      $                      mt_log,1,diagh))
      $        call errquit('driver_input: rtdb put failed',0, RTDB_ERR)
 c
-c socket ase_client ip:port
+c socket ipi_client ip:port
 c
       else if (inp_compare(.false.,'socket', field)) then
          if (inp_a(f2)) then

--- a/src/driver/socket_driver.F
+++ b/src/driver/socket_driver.F
@@ -102,7 +102,7 @@
 
       if (taskid.eq.MASTER) then
          write(luout,*)
-         write(luout,*) "== i-PI TCP Socket Client Driver =="
+         write(luout,*) "== i-PI Socket Client Driver =="
          write(luout,'(" Connected to    = ",A)') socket_ip
          write(luout,'(" Number of atoms =",I8)') nion
          write(luout,*)
@@ -169,7 +169,7 @@
             iter = iter + 1
             if (taskid.eq.MASTER) then
                write(luout,*)
-               write(luout,*) "== i-PI TCP Socket Client Computation =="
+               write(luout,*) "== i-PI Socket Client Computation =="
                write(luout,'(" Connected to    = ",A)') socket_ip
                write(luout,'(" Number of atoms =",I8, 
      >                       " (natoms last read =",I8,")")') nion,nion0

--- a/src/driver/socket_driver.F
+++ b/src/driver/socket_driver.F
@@ -20,7 +20,7 @@
       character*80 statebuffer
       character*80 buffer
       character*20 msg,ip,pp,bead_list,geom_name
-      integer ii,it,port,iter,n1,n2
+      integer ii,it,port,iter,n1,n2,inet
       integer option,tmpint,nbytes,sock
       integer rion(2),fion(2),nion,nion0
       real*8 unita(3,3),invunita(3,3),stress(3,3),energy
@@ -70,19 +70,31 @@
      >  call errquit('driver_input: rtdb get failed',7,RTDB_ERR)
 
       if (.not.rtdb_cget(rtdb,'driver:socket_ip',1,socket_ip)) then
-         socket_ip = "127.0.0.1:31415"
+          if (inp_compare(.false.,stype,'unix')) then
+             socket_ip = "nwchem"
+         else
+             socket_ip = "127.0.0.1:31415"
+         end if
       end if
       
-      ii = index(socket_ip,':')
-      it = index(socket_ip,' ') - 1
-      pp(1:it-ii) = socket_ip(ii+1:it)
-      pp(it-ii+1:it-ii+5) = '    '
-      read(pp,*,err=300) port
-      go to 301
- 300  port = 31415
- 301  continue
-      ip(1:ii-1) = socket_ip(1:ii-1)
-      ip(ii:ii+4) = "    "
+      if (inp_compare(.false.,stype,'unix')) then
+          ip = socket_ip
+          inet = 0
+          ii = index(socket_ip,' ')
+          port = 0
+      else
+          inet = 1
+          ii = index(socket_ip,':')
+          it = index(socket_ip,' ') - 1
+          pp(1:it-ii) = socket_ip(ii+1:it)
+          pp(it-ii+1:it-ii+5) = '    '
+          read(pp,*,err=300) port
+          go to 301
+ 300      port = 31415
+ 301      continue
+          ip(1:ii-1) = socket_ip(1:ii-1)
+          ip(ii:ii+4) = "    "
+      end if
 
       taskid = ga_nodeid()
 
@@ -94,7 +106,7 @@
          write(luout,'(" Connected to    = ",A)') socket_ip
          write(luout,'(" Number of atoms =",I8)') nion
          write(luout,*)
-         call util_talker(ip,ii-1,port,sock)
+         call util_talker(ip,inet,ii-1,port,sock)
          write(luout,*)
          !call nwpw_talker("127.0.0.1",9,port,sock)
       end if

--- a/src/driver/socket_driver.F
+++ b/src/driver/socket_driver.F
@@ -90,7 +90,7 @@
 
       if (taskid.eq.MASTER) then
          write(luout,*)
-         write(luout,*) "== ASE TCP Socket Client Driver =="
+         write(luout,*) "== i-PI TCP Socket Client Driver =="
          write(luout,'(" Connected to    = ",A)') socket_ip
          write(luout,'(" Number of atoms =",I8)') nion
          write(luout,*)
@@ -157,7 +157,7 @@
             iter = iter + 1
             if (taskid.eq.MASTER) then
                write(luout,*)
-               write(luout,*) "== ASE TCP Socket Client Computation =="
+               write(luout,*) "== i-PI TCP Socket Client Computation =="
                write(luout,'(" Connected to    = ",A)') socket_ip
                write(luout,'(" Number of atoms =",I8, 
      >                       " (natoms last read =",I8,")")') nion,nion0

--- a/src/nwpw/nwpw_input.F
+++ b/src/nwpw/nwpw_input.F
@@ -2075,7 +2075,7 @@ c
       goto 10
 
 c
-c socket ase_client ip:port
+c socket ipi_client ip:port
 c
  8900 if (inp_a(zone_name)) then
          move = nwpw_parse_boolean(zone_name,.true.)

--- a/src/nwpw/nwpwlib/control/control.F
+++ b/src/nwpw/nwpwlib/control/control.F
@@ -6686,6 +6686,7 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       value = .false.
       call control_socket_type(stype)
       if (inp_compare(.false.,'ipi_client',stype)) value = .true.
+      if (inp_compare(.false.,'unix',stype)) value = .true.
 
       control_runsocket = value
       return
@@ -6720,20 +6721,27 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 *     *      control_socket_ip           *
 *     *                                  *
 *     ************************************
-      subroutine control_socket_ip(stype)
+      subroutine control_socket_ip(socket_ip)
       implicit none
-      character*(*) stype
+      character*(*) socket_ip
+      character*40 stype
 
 #include "control.fh"
 #include "btdb.fh"
+#include "inp.fh"
 
 *     **** control_rtdb common block ****
       integer rtdb
       common / control_rtdb1 / rtdb
 
       if (.not.btdb_cget(rtdb,'nwpw:socket_ip',
-     >                   1,stype)) then
-         stype = "127.0.0.1:31415"
+     >                   1,socket_ip)) then
+         call control_socket_type(stype)
+         if (inp_compare(.false.,'unix',stype)) then
+            socket_ip = "nwchem"
+         else
+            socket_ip = "127.0.0.1:31415"
+         end if
       end if
       return
       end

--- a/src/nwpw/nwpwlib/control/control.F
+++ b/src/nwpw/nwpwlib/control/control.F
@@ -6685,7 +6685,7 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       value = .false.
       call control_socket_type(stype)
-      if (inp_compare(.false.,'ase_client',stype)) value = .true.
+      if (inp_compare(.false.,'ipi_client',stype)) value = .true.
 
       control_runsocket = value
       return

--- a/src/nwpw/nwpwlib/utilities/nwpw_talker.c
+++ b/src/nwpw/nwpwlib/utilities/nwpw_talker.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #if !defined(__MINGW32__)
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -36,6 +37,7 @@
 void FATR nwpw_talker_
 #if defined(USE_FCD)
 ( const _fcd fcd_addr_name,
+ Integer *inet,
  Integer *n1,
  Integer *portin,
  Integer *sockout)
@@ -43,8 +45,9 @@ void FATR nwpw_talker_
     char *addr_name = _fcdtocp(fcd_addr_name);
 
 #else
-(addr_name,n1,portin,sockout)
+(addr_name,inet,n1,portin,sockout)
 char	addr_name[];
+Integer *inet;
 Integer	*n1;
 Integer *portin;
 Integer *sockout;
@@ -57,35 +60,58 @@ Integer *sockout;
         exit(1);
 #else
     int sock = 0, valread; 
-    struct sockaddr_in serv_addr; 
     int na   = ((int) *n1);
-    int port = ((int) *portin);
-    
+
     addr_name[na]   = 0;
     addr_name[na+1] = 0;
-    
-    printf("nwpw_talker: addr_name=%s\n",addr_name);
-    printf("nwpw_talker: port=%d\n",port);
 
-    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) 
-    { 
-        printf("\nnwpw_talker:Socket creation error \n"); 
-        exit(1);
-    } 
-    serv_addr.sin_family = AF_INET; 
-    serv_addr.sin_port = htons(port); 
+    if (*inet>0)
+    {
+        struct sockaddr_in serv_addr; 
+        int port = ((int) *portin);
+        
+        printf("nwpw_talker: addr_name=%s\n",addr_name);
+        printf("nwpw_talker: port=%d\n",port);
 
-    // Convert IPv4 and IPv6 addresses from text to binary form 
-    if(inet_pton(AF_INET, addr_name, &serv_addr.sin_addr)<=0)  
-    { 
-        printf("\nnwpw_talker:Invalid address/ Address not supported \n"); 
-        exit(1);
-    } 
-    if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) 
-    { 
-        printf("\nnwpw_talker:Connection Failed \n"); 
-        exit(1);
-    } 
+        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) 
+        { 
+            printf("\nnwpw_talker:Socket creation error \n"); 
+            exit(1);
+        } 
+        serv_addr.sin_family = AF_INET; 
+        serv_addr.sin_port = htons(port); 
+
+        // Convert IPv4 and IPv6 addresses from text to binary form 
+        if(inet_pton(AF_INET, addr_name, &serv_addr.sin_addr)<=0)  
+        { 
+            printf("\nnwpw_talker:Invalid address/ Address not supported \n"); 
+            exit(1);
+        } 
+        if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) 
+        { 
+            printf("\nnwpw_talker:Connection Failed \n"); 
+            exit(1);
+        } 
+    }
+    else
+    {
+        struct sockaddr_un serv_addr;
+        memset(&serv_addr, 0, sizeof(struct sockaddr_un));
+        serv_addr.sun_family = AF_UNIX;
+        strcpy(serv_addr.sun_path, "/tmp/ipi_");
+        strcpy(serv_addr.sun_path+9, addr_name);
+        if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
+        {
+            printf("\nnwpw_talker:Socket creation error \n");
+            exit(1);
+        }
+        if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+        {
+            printf("\nnwpw_talker:Failed to connect to UNIX socket \n");
+            exit(1);
+        }
+    }
+
     printf("nwpw_talker: sockid=%d\n",sock);
     *sockout = ((Integer) sock);
 #endif

--- a/src/nwpw/pspw/cgsd/cgsdv5.F
+++ b/src/nwpw/pspw/cgsd/cgsdv5.F
@@ -657,7 +657,7 @@ c     end if
 
 *     **** run socket client ****
       if (control_runsocket().and.(flag.gt.0)) then
-         call runsocket_ase(nion,EV,
+         call runsocket_ipi(nion,EV,
      >                      dbl_mb(ion_rion_ptr()),dbl_mb(fion(1)))
       end if
 

--- a/src/nwpw/pspw/cpsd/runsocket.F
+++ b/src/nwpw/pspw/cpsd/runsocket.F
@@ -3,7 +3,7 @@
          !call nwpw_talker_write(np_i,"hello world again ericdone",26)
          !call nwpw_talker_close(np_i)
 
-      subroutine runsocket_ase(nion,energy,rion,fion)
+      subroutine runsocket_ipi(nion,energy,rion,fion)
       implicit none
       integer nion
       real*8 energy
@@ -18,12 +18,12 @@
       parameter (MASTER=0)
 
       logical done
-      integer sock,nbytes,nion0,option,ii,it,port
+      integer sock,nbytes,nion0,option,ii,it,port,inet
       integer*4 tmpint
       real*8 cpu1,cpu2
 
       character*80 statebuffer
-      character*80 buffer,ipport
+      character*80 buffer,ipport,stype
       character*20 msg,ip,pp
 
 *     **** external functions ****
@@ -33,24 +33,32 @@
       real*8 unita(3,3),iunita(3,3),stress(3,3)
       real*8 rion0(3,20)
 
+      call control_socket_type(stype)
       call control_socket_ip(ipport)
-      ii = index(ipport,':')
-      it = index(ipport,' ') - 1
-      pp(1:it-ii) = ipport(ii+1:it)
-      pp(it-ii+1:it-ii+5) = '    '
-      read(pp,*,err=300) port
-      go to 301
- 300  port = 31415
- 301  continue
-      ip(1:ii-1) = ipport(1:ii-1)
-      ip(ii:ii+4) = "    "
+      if (inp_compare(.false.,stype,'unix')) then
+         ip = ipport
+         inet = 0
+         ii = index(ipport,' ')
+         port = 0
+      else
+         ii = index(ipport,':')
+         it = index(ipport,' ') - 1
+         pp(1:it-ii) = ipport(ii+1:it)
+         pp(it-ii+1:it-ii+5) = '    '
+         read(pp,*,err=300) port
+         go to 301
+ 300     port = 31415
+ 301     continue
+         ip(1:ii-1) = ipport(1:ii-1)
+         ip(ii:ii+4) = "    "
+      end if
 
       call Parallel_taskid(taskid)
 
       statebuffer(1:13) = "READY        "
 
       if (taskid.eq.MASTER) then
-         call nwpw_talker(ip,ii-1,port,sock)
+         call nwpw_talker(ip,inet,ii-1,port,sock)
          !call nwpw_talker("127.0.0.1",9,port,sock)
       end if
       done = .false.
@@ -117,7 +125,7 @@
 
             if (taskid.eq.MASTER) then
                it = it + 1
-               write(*,*) "== i-PI TCP Socket Client Computation =="
+               write(*,*) "== i-PI Socket Client Computation =="
                write(*,'(" Connected to   = ",A)') ipport
                write(*,'(" Iteration      =",I8)') it
                write(*,'(" Iteration Time =",F8.3," seconds")')cpu2-cpu1

--- a/src/nwpw/pspw/cpsd/runsocket.F
+++ b/src/nwpw/pspw/cpsd/runsocket.F
@@ -117,7 +117,7 @@
 
             if (taskid.eq.MASTER) then
                it = it + 1
-               write(*,*) "== ASE TCP Socket Client Computation =="
+               write(*,*) "== i-PI TCP Socket Client Computation =="
                write(*,'(" Connected to   = ",A)') ipport
                write(*,'(" Iteration      =",I8)') it
                write(*,'(" Iteration Time =",F8.3," seconds")')cpu2-cpu1

--- a/src/util/util_talker.c
+++ b/src/util/util_talker.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #if !defined(__MINGW32__)
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -36,6 +37,7 @@
 void FATR util_talker_
 #if defined(USE_FCD)
 ( const _fcd fcd_addr_name,
+ Integer *inet,
  Integer *n1,
  Integer *portin,
  Integer *sockout)
@@ -43,8 +45,9 @@ void FATR util_talker_
     char *addr_name = _fcdtocp(fcd_addr_name);
 
 #else
-(addr_name,n1,portin,sockout)
+(addr_name,inet,n1,portin,sockout)
 char	addr_name[];
+Integer *inet;
 Integer	*n1;
 Integer *portin;
 Integer *sockout;
@@ -56,36 +59,59 @@ Integer *sockout;
         perror("util_talker: not coded for this architecture");
         exit(1);
 #else
-    int sock = 0, valread; 
-    struct sockaddr_in serv_addr; 
+    int sock = 0, valread;
     int na   = ((int) *n1);
-    int port = ((int) *portin);
-    
+
     addr_name[na]   = 0;
     addr_name[na+1] = 0;
-    
-    printf("util_talker: addr_name=%s\n",addr_name);
-    printf("util_talker: port=%d\n",port);
 
-    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) 
-    { 
-        printf("\nutil_talker:Socket creation error \n"); 
-        exit(1);
-    } 
-    serv_addr.sin_family = AF_INET; 
-    serv_addr.sin_port = htons(port); 
+    if (*inet>0)
+    {
+        struct sockaddr_in serv_addr; 
+        int port = ((int) *portin);
+        
+        printf("util_talker: addr_name=%s\n",addr_name);
+        printf("util_talker: port=%d\n",port);
 
-    // Convert IPv4 and IPv6 addresses from text to binary form 
-    if(inet_pton(AF_INET, addr_name, &serv_addr.sin_addr)<=0)  
-    { 
-        printf("\nutil_talker:Invalid address/ Address not supported \n"); 
-        exit(1);
-    } 
-    if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) 
-    { 
-        printf("\nutil_talker:Connection Failed \n"); 
-        exit(1);
-    } 
+        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) 
+        { 
+            printf("\nutil_talker:Socket creation error \n"); 
+            exit(1);
+        } 
+        serv_addr.sin_family = AF_INET; 
+        serv_addr.sin_port = htons(port); 
+
+        // Convert IPv4 and IPv6 addresses from text to binary form 
+        if(inet_pton(AF_INET, addr_name, &serv_addr.sin_addr)<=0)  
+        { 
+            printf("\nutil_talker:Invalid address/ Address not supported \n"); 
+            exit(1);
+        } 
+        if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) 
+        { 
+            printf("\nutil_talker:Connection Failed \n"); 
+            exit(1);
+        } 
+    }
+    else
+    {
+        struct sockaddr_un serv_addr;
+        memset(&serv_addr, 0, sizeof(struct sockaddr_un));
+        serv_addr.sun_family = AF_UNIX;
+        strcpy(serv_addr.sun_path, "/tmp/ipi_");
+        strcpy(serv_addr.sun_path+9, addr_name);
+        if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
+        {
+            printf("\nutil_talker:Socket creation error \n");
+            exit(1);
+        }
+        if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+        {
+            printf("\nutil_talker:Failed to connect to UNIX socket \n");
+            exit(1);
+        }
+    }
+
     printf("util_talker: sockid=%d\n",sock);
     *sockout = ((Integer) sock);
 #endif


### PR DESCRIPTION
Add support for i-PI communication over UNIX sockets. The syntax is:

```
driver
    socket unix my_socket_name
end
```
NWChem will create a UNIX socket file located at `/tmp/ipi_my_socket_name`, per the i-PI protocol standard. To be clear, `my_socket_name` can be any valid UNIX file name, except that it may not include spaces.

IP sockets can still be used if the argument `unix` is replaced by any other keyword.