### PR TITLE
Implement Marzari-Vanderbilt fractional occupations in nwpw

### DIFF
--- a/src/nwpw/band/lib/psi/cpsi.F
+++ b/src/nwpw/band/lib/psi/cpsi.F
@@ -1425,6 +1425,12 @@ c     &       MA_ERR)
                    smearcorrection 
      >                 = smearcorrection 
      >                 - kT*wb*dexp(-x*x)/(4.0d0*dsqrt(pi))
+                 else if (smeartype.eq.4) then
+                   smearcorrection
+     >                 = smearcorrection
+     >                 - kT*wb*dexp(-(x+dsqrt(0.5d0))*(x+dsqrt(0.5d0)))
+     >                 * (1.0d0 + dsqrt(2.0d0) * x)
+     >                 / (2.0d0 * dsqrt(pi))
                  end if
                  shift1  = shift1 + 1
                  shift2  = shift2 + 1
@@ -1442,6 +1448,7 @@ c     &       MA_ERR)
 
 
 c  set nwpw:fractional_smeartype 1 #0-none, 1-Fermi-Dirac, 2-Gaussian, 3-Hermite
+c                                   4-Marzari-Vanderbilt
 
       real*8 function cpsi_occ_distribution(smeartype,e)
       implicit none
@@ -1463,6 +1470,10 @@ c  set nwpw:fractional_smeartype 1 #0-none, 1-Fermi-Dirac, 2-Gaussian, 3-Hermite
          end if
       else if (smeartype.eq.2) then
          f = 0.5d0*util_erfc(e)
+      else if (smeartype.eq.4) then
+         f = dexp(-(e + dsqrt(0.5d0)) * (e + dsqrt(0.5d0)))
+     >     * dsqrt(0.125d0 / datan(1.0d0))
+     >     + 0.5d0 * util_erfc(e + dsqrt(0.5d0))
       else 
          if (e.gt.0.0d0) then
            f = 0.0d0

--- a/src/nwpw/band/minimizer/band_minimizer.F
+++ b/src/nwpw/band/minimizer/band_minimizer.F
@@ -515,6 +515,8 @@ c     **** print brillioun zone - extra logic for distributed kpoints ****
      >       write(6,1298) "Fermi-Dirac"
            if (control_fractional_smeartype().eq.2)
      >       write(6,1298) "Gaussian"
+           if (control_fractional_smeartype().eq.4)
+     >       write(6,1298) "Marzari-Vanderbilt"
            write(6,1299) control_fractional_kT(),
      >                   control_fractional_temperature(),
      >                   control_fractional_alpha()

--- a/src/nwpw/nwpw_input.F
+++ b/src/nwpw/nwpw_input.F
@@ -1361,7 +1361,8 @@ c
       if (inp_compare(.false.,zone_name,'step'))     nz = 0
       if (inp_compare(.false.,zone_name,'fermi'))    nz = 1
       if (inp_compare(.false.,zone_name,'gaussian')) nz = 2
-     
+      if (inp_compare(.false.,zone_name,'marzari-vanderbilt')) nz = 4
+
       if (inp_compare(.false.,zone_name,'orbitals')) then
          if (.not.inp_i(loop(1))) then
             loop(1) = 4

--- a/src/nwpw/pspw/cgsd/cgsdv5.F
+++ b/src/nwpw/pspw/cgsd/cgsdv5.F
@@ -578,6 +578,8 @@ c           call psp_check_print(ia)
      >       write(6,1298) "Fermi-Dirac"
            if (control_fractional_smeartype().eq.2)
      >       write(6,1298) "Gaussian"
+           if (control_fractional_smeartype().eq.4)
+     >       write(6,1298) "Marzari-Vanderbilt"
            if (control_fractional_smeartype().ge.0)
      >       write(6,1299) control_fractional_kT(),
      >                     control_fractional_temperature(),

--- a/src/nwpw/pspw/lib/psi/psi.F
+++ b/src/nwpw/pspw/lib/psi/psi.F
@@ -5500,6 +5500,12 @@ c      call Orb_Analysis(iunit,ispin,ne,dcpl_mb(psi1(1)))
                 smearcorrection 
      >              = smearcorrection 
      >              - kT*dexp(-x*x)/(4.0d0*dsqrt(pi))
+              else if (smeartype.eq.4) then
+                smearcorrection
+     >              = smearcorrection
+     >              - kT*dexp(-(x+dsqrt(0.5d0))*(x+dsqrt(0.5d0)))
+     >              * (1.0d0 + dsqrt(2.0d0) * x)
+     >              / (2.0d0 * dsqrt(pi))
               end if
 
               shift1  = shift1 + 1
@@ -5527,7 +5533,7 @@ c      call Orb_Analysis(iunit,ispin,ne,dcpl_mb(psi1(1)))
 
 
 c  set nwpw:fractional_smeartype 1 #0-none, 1-Fermi-Dirac, 2-Gaussian, 3-Hermite
-
+c                                   4-Marzari-Vanderbilt
       real*8 function psi_occ_distribution(smeartype,e)
       implicit none
       integer smeartype
@@ -5548,6 +5554,10 @@ c  set nwpw:fractional_smeartype 1 #0-none, 1-Fermi-Dirac, 2-Gaussian, 3-Hermite
          end if
       else if (smeartype.eq.2) then
          f = 0.5d0*util_erfc(e)
+      else if (smeartype.eq.4) then
+         f = dexp(-(e + dsqrt(0.5d0)) * (e + dsqrt(0.5d0)))
+     >     * dsqrt(0.125d0 / datan(1.0d0))
+     >     + 0.5d0 * util_erfc(e + dsqrt(0.5d0))
       else 
          if (e.gt.0.0d0) then
            f = 0.0d0


### PR DESCRIPTION
Implement the [Marzari-Vanderbilt](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.82.3296) thermal smearing method. This method is sometimes referred to as "cold smearing". Somehow it seems to work better with `band` than with `pspw`, but in practice I imagine it will be most useful for `band` calculations, so perhaps. this is not a problem.