### PR TITLE
Adding another possible location for nwchemrc.

### DIFF
--- a/src/util/util_nwchemrc.F
+++ b/src/util/util_nwchemrc.F
@@ -70,9 +70,10 @@ c
 c     Because on UNIX/LINUX it is common to install a system wide
 c     configuration file in /etc, and perhaps a more specific one in
 c     a user-s home directory the original logic has been extended.
-c     Now we first look for $HOME/.nwchemrc if the key is found in there
+c     Now we first look for ./nwchemrc if the key is found in there
 c     we will return the corresponding value. If key was not found or
-c     the file does not exist we try /etc/nwchemrc. If both sources
+c     the file does not exist we try $HOME/.nwchemrc if the key is
+c     not found in there we try /etc/nwchemrc. If all sources
 c     fail the function returns .false.
 c
 c     On the key-value lines all information following a # token will
@@ -106,9 +107,11 @@ c
       do while (.not.found)
         ipass=ipass+1
         if (ipass.eq.1) then
+          nwchrc="./nwchemrc"
+        else if (ipass.eq.2) then
           call util_getenv('HOME',home)
           nwchrc=home(1:inp_strlen(home))//'/.nwchemrc '
-        elseif (ipass.eq.2) then
+        elseif (ipass.eq.3) then
           nwchrc="/etc/nwchemrc"
         else
           return


### PR DESCRIPTION
On some machines (e.g. Summit) the users home directory is not necessarily accessible on the compute nodes. This causes problems because NWChem expects $HOME/.nwchemrc to exist to find parameter sets for MD calculations. Previously, /etc/nwchemrc was added as an alternative location so one could install a system wide version of nwchemrc. 

The code change provided here allows ./nwchemrc as another option. With this code change the following locations will be tried in order:

1. ./nwchemrc
2. $HOME/.nwchemrc
3. /etc/nwchemrc

The first match will be used. Another advantage is that this allows for special parameters sets on a per calculation basis. I.e. it is possible to add missing parameters for a single calculations without affecting all other calculations done with a particular NWChem installation.