### PR TITLE
DFT-D3(BJ) Fixes

### DIFF
--- a/src/nwdft/xc/xc_vdw_util.F
+++ b/src/nwdft/xc/xc_vdw_util.F
@@ -882,13 +882,13 @@ c b3pw91
            a2       = 4.4693d0
 c pwb6k
        else if (xccomb(26)) then
-           scales8  = 0.1805d0
-           a1       = 0.9383d0
+           a1       = 0.1805d0
+           scales8  = 0.9383d0
            a2       = 7.7627d0
 c b1b95
        else if (xccomb(23)) then
            a1       = 0.2092d0
-           scale8   = 1.4507d0
+           scales8  = 1.4507d0
            a2       = 5.5545d0
 c CAM-B3LYP
          else if (abs(xfac(40)-1.0d0).lt.1d-5.and.cfac(2).ne.0d0.
@@ -905,8 +905,8 @@ c LC-wPBE
           a2      = 5.0897d0
 c hcth120
        else if (xccomb(7)) then
-           scales8  = 0.3563d0
-           a1       = 1.0821d0
+           a1       = 0.3563d0
+           scales8  = 1.0821d0
            a2       = 4.3359d0
 c mpw1b95
        else if (xccomb(21)) then
@@ -915,8 +915,8 @@ c mpw1b95
            a2       = 6.4177d0
 c bop
        else if (xccomb(27)) then
-           scales8  = 0.4870d0
-           a1       = 3.2950d0
+           a1       = 0.4870d0
+           scales8  = 3.2950d0
            a2       = 3.5043d0
 c o-lyp
        else if (xfac(16).eq.1d0.and.cfac(2).eq.1d0) then
@@ -935,8 +935,8 @@ c o-pbe
            a2       = 2.9444d0
 c ssb
         else if (xccomb(46)) then
-           scales8  = -0.0952d0
-           a1       = -0.1744d0
+           a1       = -0.0952d0
+           scales8  = -0.1744d0
            a2       =  5.2170d0
 c mpwb1k
         else if (xccomb(22)) then

--- a/src/nwdft/xc/xc_vdw_util.F
+++ b/src/nwdft/xc/xc_vdw_util.F
@@ -887,8 +887,8 @@ c pwb6k
            a2       = 7.7627d0
 c b1b95
        else if (xccomb(23)) then
-           scales8  = 0.2092d0
-           a1       = 1.4507d0
+           a1       = 0.2092d0
+           scale8   = 1.4507d0
            a2       = 5.5545d0
 c CAM-B3LYP
          else if (abs(xfac(40)-1.0d0).lt.1d-5.and.cfac(2).ne.0d0.
@@ -908,15 +908,10 @@ c hcth120
            scales8  = 0.3563d0
            a1       = 1.0821d0
            a2       = 4.3359d0
-c tpssh
-       else if (xccomb(18)) then
-           scales8  = 0.4529d0
-           a1       = 2.2382d0
-           a2       = 4.6550d0
 c mpw1b95
        else if (xccomb(21)) then
-           scales8  = 0.1955d0
-           a1       = 1.0508d0
+           a1       = 0.1955d0
+           scales8  = 1.0508d0
            a2       = 6.4177d0
 c bop
        else if (xccomb(27)) then
@@ -925,18 +920,18 @@ c bop
            a2       = 3.5043d0
 c o-lyp
        else if (xfac(16).eq.1d0.and.cfac(2).eq.1d0) then
-           scales8  = 0.5299d0
-           a1       = 2.6205d0
+           a1       = 0.5299d0
+           scales8  = 2.6205d0
            a2       = 2.8065d0
 c bpbe
        else if (xfac(3).eq.1d0.and.cfac(12).eq.1d0) then
-           scales8  = 0.4567d0
-           a1       = 4.0728d0
+           a1       = 0.4567d0
+           scales8  = 4.0728d0
            a2       = 4.3908d0
 c o-pbe
        else if (xfac(16).eq.1d0.and.cfac(12).eq.1d0) then
-           scales8  = 0.5512d0
-           a1       = 3.3816d0
+           a1       = 0.5512d0
+           scales8  = 3.3816d0
            a2       = 2.9444d0
 c ssb
         else if (xccomb(46)) then
@@ -953,6 +948,11 @@ c hf
            scales8  =  0.9171d0
            a1       =  0.3385d0
            a2       =  2.8830d0
+c scan
+        else if (xccomb(66)) then
+           a1       =  0.5380d0
+           scales8  =  0.0000d0
+           a2       =  5.4200d0
         else
 c     try to see if set rtdb was used
            read_ok=abs(scales8).gt.0d0.and.


### PR DESCRIPTION
Added DFT-D3(BJ) parameters for the SCAN functional.
Several `a1` and `scales8` parameters were interchanged. Fixes are according to [Grimme's website](https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dft-d3/functionalsbj).