### PR TITLE
Rework ifx compiler configuration

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -1977,15 +1977,9 @@ endif
           FOPTIONS += -i8
         endif
         ifdef USE_OPENMP
-          DEFINES += -DUSE_OPENMP
-          ifdef USE_OPENMP_TASKS
-            DEFINES += -DUSE_OPENMP_TASKS
-          endif
+          FOPTIONS += -fiopenmp
           ifdef USE_OFFLOAD
-            DEFINES += -DUSE_OFFLOAD
-            FOPTIONS += -fiopenmp -fopenmp-targets=spirv64
-          else
-            FOPTIONS += -fiopenmp
+            FOPTIONS += -fopenmp-targets=spirv64
           endif
         endif
         ifdef IFX_DEBUG
@@ -2602,6 +2596,22 @@ endif
 
 
 endif
+
+
+###################################################################
+#  Some generic settings about programming models, e.g., OpenMP,  #
+#  that are orthogonal to the actual compiler used.               #
+###################################################################
+ifdef USE_OPENMP
+  DEFINES += -DUSE_OPENMP
+  ifdef USE_OPENMP_TASKS
+    DEFINES += -DUSE_OPENMP_TASKS
+  endif
+  ifdef USE_OFFLOAD
+    DEFINES += -DUSE_OFFLOAD
+  endif
+endif
+
 
 
 ###################################################################

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -1985,7 +1985,7 @@ endif
             DEFINES += -DUSE_OFFLOAD
             FOPTIONS += -fiopenmp -fopenmp-targets=spirv64
           else
-            FOPTIONS += -qopenmp
+            FOPTIONS += -fiopenmp
           endif
         endif
         ifdef IFX_DEBUG


### PR DESCRIPTION
This commit is to rework the configuration of the new Intel(R)
Fortran compiler in the build system.  The compiler is no longer
a variant of the traditional Intel(R) Fortra compiler.

Compiler debugging can be enabled by setting IFX_DEBUG=1 in the build
environment.