### PR TITLE
Mkdocs

### DIFF
--- a/contrib/mkdocs/README.md
+++ b/contrib/mkdocs/README.md
@@ -17,15 +17,17 @@
 ```
 mkdocs.yml
 ```
-https://www.mkdocs.org/#theming-our-documentation
-https://www.mkdocs.org/user-guide/plugins/
+https://www.mkdocs.org/#theming-our-documentation  
+https://www.mkdocs.org/user-guide/plugins/  
 
 ## Checkout the Markdown source of the Wiki pages
 ```
 git clone https://github.com/nwchemgit/nwchem-wiki docs
 ```
 
-## Test the changes
+## Test the changes 
+
+The file `index.md` is the main file
 
 ```
 mkdocs serve

--- a/contrib/mkdocs/README.md
+++ b/contrib/mkdocs/README.md
@@ -32,6 +32,7 @@ The file `index.md` is the main file
 ```
 mkdocs serve
 ```
+Point your browser to  http://127.0.0.1:8000
 
 ## Build the html
 ```
@@ -61,3 +62,8 @@ rsync -av /path/to/mkdocs/site/* .
 git commit -m
 git push
 ```
+
+# Browse new web pages
+https://edoapra.github.io/nwchem/
+or in future
+https://nwchemgit.github.io/nwchem/

--- a/contrib/mkdocs/README.md
+++ b/contrib/mkdocs/README.md
@@ -1,0 +1,61 @@
+## Install mkdocs https://www.mkdocs.org/
+
+```
+ python3 -m pip install --user mkdocs
+ python3 -m pip install --user mkdocs-material
+``` 
+
+## Install the MkDocs plugin that simplifies internal links creation
+
+```
+ git clone https://github.com/cmitu/mkdocs-altlink-plugin
+ cd mkdocs-altlink-plugin
+ python3 -m pip install --user -e .
+```
+
+# Edit the configuration
+```
+mkdocs.yml
+```
+https://www.mkdocs.org/#theming-our-documentation
+https://www.mkdocs.org/user-guide/plugins/
+
+## Checkout the Markdown source of the Wiki pages
+```
+git clone https://github.com/nwchemgit/nwchem-wiki docs
+```
+
+## Test the changes
+
+```
+mkdocs serve
+```
+
+## Build the html
+```
+mkdocs build
+```
+
+## Create gh-pages branch (if needed)
+
+**Need to do it only once!
+The second time will wipe out the whole existing branch ...**
+```
+cd /path/to/repo-gh-pages
+git symbolic-ref HEAD refs/heads/gh-pages
+rm .git/index
+git clean -fdx
+echo "My GitHub Page" > index.html
+git add .
+git commit -a -m "First pages commit"
+git push origin gh-pages
+```
+
+## push files to gh-pages branch
+
+```
+cd /path/to/repo-gh-pages
+rsync -av /path/to/mkdocs/site/* .
+git commit -m
+git push
+```

--- a/contrib/mkdocs/mkdocs.yml
+++ b/contrib/mkdocs/mkdocs.yml
@@ -1,0 +1,27 @@
+site_name: NWChem
+repo_url: https://github.com/nwchemgit/nwchem-wiki
+edit_uri: blob/master/
+theme:
+  name: readthedocs
+  prev_next_buttons_location: both
+use_directory_urls: false
+plugins:
+  - search
+  - alternate-link
+nav:
+      - Documentation Home: Home.md
+      - Overview.md
+      - System-Description.md
+      - Quantum-Mechanical-Methods.md
+      - Classical-Methods.md
+      - Hybrid-Approaches.md
+      - Potential-Energy-Surface-Analysis.md
+      - Electronic-Structure-Analysis.md
+      - Other-Capabilities.md
+      - Examples.md
+      - Supplementary-Information.md
+      - Compiling-NWChem.md
+      - Developer.md
+      - Benchmarks.md
+      - FAQ.md
+      - Known-Bugs.md


### PR DESCRIPTION
New web pages for nwchem-sw.org replacement under https://nwchemgit.github.io/nwchem/