### PR TITLE
r2scan

### DIFF
--- a/src/nwdft/input_dft/dft_rdinput.F
+++ b/src/nwdft/input_dft/dft_rdinput.F
@@ -604,6 +604,8 @@ c
       cname(68)='            revM06 Correlation Potential'
       cname(69)='          revM06-L Correlation Potential'
       cname(71)='             rSCAN Correlation Potential'
+      cname(73)='           r^2SCAN Correlation Potential'
+      cname(74)='         r^2SCAN-L Correlation Potential'
 c
 c     Exchange functional name defaults.
 c
@@ -672,6 +674,8 @@ c
       xname(70)='                LB94 Exchange Functional'
       xname(71)='       rSCAN metaGGA Exchange Functional'
       xname(72)='            NCAP GGA Exchange Functional'
+      xname(73)='     r^2SCAN metaGGA Exchange Functional'
+      xname(74)='   r^2SCAN-L metaGGA Exchange Functional'
 c
 c     Exchange-Correlation combination functional name defaults.
 c
@@ -740,6 +744,8 @@ c
       xcname(70)='              SCAN0 Method XC Functional'
       xcname(71)='              rSCAN Method XC Functional'
       xcname(72)='               NCAP Method XC Functional'
+      xcname(73)='            r^2SCAN Method XC Functional'
+      xcname(74)='          r^2SCAN-L Method XC Functional'
 c     
 c     place character XC parameters in rtdb
 c     

--- a/src/nwdft/input_dft/xc_inp.F
+++ b/src/nwdft/input_dft/xc_inp.F
@@ -137,7 +137,7 @@ c     xperde86 ==> 9520
 c
 c
       integer num_dirs, ind, mlen, iline, n
-      parameter (num_dirs=151)
+      parameter (num_dirs=153)
 c
       character*15 dirs(num_dirs)
       character*255 test
@@ -188,7 +188,7 @@ c
      &     's12g','s12h','cam-s12g','cam-s12h',
      &     'becke86b','xperdew86','xmvs15','cvpbe09','mvs',
      &     'hle16', 'scan', 'scanl','scan0','lb94', 'rscan',
-     &     'xncap', 'ncap' /
+     &     'xncap', 'ncap', 'r2scan', 'r2scanl' /
 c     becke97-d, ssb-d
       logical disp, dumdirect
       integer ivdw
@@ -259,7 +259,7 @@ c
      &  8532,8533,8534,9300,9310,9320,4610,4620,4630,4640,
      &  9510,9520,4115,2109,4124,3101,
      &  9610,9620,9630,9494,9640,
-     &  9710,9720,1999) ind
+     &  9710,9720,9650,9660,1999) ind
       call errquit('xc_inp: unimplemented directive', ind, INPUT_ERR)
 c     
 c     acm; adiabatic connection method
@@ -1739,6 +1739,29 @@ c
       nlxfac(72) = .true.
       xfac(72) = 1.0d0
       goto 10
+c
+c r2SCAN metaGGA
+c
+9650  xccomb(73) = .true.
+       lcfac(73) = .true.
+      nlcfac(73) = .true.
+        cfac(73) = 1.0d0
+       lxfac(73) = .true.
+      nlxfac(73) = .true.
+        xfac(73) = 1.0d0
+      goto 10
+c
+c r2SCAN-L deorbitalized metaGGA
+c
+9660  xccomb(74) = .true.
+       lcfac(74) = .true.
+      nlcfac(74) = .true.
+        cfac(74) = 1.0d0
+       lxfac(74) = .true.
+      nlxfac(74) = .true.
+        xfac(74) = 1.0d0
+      goto 10
+
 c
 c lb94 Vxc function
 c fill only x here, no c

--- a/src/nwdft/xc/GNUmakefile
+++ b/src/nwdft/xc/GNUmakefile
@@ -56,7 +56,8 @@ HEADERS = xc.fh xc_vdw.fh xc_params.fh xc_hcth.fh
 	xc_3rd_deriv.o xc_xpw86.o xc_xb86b.o xc_xdm.o \
 	ts_eval_fnl.o ts_tf.o ts_vw.o xc_xn12.o \
 	xc_xscan.o xc_cscan.o xc_xscanl.o xc_cscanl.o ts_pc.o\
-	xc_xncap.o xc_xncap.o
+	xc_xncap.o xc_xncap.o xc_xr2scan.o xc_xr2scanl.o\
+	xc_cr2scan.o xc_cr2scanl.o
 
      LIBRARY = libnwdft.a
 

--- a/src/nwdft/xc/xc_cr2scan.F
+++ b/src/nwdft/xc/xc_cr2scan.F
@@ -1,19 +1,5 @@
-c Copyright 2018 (C) Orbital-free DFT group at University of Florida
-c Licensed under the Educational Community License, Version 2.0 
-c (the "License"); you may not use this file except in compliance with 
-c the License. You may obtain a copy of the License at
-c
-c    http://www.osedu.org/licenses/ECL-2.0
-c
-c Unless required by applicable law or agreed to in writing,
-c software distributed under the License is distributed on an "AS IS"
-c BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-c or implied. See the License for the specific language governing
-c permissions and limitations under the License.
-c
-c ---------------------------------------------------------------------
-c
-c     Strongly constrained and appropriately normed (SCAN) 
+c     Regularized and restored strongly constrained and 
+c     appropriately normed (r^2SCAN) 
 c     functional (Correlation part only)
 c           META GGA
 C         utilizes ingredients:
@@ -23,18 +9,13 @@ c                              tau - K.S kinetic energy density
 c
 c     Written by:
 c     Daniel Mejia-Rodriguez
-c     QTP, Department of Physics, University of Florida
 c
 c     References:
-c     J. Sun, A. Ruzsinszky, J.P. Perdew
-c     PRL 115, 036402 (2015)
-c     DOI: 10.1103/PhysRevLett.115036402
-c
-c     A.P. Bartok and J.R. Yates
-c     JCP 150, 161101 (2019)
-c     DOI: 10.1063/1.5094646
+c     J.W. Furness, A.D. Kaplan, J. Ning, J.P. Perdew, J. Sun
+c     JPCLett 11, 8208-8215 (2020)
+c     DOI: 10.1021/acs.jpclett.0c02405
 
-      Subroutine xc_cscan(whichfc, tol_rho, cfac, rho, delrho, Amat, 
+      Subroutine xc_cr2scan(tol_rho, cfac, rho, delrho, Amat, 
      &                    Cmat, nq, ipol, Ec, qwght, ldew, func,
      &                    tau, Mmat)     
 c
@@ -45,7 +26,6 @@ c
 c
 c     Input and other parameters
 c
-      character(*) whichfc
       integer ipol, nq
       double precision dummy(1)
       double precision cfac
@@ -115,9 +95,14 @@ c
       double precision fca,dfcada,dfcadg,dfcadzeta,dfcadn
       double precision exp5,exp6
       double precision vcpol,vcn
+      double precision eclda0, eclda1, declda0drs, d2eclda0drs2
+      double precision declda1drs, declda1dz, d2eclda1drs2
+      double precision d2eclda1drsdz
+      double precision deltaY, deltaYp, ddeltaYpdrs, ddeltaYpdp
+      double precision ddeltaYpdz, GAt2y, dGAt2ydrs, dGAt2ydp
+      double precision dGAt2ydz,opz23,omz23,exp1
 
       double precision GAMMA,BETAzero,pi,p14a,p14b,p14f,ckf,ckf2
-      parameter (GAMMA = 0.03109069086965489503494086371273d0)
       parameter (BETAzero = 0.06672455060314922d0)
       parameter (p14a=0.1d0,p14b=0.1778d0)
 
@@ -132,7 +117,6 @@ c
       parameter (F8=8d0,F5=5d0,F16=1d0/6d0)
 
       double precision rRegu(0:7), rRegu1(7), rtemp(0:7)
-      double precision regalpha, dregalpha
       parameter ( rRegu = (/ 1d0, -0.64d0, -0.4352d0, 
      &            -1.535685604549d0, 3.061560252175d0,
      &            -1.915710236206d0, 5.16884468372d-1,
@@ -141,10 +125,14 @@ c
      &            -3d0*1.535685604549d0, 4d0*3.061560252175d0,
      &            -5d0*1.915710236206d0, 6d0*5.16884468372d-1,
      &            -7d0*5.1848879792d-2 /) )
+
+      double precision eta, rDp2, rfc2
+      parameter (eta=1d-3, rDp2=0.361d0, rfc2 = sum(rRegu1))
 c
 c     ======> BOTH SPIN-RESTRICETED AND UNRESTRICTED <======
 c
       Pi = dacos(-1d0)
+      gamma = (1d0 - dlog(2d0))/pi**2
       p14f = (3d0/(4d0*Pi))**F13
       ckf = (3d0*Pi*Pi)**F13
       ckf2 = ckf*ckf
@@ -156,14 +144,40 @@ c
 
          n13=ntot**F13
          n83=ntot**F83
+         rs=p14f/n13
+         rs12=dsqrt(rs)
+         drsdn=-F13*rs/ntot
+c
+c----------------------------------------------------------------------
+c functions related to spin-polarization
+c----------------------------------------------------------------------
 c
          if (ipol.eq.1) then
            zeta = 0d0
+           phi = 1d0
+           ds = 1d0
+           dx = 1d0
+           gc = 1d0
          else
            zeta = (rho(n,2) - rho(n,3))/ntot      
            if (zeta.lt.-1d0) zeta=-1d0
            if (zeta.gt. 1d0) zeta= 1d0
+           opz = 1d0 + zeta
+           omz = 1d0 - zeta
+           opz23 = opz**f23
+           omz23 = omz**f23
+           phi = 0.5d0*(opz23 + omz23)
+           ds = 0.5d0*(opz23*opz + omz23*omz)
+           dx = 0.5d0*(opz23*opz23 + omz23*omz23)
+           gc = (1d0 - dxc*(dx - 1d0))*(1d0 - zeta**12)
          endif
+         phi2 = phi*phi
+         phi3 = phi2*phi
+         tueg = 0.3d0*ckf2*ds*ntot**F53
+c         
+c----------------------------------------------------------------------
+c functions related to delrho  
+c----------------------------------------------------------------------
 c
          if (ipol.eq.1) then
            dn2=delrho(n,1,1)**2 + delrho(n,2,1)**2 + delrho(n,3,1)**2
@@ -172,76 +186,120 @@ c
      &         (delrho(n,2,1)+delrho(n,2,2))**2 +
      &         (delrho(n,3,1)+delrho(n,3,2))**2
          end if
-
+c         
+         p=dn2/(F4*ckf2*n83)
+         dpdg = 1d0/(F4*ckf2*n83)
+         dpdn = -F83*p/ntot
+c         
+         t2 = ckf2*p/(4d0*phi2*rs*2d0**F23)
+         dt2dp = ckf2/(4d0*phi2*rs*2d0**F23)
+         dt2drs = -t2/rs
+c
+         tvw = 0.125d0*dn2/ntot
+c
+c----------------------------------------------------------------------
+c functions related to tau
+c----------------------------------------------------------------------
+c
          if (ipol.eq.1) then
            tautot=tau(n,1)
          else
            tautot=tau(n,1)+tau(n,2)
          endif
 
-         p=dn2/(F4*ckf2*n83)
-         dpdg = 1d0/(F4*ckf2*n83)
-         dpdn = -F83*p/ntot
+         alpha = (tautot - tvw)/(tueg + eta*tvw)
+         oma = 1d0 - alpha
+         oma2 = oma*oma
 
-         rs=p14f/n13
-         drsdn=-F13*rs/ntot
-         rs12=dsqrt(rs)
+         if (alpha.lt.0d0) then
+           exp5 = dexp(-c1c*alpha/oma)
+           fca = exp5
+           dfcada = -c1c*exp5/oma2
+         elseif (alpha.lt.2.5d0) then
+           rtemp(0) = 1d0
+           do ifc=1,7
+             rtemp(ifc) = rtemp(ifc-1)*alpha
+           enddo
+           fca = dot_product(rRegu,rtemp)
+           dfcada = dot_product(rRegu1, rtemp(0:6))
+         else
+           exp6 = dexp(c2c/oma)
+           fca = -dc*exp6
+           dfcada = -dc*exp6*c2c/oma2
+         endif
 c
-         call lsdac(tol_rho,rs,zeta,epsc,depscdrs,depscdzeta,dummy,
-     &              dummy,dummy)
+         dalphadt = 1d0/(tueg + eta*tvw)
+         dalphadg = -0.125d0/(ntot*(tueg + eta*tvw))*(1d0 + alpha*eta)
+         dalphadn = f53*tueg/(ntot*(tueg+eta*tvw))*
+     &                (p/ds*(1d0+eta*alpha) - alpha)
 c
-         opz = 1d0 + zeta
-         omz = 1d0 - zeta
-         phi = 0.5d0*(opz**F23 + omz**F23)
-         phi2 = phi*phi
-         phi3 = phi2*phi
+c----------------------------------------------------------------------
+c EC1
+c----------------------------------------------------------------------
+c
+c eclda1 and derivatives
+c
+         call lsdac(tol_rho,rs,zeta,eclda1,declda1drs,declda1dz,
+     &              d2eclda1drs2,d2eclda1drsdz,dummy)
+c
+c eclda0 and derivatives
+c
+         eclda0 = -b1c/(1d0 + b2c*rs12 + b3c*rs)
+         declda0drs = -eclda0*(b3c + 0.5d0*b2c/rs12)/
+     &                (1d0 + b2c*rs12 + b3c*rs)
+         d2eclda0drs2 = eclda0/(1d0 + b2c*rs12 + b3c*rs) *
+     &          ( 2d0*(b3c+0.5d0*b2c/rs12)**2/(1d0+b2c*rs12+b3c*rs) +
+     &            0.25d0*b2c/rs/rs12 )
 c
          BETA = BETAzero*(1d0 + p14a*rs)/(1d0 + p14b*rs)
          dBETAdrs = BETAzero*(p14a - p14b)/(1d0 + p14b*rs)**2
 c
-         w1fac = epsc/(GAMMA*phi3)
+         w1fac = eclda1/(GAMMA*phi3)
          expw1 = dexp(-w1fac)
          w1 = expw1 - 1d0
-         dw1drs = -expw1*depscdrs/(GAMMA*phi3)
+         dw1drs = -expw1*declda1drs/(GAMMA*phi3)
 
          A = BETA/GAMMA/w1
          dAdrs = dBETAdrs/GAMMA/w1 - A*dw1drs/w1
-
-         t2 = ckf2*p/(4d0*phi2*rs*2d0**F23)
-         dt2dp = ckf2/(4d0*phi2*rs*2d0**F23)
-         dt2drs = -t2/rs
-
+c         
          At2 = A*t2
-         Gaux = 1d0 + 4d0*At2
-         GAt2 = 1d0/dsqrt(dsqrt(Gaux))
+         exp1 = dexp(-p**2/rDp2**4)
+         deltaY = rfc2/(27d0*gamma*phi3*w1*ds) *
+     &              (20d0*rs*(declda0drs-declda1drs) - 
+     &               45d0*eta*(eclda0-eclda1))
+         deltaYp = deltaY*p*exp1
+         ddeltaYpdrs = -deltaYp/w1*dw1drs + 
+     &                rfc2/(27d0*gamma*phi3*w1*ds)*
+     &                  (20d0*(declda0drs-declda1drs) +
+     &                   20d0*rs*(d2eclda0drs2-d2eclda1drs2) - 
+     &                   45d0*eta*(declda0drs-declda1drs))*p*exp1
+         ddeltaYpdp = deltaY*exp1 - 2d0*p*deltaYp/rDp2**4
 
-         arg1 = 1d0 + w1*(1d0 - GAt2)
-         darg1drs = dw1drs*(1d0 - GAt2) +
-     &              Gat2*w1*(t2*dAdrs + A*dt2drs)/Gaux
-         darg1dp = Gat2*w1*A*dt2dp/Gaux
+         Gaux = 1d0 + 4d0*(At2-deltaYp)
+         GAt2y = 1d0/dsqrt(dsqrt(Gaux))
+         dGat2ydrs = -Gat2y*(dAdrs*t2 + A*dt2drs - ddeltaYpdrs)/Gaux
+         dGat2ydp = -Gat2y*(A*dt2dp - ddeltaYpdp)/Gaux
 
+         arg1 = 1d0 + w1*(1d0 - GAt2y)
+         darg1drs = dw1drs*(1d0 - GAt2y) - w1*dGat2ydrs
+         darg1dp = -w1*dGAt2ydp
 
          H1 = GAMMA*phi3*dlog(arg1)
          dH1dp = GAMMA*phi3*darg1dp/arg1
          dH1drs = GAMMA*phi3*darg1drs/arg1
 
-         Ec1 = epsc + H1
-         dEc1drs = depscdrs + dH1drs
+         Ec1 = eclda1 + H1
+         dEc1drs = declda1drs + dH1drs
          dEc1dp = dH1dp
 c
-c        --------------------------------------------------------------
+c--------------------------------------------------------------
+c EC0
+c--------------------------------------------------------------
 c
-         epsc0 = -b1c/(1d0 + b2c*rs12 + b3c*rs)
-         depsc0drs = b1c*(b3c + 0.5d0*b2c/rs12)/
-     &               (1d0 + b2c*rs12 + b3c*rs)**2
- 
-         dx = 0.5d0*(opz**F43 + omz**F43)
-         gc = (1d0 - dxc*(dx - 1d0))*(1d0 - zeta**12)
-
-         w0fac = epsc0/b1c
+         w0fac = eclda0/b1c
          expw0 = dexp(-w0fac)
          w0 = expw0 - 1d0
-         dw0drs = -depsc0drs*expw0/b1c
+         dw0drs = -declda0drs*expw0/b1c
 
          ginf = (1d0/(1d0 + 4d0*xi*p))**F14
          dginfdp = -xi*ginf/(1d0 + 4d0*xi*p)
@@ -254,76 +312,14 @@ c
          dH0dp = b1c*darg0dp/arg0
          dH0drs = b1c*darg0drs/arg0
 
-         Ec0 = (epsc0 + H0)*gc
-         dEc0drs = gc*(depsc0drs + dH0drs)
+         Ec0 = (eclda0 + H0)*gc
+         dEc0drs = gc*(declda0drs + dH0drs)
          dEc0dp = gc*dH0dp
-c
-c        --------------------------------------------------------------
-c
-         ds = 0.5d0*(opz**F53 + omz**F53)
-         tueg = 0.3d0*ckf*ckf*ds*ntot**F53
-         tvw = 0.125d0*dn2/ntot
-         if (whichfc.eq.'orig') then
-           alpha = (tautot - tvw)/tueg
-           if (alpha.lt.0d0) alpha=0d0
-           regalpha = alpha
-           dregalpha = 1d0
-         else if (whichfc.eq.'regu') then
-           alpha = (tautot - tvw)/(tueg + 1d-4*ds)
-           if (alpha.lt.0d0) alpha=0d0
-           regalpha = alpha**3/(alpha**2 + 1d-3)
-           dregalpha = alpha/(alpha**2 + 1d-3) * 
-     &                 (3d0*alpha - 2d0*regalpha)
-         endif
-         oma = 1d0 - regalpha
-         oma2 = oma*oma
-
-         if (whichfc.eq.'orig') then
-           if (regalpha.ge.thr1) then
-             exp5 = 0d0
-           else
-             exp5 = dexp(-c1c*regalpha/oma)
-           end if
-           if (regalpha.le.thr2) then
-             exp6 = 0d0
-           else
-             exp6 = dexp(c2c/oma)
-           end if
-           fca = exp5 - dc*exp6
-           if (regalpha.ge.thr1.and.regalpha.le.thr2) then
-             dfcada = 0d0
-           else
-             dfcada = -(c1c*exp5 + dc*exp6*c2c)/oma2
-           end if
-         else if(whichfc.eq.'regu') then
-           if (regalpha.lt.2.5d0) then
-             rtemp(0) = 1d0
-             do ifc=1,7
-               rtemp(ifc) = rtemp(ifc-1)*regalpha
-             enddo
-             fca = dot_product(rRegu,rtemp)
-             dfcada = dot_product(rRegu1, rtemp(0:6))*dregalpha
-           else
-             exp6 = dexp(c2c/oma)
-             fca = -dc*exp6
-             dfcada = -dc*exp6*c2c/oma2*dregalpha
-           endif
-         endif
 c
 c        --------------------------------------------------------------
 c
          Ec = Ec + cfac*ntot*(Ec1 + fca*(Ec0-Ec1))*qwght(n)
          if (ldew) func(n) = func(n) + cfac*ntot*(Ec1 + fca*(Ec0-Ec1))
-c
-         if (whichfc.eq.'orig') then
-           idalphadn = f53*(p/ds-alpha)/ntot
-           dalphadg = -0.125d0/(tueg*ntot)
-           dalphadt = 1d0/tueg
-         else if (whichfc.eq.'regu') then
-           dalphadn = 5d0/3d0*(p/ds-alpha)*tueg/((tueg+1d-4*ds)*ntot)
-           dalphadg = -0.125d0/((tueg+1d-4*ds)*ntot)
-           dalphadt = 1d0/(tueg+1d-4*ds)
-         endif
 
          dEc1dn = dEc1drs*drsdn + dEc1dp*dpdn
          dEc0dn = dEc0drs*drsdn + dEc0dp*dpdn
@@ -355,30 +351,37 @@ c
      &                             ntot*dfcada*dalphadt*(Ec0-Ec1)
 
            if (omz.lt.tol_rho) then
-             dphidzeta = 0.5d0*F23*(opz**F23/opz)
+             dphidzeta = 0.5d0*F23*(opz23/opz)
            else if (opz.lt.tol_rho) then
-             dphidzeta = -0.5d0*F23*(omz**F23/omz)
+             dphidzeta = -0.5d0*F23*(omz23/omz)
            else
-             dphidzeta = 0.5d0*F23*(opz**F23/opz - omz**F23/omz)
+             dphidzeta = 0.5d0*F23*(opz23/opz - omz23/omz)
            end if
 
            dt2dzeta = -2d0*t2*dphidzeta/phi
            dw1dzeta = (3d0*w1fac*dphidzeta/phi - 
-     &                 depscdzeta/(GAMMA*phi3))*expw1
+     &                 declda1dz/(GAMMA*phi3))*expw1
            dAdzeta = -A*dw1dzeta/w1
-           darg1dzeta = dw1dzeta*(1d0 - Gat2) + 
-     &                  Gat2*w1*(t2*dAdzeta + A*dt2dzeta)/Gaux
+
+           ddsdzeta = 0.5d0*F53*(opz23 - omz23)
+           ddeltaYpdz = -deltaYp/w1*dw1dzeta - deltaYp/ds*ddsdzeta -
+     &                  3d0*deltaYp*dphidzeta/phi +
+     &                  rfc2/(27d0*gamma*phi3*w1*ds)*(
+     &                     -20d0*rs*d2eclda1drsdz +
+     &                     45d0*eta*declda1dz)*p*exp1
+
+           dGAt2ydz = -GAt2y*(dAdzeta*t2 + A*dt2dzeta - ddeltaYpdz)/Gaux
+           darg1dzeta = dw1dzeta*(1d0-GAt2y) - w1*dGAt2ydz
            dH1dzeta = 3d0*H1*dphidzeta/phi + GAMMA*phi3*darg1dzeta/arg1
-           dEc1dzeta = depscdzeta + dH1dzeta
+           dEc1dzeta = declda1dz + dH1dzeta
 
            ddxdzeta = 0.5d0*F43*(opz**F13 - omz**F13)
            dgcdzeta = -dxc*ddxdzeta*(1d0 - zeta**12) -
      &                12d0*zeta**11*(1d0 - dxc*(dx - 1d0))
-           dEc0dzeta = dgcdzeta*(epsc0 + H0)
+           dEc0dzeta = dgcdzeta*(eclda0 + H0)
 
-           ddsdzeta = 0.5d0*F53*(opz**F23 - omz**F23)
 
-           dalphadzeta = -alpha*ddsdzeta/ds
+           dalphadzeta = -alpha/(tueg+eta*tvw)*tueg*ddsdzeta/ds
 
            dfcadzeta = dfcada*dalphadzeta
 
@@ -393,7 +396,7 @@ c
 20    continue
       end
 
-      Subroutine xc_cscan_d2()
+      Subroutine xc_cr2scan_d2()
       implicit none
       call errquit(' xc_cscan: d2 not coded ',0,0)
       return

--- a/src/nwdft/xc/xc_cr2scanl.F
+++ b/src/nwdft/xc/xc_cr2scanl.F
@@ -1,0 +1,461 @@
+c     Deorbitalized version of the regularized and restored 
+c     strongly constrained and appropriately normed (r^2SCAN-L) 
+c     functional (correlation part only)
+c           META GGA
+C         utilizes ingredients:
+c                              rho   -  density
+c                              delrho - gradient of density
+c                              laprho - Laplacian of density
+c
+c     Written by:
+c     Daniel Mejia-Rodriguez
+c
+c     References:
+c     J.W. Furness, A.D. Kaplan, J. Ning, J.P. Perdew, J. Sun
+c     JPCLett 11, 8208-8215 (2020)
+c     DOI: 10.1021/acs.jpclett.0c02405
+c
+c     D. Mejia-Rodriguez, S.B. Trickey
+c     PRB 102, 121109(R) (2020)
+c     DOI: 10.1103/PhysRevB.102.121109
+
+      Subroutine xc_cr2scanl(tol_rho, cfac, rho, delrho, laprho, Amat, 
+     &                    Cmat, Lmat, nq, ipol, Ec, qwght, ldew, func)
+c
+      implicit none
+c
+#include "errquit.fh"
+#include "dft2drv.fh"
+c
+c     Input and other parameters
+c
+      integer ipol, nq
+      double precision dummy(1)
+      double precision cfac
+      logical ldew
+      double precision func(*)
+      double precision fac
+      double precision tol_rho
+c
+c     Threshold parameters
+c
+      double precision thr1,thr2
+      parameter (thr1=0.996d0,thr2=1.004d0)
+c
+c     Correlation energy
+c
+      double precision Ec
+c
+c     Charge Density 
+c
+      double precision rho(nq,ipol*(ipol+1)/2)
+c
+c     Charge Density Gradient
+c
+      double precision delrho(nq,3,ipol), gammaval, gam12
+c
+c     Charge Density Laplacian
+c
+      double precision laprho(nq,ipol)
+c
+c     Quadrature Weights
+c
+      double precision qwght(nq)
+c
+c     Sampling Matrices for the XC Potential
+c
+      double precision Amat(nq,ipol), Cmat(nq,*), Lmat(nq,ipol)
+c
+c     Intermediate derivatives, results, etc.
+c
+      integer n, ifc
+      double precision ntot,n13,n83,n53,tautot
+      double precision dn2,p,rs,rs12,drsdn,dpdg,dpdn
+      double precision epsc,depscdrs,depscdzeta
+      double precision zeta,omz,opz
+      double precision phi,phi2,phi3,dphidzeta
+      double precision t2,dt2dp,dt2drs,dt2dzeta
+      double precision BETA,dBETAdrs
+      double precision A,dAdrs,dAdzeta
+      double precision At2,Gaux,Gat2
+      double precision w1fac,expw1,w1,dw1drs,dw1dzeta
+      double precision arg1,darg1dp,darg1drs,darg1dzeta
+      double precision H1,dH1dp,dH1drs,dH1dzeta
+      double precision Ec1,dEc1drs,dEc1dp,dEc1dzeta,dEc1dn,dEc1dg
+      double precision epsc0,depsc0drs,depsc0dn
+      double precision dx,ddxdzeta
+      double precision gc,dgcdzeta
+      double precision ginf,dginfdp
+      double precision w0fac,expw0,w0,dw0drs
+      double precision arg0,darg0dp,darg0drs
+      double precision H0,dH0dp,dH0drs
+      double precision Ec0,dEc0dp,dEc0drs,dEc0dzeta,dEc0dn,dEc0dg
+      double precision ds,ddsdzeta
+      double precision tueg,tvw
+      double precision alpha,dalphadzeta,dalphadn,dalphadg,dalphadt
+      double precision oma,oma2
+      double precision fca,dfcada,dfcadg,dfcadzeta,dfcadn
+      double precision exp5,exp6
+      double precision vcpol,vcn
+      double precision eclda0, eclda1, declda0drs, d2eclda0drs2
+      double precision declda1drs, declda1dz, d2eclda1drs2
+      double precision d2eclda1drsdz
+      double precision deltaY, deltaYp, ddeltaYpdrs, ddeltaYpdp
+      double precision ddeltaYpdz, GAt2y, dGAt2ydrs, dGAt2ydp
+      double precision dGAt2ydz,opz23,omz23,exp1
+      double precision tuega, tuegb, pa, pb, qa, qb
+      double precision fsa, fsb, dfsdpa, dfsdpb, dfsdqa, dfsdqb, dfcadt
+      double precision dtdna, dtdnb, dtdga, dtdgb, dtdla, dtdlb
+
+      double precision GAMMA,BETAzero,pi,p14a,p14b,p14f,ckf,ckf2
+      parameter (BETAzero = 0.06672455060314922d0)
+      parameter (p14a=0.1d0,p14b=0.1778d0)
+
+      double precision b1c,b2c,b3c,c1c,c2c,dc,dxc,xi
+      parameter (b1c=0.0285764d0,b2c=0.0889d0,b3c=0.125541d0)
+      parameter (c1c=0.64d0,c2c=1.5d0,dc=0.7d0,dxc=2.3631d0)
+      parameter (xi=0.12802585262625815d0)
+
+      double precision F4,F13,F23,F43,F53,F83,F14,F8,F5,F16
+      parameter (F4=4d0,F13=1d0/3d0,F23=F13+F13,F43=F13+1d0)
+      parameter (F53=F23+1d0,F83=F53+1d0,F14=0.25d0)
+      parameter (F8=8d0,F5=5d0,F16=1d0/6d0)
+
+      double precision rRegu(0:7), rRegu1(7), rtemp(0:7)
+      parameter ( rRegu = (/ 1d0, -0.64d0, -0.4352d0, 
+     &            -1.535685604549d0, 3.061560252175d0,
+     &            -1.915710236206d0, 5.16884468372d-1,
+     &            -5.1848879792d-2 /) )
+      parameter ( rRegu1 = (/ -0.64d0, -2d0*0.4352d0,
+     &            -3d0*1.535685604549d0, 4d0*3.061560252175d0,
+     &            -5d0*1.915710236206d0, 6d0*5.16884468372d-1,
+     &            -7d0*5.1848879792d-2 /) )
+
+      double precision eta, rDp2, rfc2, two53
+      parameter (eta=1d-3, rDp2=0.361d0, rfc2 = sum(rRegu1))
+      parameter (two53=2d0**F53)
+c
+c     ======> BOTH SPIN-RESTRICETED AND UNRESTRICTED <======
+c
+      Pi = dacos(-1d0)
+      gamma = (1d0 - dlog(2d0))/pi**2
+      p14f = (3d0/(4d0*Pi))**F13
+      ckf = (3d0*Pi*Pi)**F13
+      ckf2 = ckf*ckf
+
+      do 20 n = 1, nq
+c
+         ntot=rho(n,1)
+         if (ntot.le.tol_rho) goto 20
+
+         n13=ntot**F13
+         n53=ntot**F53
+         n83=ntot**F83
+
+         if (ipol.eq.1) then
+           dn2=delrho(n,1,1)**2 + delrho(n,2,1)**2 + delrho(n,3,1)**2
+         else
+           dn2=(delrho(n,1,1)+delrho(n,1,2))**2 +
+     &         (delrho(n,2,1)+delrho(n,2,2))**2 +
+     &         (delrho(n,3,1)+delrho(n,3,2))**2
+         end if
+c         
+         if (ipol.eq.1) then
+           pa = dn2/(4d0*ckf2*n83)
+           qa = laprho(n,1)/(4d0*ckf2*n53)
+           tuega = 0.3d0*ckf2*n53
+           call ts_pc(tol_rho, rho(n,1), delrho(n,1:3,1), laprho(n,1),
+     &                dfsdpa, dfsdqa, fsa, 1d0)
+           tautot = tuega*fsa
+           dtdna = F53*tuega/rho(n,1)*fsa - 
+     &             tuega*(F83*dfsdpa*pa/rho(n,1) + 
+     &                    F53*dfsdqa*qa/rho(n,1))
+           dtdga = 2d0*tuega*dfsdpa/(4d0*ckf2*n83)
+           dtdla = tuega*dfsdqa/(4d0*ckf2*n53)
+         else
+           tuega = 0.5d0*0.3d0*two53*ckf2*rho(n,2)**F53
+           tuegb = 0.5d0*0.3d0*two53*ckf2*rho(n,3)**F53
+           call ts_pc(tol_rho, rho(n,2), delrho(n,1:3,1), laprho(n,1),
+     &                dfsdpa, dfsdqa, fsa, 2d0)
+           call ts_pc(tol_rho, rho(n,3), delrho(n,1:3,2), laprho(n,2),
+     &                dfsdpb, dfsdqb, fsb, 2d0)
+           tautot=(tuega*fsa + tuegb*fsb)
+           if (rho(n,2).gt.tol_rho) then
+             pa = (delrho(n,1,1)**2 +
+     &             delrho(n,2,1)**2 +
+     &             delrho(n,3,1)**2)/(ckf2*(2d0*rho(n,2))**F83)
+             qa = laprho(n,1)/(2d0*ckf2*(2d0*rho(n,2))**F53)
+             dtdna = F53*tuega/rho(n,2)*fsa -
+     &               tuega*(F83*dfsdpa*pa/rho(n,2) +
+     &                      F53*dfsdqa*qa/rho(n,2))
+             dtdga = tuega*dfsdpa/(ckf2*(2d0*rho(n,2))**F83)
+             dtdla = tuega*dfsdqa/(2d0*ckf2*(2d0*rho(n,2))**F53)
+           else
+             dtdna = 0d0
+             dtdga = 0d0
+             dtdla = 0d0
+           endif
+           if (rho(n,3).gt.tol_rho) then
+             pb = (delrho(n,1,2)**2 +
+     &             delrho(n,2,2)**2 +
+     &             delrho(n,3,2)**2)/(ckf2*(2d0*rho(n,3))**F83)
+             qb = laprho(n,2)/(2d0*ckf2*(2d0*rho(n,3))**F53)
+             dtdnb = F53*tuegb/rho(n,3)*fsb -
+     &               tuegb*(F83*dfsdpb*pb/rho(n,3) +
+     &                      F53*dfsdqb*qb/rho(n,3))
+             dtdgb = tuegb*dfsdpb/(ckf2*(2d0*rho(n,3))**F83)
+             dtdlb = tuegb*dfsdqb/(2d0*ckf2*(2d0*rho(n,3))**F53)
+           else
+             dtdnb = 0d0
+             dtdgb = 0d0
+             dtdlb = 0d0
+           endif
+         endif
+
+
+         rs=p14f/n13
+         rs12=dsqrt(rs)
+         drsdn=-F13*rs/ntot
+c
+c----------------------------------------------------------------------
+c functions related to spin-polarization
+c----------------------------------------------------------------------
+c
+         if (ipol.eq.1) then
+           zeta = 0d0
+           phi = 1d0
+           ds = 1d0
+           dx = 1d0
+           gc = 1d0
+         else
+           zeta = (rho(n,2) - rho(n,3))/ntot      
+           if (zeta.lt.-1d0) zeta=-1d0
+           if (zeta.gt. 1d0) zeta= 1d0
+           opz = 1d0 + zeta
+           omz = 1d0 - zeta
+           opz23 = opz**f23
+           omz23 = omz**f23
+           phi = 0.5d0*(opz23 + omz23)
+           ds = 0.5d0*(opz23*opz + omz23*omz)
+           dx = 0.5d0*(opz23*opz23 + omz23*omz23)
+           gc = (1d0 - dxc*(dx - 1d0))*(1d0 - zeta**12)
+         endif
+         phi2 = phi*phi
+         phi3 = phi2*phi
+         tueg = 0.3d0*ckf2*ds*ntot**F53
+c         
+c----------------------------------------------------------------------
+c functions related to delrho  
+c----------------------------------------------------------------------
+c
+         p=dn2/(F4*ckf2*n83)
+         dpdg = 1d0/(F4*ckf2*n83)
+         dpdn = -F83*p/ntot
+c         
+         t2 = ckf2*p/(4d0*phi2*rs*2d0**F23)
+         dt2dp = ckf2/(4d0*phi2*rs*2d0**F23)
+         dt2drs = -t2/rs
+c
+         tvw = 0.125d0*dn2/ntot
+c
+c----------------------------------------------------------------------
+c functions related to tau
+c----------------------------------------------------------------------
+c
+
+         alpha = (tautot - tvw)/(tueg + eta*tvw)
+         oma = 1d0 - alpha
+         oma2 = oma*oma
+
+         if (alpha.lt.0d0) then
+           exp5 = dexp(-c1c*alpha/oma)
+           fca = exp5
+           dfcada = -c1c*exp5/oma2
+         elseif (alpha.lt.2.5d0) then
+           rtemp(0) = 1d0
+           do ifc=1,7
+             rtemp(ifc) = rtemp(ifc-1)*alpha
+           enddo
+           fca = dot_product(rRegu,rtemp)
+           dfcada = dot_product(rRegu1, rtemp(0:6))
+         else
+           exp6 = dexp(c2c/oma)
+           fca = -dc*exp6
+           dfcada = -dc*exp6*c2c/oma2
+         endif
+c
+         dalphadt = 1d0/(tueg + eta*tvw)
+         dalphadg = -0.125d0/(ntot*(tueg + eta*tvw))*(1d0 + alpha*eta)
+         dalphadn = f53*tueg/(ntot*(tueg+eta*tvw))*
+     &                (p/ds*(1d0+eta*alpha) - alpha)
+c
+c----------------------------------------------------------------------
+c EC1
+c----------------------------------------------------------------------
+c
+c eclda1 and derivatives
+c
+         call lsdac(tol_rho,rs,zeta,eclda1,declda1drs,declda1dz,
+     &              d2eclda1drs2,d2eclda1drsdz,dummy)
+c
+c eclda0 and derivatives
+c
+         eclda0 = -b1c/(1d0 + b2c*rs12 + b3c*rs)
+         declda0drs = -eclda0*(b3c + 0.5d0*b2c/rs12)/
+     &                (1d0 + b2c*rs12 + b3c*rs)
+         d2eclda0drs2 = eclda0/(1d0 + b2c*rs12 + b3c*rs) *
+     &          ( 2d0*(b3c+0.5d0*b2c/rs12)**2/(1d0+b2c*rs12+b3c*rs) +
+     &            0.25d0*b2c/rs/rs12 )
+c
+         BETA = BETAzero*(1d0 + p14a*rs)/(1d0 + p14b*rs)
+         dBETAdrs = BETAzero*(p14a - p14b)/(1d0 + p14b*rs)**2
+c
+         w1fac = eclda1/(GAMMA*phi3)
+         expw1 = dexp(-w1fac)
+         w1 = expw1 - 1d0
+         dw1drs = -expw1*declda1drs/(GAMMA*phi3)
+
+         A = BETA/GAMMA/w1
+         dAdrs = dBETAdrs/GAMMA/w1 - A*dw1drs/w1
+c         
+         At2 = A*t2
+         exp1 = dexp(-p**2/rDp2**4)
+         deltaY = rfc2/(27d0*gamma*phi3*w1*ds) *
+     &              (20d0*rs*(declda0drs-declda1drs) - 
+     &               45d0*eta*(eclda0-eclda1))
+         deltaYp = deltaY*p*exp1
+         ddeltaYpdrs = -deltaYp/w1*dw1drs + 
+     &                rfc2/(27d0*gamma*phi3*w1*ds)*
+     &                  (20d0*(declda0drs-declda1drs) +
+     &                   20d0*rs*(d2eclda0drs2-d2eclda1drs2) - 
+     &                   45d0*eta*(declda0drs-declda1drs))*p*exp1
+         ddeltaYpdp = deltaY*exp1 - 2d0*p*deltaYp/rDp2**4
+
+         Gaux = 1d0 + 4d0*(At2-deltaYp)
+         GAt2y = 1d0/dsqrt(dsqrt(Gaux))
+         dGat2ydrs = -Gat2y*(dAdrs*t2 + A*dt2drs - ddeltaYpdrs)/Gaux
+         dGat2ydp = -Gat2y*(A*dt2dp - ddeltaYpdp)/Gaux
+
+         arg1 = 1d0 + w1*(1d0 - GAt2y)
+         darg1drs = dw1drs*(1d0 - GAt2y) - w1*dGat2ydrs
+         darg1dp = -w1*dGAt2ydp
+
+         H1 = GAMMA*phi3*dlog(arg1)
+         dH1dp = GAMMA*phi3*darg1dp/arg1
+         dH1drs = GAMMA*phi3*darg1drs/arg1
+
+         Ec1 = eclda1 + H1
+         dEc1drs = declda1drs + dH1drs
+         dEc1dp = dH1dp
+c
+c--------------------------------------------------------------
+c EC0
+c--------------------------------------------------------------
+c
+         w0fac = eclda0/b1c
+         expw0 = dexp(-w0fac)
+         w0 = expw0 - 1d0
+         dw0drs = -declda0drs*expw0/b1c
+
+         ginf = (1d0/(1d0 + 4d0*xi*p))**F14
+         dginfdp = -xi*ginf/(1d0 + 4d0*xi*p)
+
+         arg0 = 1d0 + w0*(1d0 - ginf)
+         darg0drs = dw0drs*(1d0 - ginf)
+         darg0dp = -w0*dginfdp
+
+         H0 = b1c*dlog(arg0)
+         dH0dp = b1c*darg0dp/arg0
+         dH0drs = b1c*darg0drs/arg0
+
+         Ec0 = (eclda0 + H0)*gc
+         dEc0drs = gc*(declda0drs + dH0drs)
+         dEc0dp = gc*dH0dp
+c
+c        --------------------------------------------------------------
+c
+         Ec = Ec + cfac*ntot*(Ec1 + fca*(Ec0-Ec1))*qwght(n)
+         if (ldew) func(n) = func(n) + cfac*ntot*(Ec1 + fca*(Ec0-Ec1))
+
+         dEc1dn = dEc1drs*drsdn + dEc1dp*dpdn
+         dEc0dn = dEc0drs*drsdn + dEc0dp*dpdn
+         dfcadn = dfcada*dalphadn
+         dfcadt = dfcada*dalphadt
+
+         vcn = Ec1 + fca*(Ec0-Ec1) + 
+     &         ntot*(dEc1dn + fca*(dEc0dn-dEc1dn) + dfcadn*(Ec0-Ec1))
+
+         Amat(n,1) = Amat(n,1) + cfac*(vcn+ntot*dfcadt*(Ec0-Ec1)*dtdna)
+
+         dEc1dg = dEc1dp*dpdg
+         dEc0dg = dEc0dp*dpdg
+         dfcadg = dfcada*dalphadg         
+
+         Cmat(n,D1_GAA) = Cmat(n,D1_GAA) + cfac*ntot*(dEc1dg + 
+     &   fca*(dEc0dg-dEc1dg) + dfcadg*(Ec0-Ec1) +
+     &   dfcadt*(Ec0-Ec1)*dtdga)
+         Cmat(n,D1_GAB) = Cmat(n,D1_GAB) + cfac*ntot*(dEc1dg + 
+     &   fca*(dEc0dg-dEc1dg) + dfcadg*(Ec0-Ec1))*2d0
+
+         Lmat(n,1) = Lmat(n,1) + cfac*ntot*dfcadt*dtdla*(Ec0-Ec1)
+
+         if (ipol.eq.2) then
+           Amat(n,2) = Amat(n,2)+cfac*(vcn+ntot*dfcadt*(Ec0-Ec1)*dtdnb)
+
+           Cmat(n,D1_GBB) = Cmat(n,D1_GBB) + cfac*ntot*(dEc1dg +
+     &     fca*(dEc0dg-dEc1dg) + dfcadg*(Ec0-Ec1) +
+     &     dfcadt*(Ec0-Ec1)*dtdgb)
+           
+           Lmat(n,2) = Lmat(n,2) + cfac*ntot*dfcadt*dtdlb*(Ec0-Ec1)
+
+           if (omz.lt.tol_rho) then
+             dphidzeta = 0.5d0*F23*(opz23/opz)
+           else if (opz.lt.tol_rho) then
+             dphidzeta = -0.5d0*F23*(omz23/omz)
+           else
+             dphidzeta = 0.5d0*F23*(opz23/opz - omz23/omz)
+           end if
+
+           dt2dzeta = -2d0*t2*dphidzeta/phi
+           dw1dzeta = (3d0*w1fac*dphidzeta/phi - 
+     &                 declda1dz/(GAMMA*phi3))*expw1
+           dAdzeta = -A*dw1dzeta/w1
+
+           ddsdzeta = 0.5d0*F53*(opz23 - omz23)
+           ddeltaYpdz = -deltaYp/w1*dw1dzeta - deltaYp/ds*ddsdzeta -
+     &                  3d0*deltaYp*dphidzeta/phi +
+     &                  rfc2/(27d0*gamma*phi3*w1*ds)*(
+     &                     -20d0*rs*d2eclda1drsdz +
+     &                     45d0*eta*declda1dz)*p*exp1
+
+           dGAt2ydz = -GAt2y*(dAdzeta*t2 + A*dt2dzeta - ddeltaYpdz)/Gaux
+           darg1dzeta = dw1dzeta*(1d0-GAt2y) - w1*dGAt2ydz
+           dH1dzeta = 3d0*H1*dphidzeta/phi + GAMMA*phi3*darg1dzeta/arg1
+           dEc1dzeta = declda1dz + dH1dzeta
+
+           ddxdzeta = 0.5d0*F43*(opz**F13 - omz**F13)
+           dgcdzeta = -dxc*ddxdzeta*(1d0 - zeta**12) -
+     &                12d0*zeta**11*(1d0 - dxc*(dx - 1d0))
+           dEc0dzeta = dgcdzeta*(eclda0 + H0)
+
+
+           dalphadzeta = -alpha/(tueg+eta*tvw)*tueg*ddsdzeta/ds
+
+           dfcadzeta = dfcada*dalphadzeta
+
+           vcpol = dEc1dzeta + dfcadzeta*(Ec0-Ec1) + 
+     &             fca*(dEc0dzeta-dEc1dzeta)
+
+           Amat(n,1) = Amat(n,1) + cfac*omz*vcpol
+           Amat(n,2) = Amat(n,2) - cfac*opz*vcpol
+         
+         end if
+
+20    continue
+      end
+
+      Subroutine xc_cr2scanl_d2()
+      implicit none
+      call errquit(' xc_cr2scanl: d2 not coded ',0,0)
+      return
+      end

--- a/src/nwdft/xc/xc_cscan.F
+++ b/src/nwdft/xc/xc_cscan.F
@@ -316,7 +316,7 @@ c
          if (ldew) func(n) = func(n) + cfac*ntot*(Ec1 + fca*(Ec0-Ec1))
 c
          if (whichfc.eq.'orig') then
-           idalphadn = f53*(p/ds-alpha)/ntot
+           dalphadn = f53*(p/ds-alpha)/ntot
            dalphadg = -0.125d0/(tueg*ntot)
            dalphadt = 1d0/tueg
          else if (whichfc.eq.'regu') then

--- a/src/nwdft/xc/xc_eval_fnl.F
+++ b/src/nwdft/xc/xc_eval_fnl.F
@@ -1691,6 +1691,50 @@ c
          endif
       endif
 c
+c     r^2SCAN meta GGA
+c
+      if (abs(xfac(73)).gt.eps) then
+         if(.not. do_2nd) then
+            call xc_xr2scan(tol_rho, xfac(73), rho, delrho, Amat, 
+     &                    Cmat, nq, ipol, Ex, qwght, ldew, func, ttau, 
+     &                    Mmat)
+         else
+            call xc_xr2scan_d2()
+         endif
+      endif
+c
+      if (abs(cfac(73)).gt.eps) then
+         if(.not. do_2nd) then
+            call xc_cr2scan(tol_rho, cfac(73), rho, delrho, Amat, 
+     &                    Cmat, nq, ipol, Ec, qwght, ldew, func, ttau, 
+     &                    Mmat)
+         else
+            call xc_cr2scan_d2()
+         endif
+      endif
+c
+c     r^2SCAN-L meta GGA
+c
+      if (abs(xfac(74)).gt.eps) then
+         if(.not. do_2nd) then
+            call xc_xr2scanl(tol_rho, xfac(74), rho, delrho, laprho, 
+     &                    Amat, Cmat, Lmat, nq, ipol, Ex, qwght, ldew, 
+     &                    func)
+         else
+            call xc_xr2scanl_d2()
+         endif
+      endif
+c
+      if (abs(cfac(74)).gt.eps) then
+         if(.not. do_2nd) then
+            call xc_cr2scanl(tol_rho, cfac(74), rho, delrho, laprho, 
+     &                    Amat, Cmat, Lmat, nq, ipol, Ec, qwght, ldew, 
+     &                    func)
+         else
+            call xc_cr2scanl_d2()
+         endif
+      endif
+c
 c     Calculate the steric energy
 c
       if (lsteric) then

--- a/src/nwdft/xc/xc_util.F
+++ b/src/nwdft/xc/xc_util.F
@@ -40,7 +40,7 @@ c
      + xfac(60) + xfac(61) + xfac(62) + xfac(63) + xfac(68) + xfac(69)+
      +     xfac(66) + cfac(66) + xfac(67) + cfac(67) +
      +     cfac(68)+  cfac(69) + xfac(70) + xfac(71) + cfac(71) +
-     L     xfac(72) + lxdm +
+     L     xfac(72) + xfac(73) + xfac(74) + lxdm +
 cc AJL/Begin/FDE
      + xfac_fde(3) + xfac_fde(4) + xfac_fde(5) + xfac_fde(6) + 
      + xfac_fde(7) +
@@ -190,6 +190,8 @@ cb973     .     xfac(22).ne.0d0.or.
      .     xfac(68).ne.0d0.or.
      .     xfac(69).ne.0d0.or.
      .     xfac(71).ne.0d0.or.
+     .     xfac(73).ne.0d0.or.
+     .     xfac(74).ne.0d0.or.
 c
 chcth     .     cfac(13).ne.0d0.or.
 cCbecke97     .     cfac(14).ne.0d0.or.
@@ -224,6 +226,8 @@ chp414     .     cfac(21).ne.0d0.or.
      .     cfac(68).ne.0d0.or.
      .     cfac(69).ne.0d0.or.
      .     cfac(71).ne.0d0.or.
+     .     cfac(73).ne.0d0.or.
+     .     cfac(74).ne.0d0.or.
      .     cfac(36).ne.0d0)
       if (util_module_avail("nwxc")) then
          call nwxc_getvals("nwxc_has_2nd",out1)
@@ -259,7 +263,7 @@ c
      +      cfac(48) + cfac(49) + cfac(50) + cfac(51) +
      +      xfac(66) + cfac(66) + xfac(67) + cfac(67) +
      +      xfac(68) + cfac(68) + xfac(69) + cfac(69) +
-     +      xfac(71) + cfac(71) +
+     +      xfac(71) + cfac(71) + xfac(73) + cfac(73) +
 cc AJL/Begin/FDE
      +      xfac_fde(18) + cfac_fde(25) + xfac_fde(21) + cfac_fde(27) +
      +      xfac_fde(28) + xfac_fde(29) + xfac_fde(33) + xfac_fde(34) + 
@@ -491,7 +495,9 @@ c
      .     xfac(67).ne.0d0.or.  ! SCAN-L
      .     xfac(68).ne.0d0.or.  ! revM06
      .     xfac(69).ne.0d0.or.  ! revM06-L
-     .     xfac(71).ne.0d0.or.  ! regSCAN
+     .     xfac(71).ne.0d0.or.  ! rSCAN
+     .     xfac(73).ne.0d0.or.  ! r^2SCAN
+     .     xfac(74).ne.0d0.or.  ! r^2SCAN-L
 c
      .     cfac(5).ne.0d0.or.   ! PW91
      .     cfac(13).ne.0d0.or.  ! HCTH
@@ -537,7 +543,9 @@ c
      .     cfac(67).ne.0d0.or.  ! SCAN-L
      .     cfac(68).ne.0d0.or.  ! revM06
      .     cfac(69).ne.0d0.or.  ! revM06-L
-     .     cfac(71).ne.0d0      ! regSCAN
+     .     cfac(71).ne.0d0.or.  ! rSCAN
+     .     cfac(73).ne.0d0.or.  ! r^2SCAN
+     .     cfac(74).ne.0d0      ! r^2SCAN-L
      .                )
 c
       return
@@ -549,7 +557,7 @@ C
 #include "util.fh"
       double precision tot,eps
       parameter(eps=1.d-10)
-      tot = xfac(67) + cfac(67)
+      tot = xfac(67) + cfac(67) + xfac(74) + cfac(74)
 
       if (abs(tot).gt.eps) then
         xc_chklap = .true.

--- a/src/nwdft/xc/xc_xr2scan.F
+++ b/src/nwdft/xc/xc_xr2scan.F
@@ -1,18 +1,6 @@
-c Copyright 2018 (C) Orbital-free DFT group at University of Florida
-c Licensed under the Educational Community License, Version 2.0 
-c (the "License"); you may not use this file except in compliance with 
-c the License. You may obtain a copy of the License at
-c
-c    http://www.osedu.org/licenses/ECL-2.0
-c
-c Unless required by applicable law or agreed to in writing,
-c software distributed under the License is distributed on an "AS IS"
-c BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-c or implied. See the License for the specific language governing
-c permissions and limitations under the License.
-c
 #include "dft2drv.fh"
-c     Strongly constrained and appropriately normed (SCAN) 
+c     Regularized and restored strongly constrained 
+c     and appropriately normed (r^2SCAN) 
 c     functional (Exchange part only)
 c           META GGA
 C         utilizes ingredients:
@@ -22,23 +10,16 @@ c                              tau - K.S kinetic energy density
 c
 c     Written by:
 c     Daniel Mejia-Rodriguez
-c     QTP, Department of Physics, University of Florida
 c
 c     References:
-c     J. Sun, A. Ruzsinszky, J.P. Perdew
-c     PRL 115, 036402 (2015)
-c     DOI: 10.1103/PhysRevLett.115036402
-c
-c     A.P. Bartok and J.R. Yates
-c     JCP 150, 161101 (2019)
-c     DOI: 10.1063/1.5094646
+c     J.W. Furness, A.D. Kaplan, J. Ning, J.P. Perdew, J. Sun
+c     JPCLett 11, 8208-8215 (2020)
+c     DOI: 10.1021/acs.jpclett.0c02405
 
-      Subroutine xc_xscan(whichfx, tol_rho, fac,  rho, delrho, 
+      Subroutine xc_xr2scan(tol_rho, fac,  rho, delrho, 
      &                    Amat, Cmat, nq, ipol, Ex, 
      &                    qwght, ldew, func, tau,Mmat)
       implicit none
-c
-      character*(*) whichfx
 c
       double precision fac, Ex
       integer nq, ipol
@@ -73,7 +54,7 @@ c
 c     SPIN-RESTRICTED
 c     Ex = Ex[n]
 c
-         call xc_xscan_cs(whichfx, tol_rho, fac,  rho, delrho, 
+         call xc_xr2scan_cs(tol_rho, fac,  rho, delrho, 
      &                    Amat, Cmat, nq, Ex, 1d0,
      &                    qwght, ldew, func, tau,Mmat)
       else
@@ -84,7 +65,7 @@ c     Ex = Ex[2n_up]/2 + Ex[2n_down]/2
          do ispin=1,2
             if (ispin.eq.1) cmatpos=D1_GAA
             if (ispin.eq.2) cmatpos=D1_GBB
-            call xc_xscan_cs(whichfx, tol_rho, fac,  
+            call xc_xr2scan_cs(tol_rho, fac,  
      R           rho(1,ispin+1), delrho(1,1,ispin), 
      &           Amat(1,ispin), Cmat(1,cmatpos), 
      &           nq, Ex, 2d0,
@@ -95,12 +76,11 @@ c     Ex = Ex[2n_up]/2 + Ex[2n_down]/2
       endif
       return
       end
-      Subroutine xc_xscan_cs(whichfx, tol_rho, fac,  rho, delrho, 
+      Subroutine xc_xr2scan_cs(tol_rho, fac,  rho, delrho, 
      &                     Amat, Cmat, nq, Ex, facttwo,
      &                     qwght, ldew, func, tau,Mmat)
       implicit none
 c
-      character*(*) whichfx
       double precision fac, Ex
       integer nq
       logical ldew
@@ -135,9 +115,9 @@ c
       double precision p, p14, a, g2
 
       double precision F13, F23, F43, F53, F83, F18
-      double precision Ax, Pconst, thr1, thr2
-      double precision rH0, rK1, rA1, rC1, rC2, rD, rMu
-      double precision rB1, rB2, rB3, rB4
+      double precision Ax, Pconst
+      double precision rH0, rK1, rA1, rC1x, rC2x, rD, rMu
+      double precision rCeta, rC2, eta, rDp2
 
       double precision oma, oma2
       double precision exp1, exp2, exp3, exp4, exp5
@@ -156,23 +136,24 @@ c     functional derivatives below FFFFFFFFFFFF
       double precision dxdp, dx1dp, dx2dp, dxda
       double precision dpdg, dpdr 
       double precision dFxda, dFxdp, dFxdr, dFxdg, dFxdt
-      double precision dadp,dadg,dadt,dadr
+      double precision dadp,dadg,dadt,dadr,alpha
       
 c     functional derivatives above FFFFFFFFFFFF
       
       parameter (F43=4.d0/3.d0, F13=1.d0/3.d0)
       parameter (F83=8.d0/3.d0, F23=2.d0/3.d0)
       parameter (F18=1.d0/8.d0, F53=5.d0/3.d0)
-      parameter (thr1=0.996d0, thr2=1.004d0)
 
       parameter (rH0=1.174d0)
       parameter (rK1=0.065d0)
       parameter (rA1=4.9479d0)
-      parameter (rC1=0.667d0)
-      parameter (rC2=0.8d0)
+      parameter (rC1x=0.667d0)
+      parameter (rC2x=0.8d0)
       parameter (rD=1.24d0)
       parameter (rMu=10.0d0/81.0d0)
-      parameter (rB3=0.5d0)
+      parameter (eta=1d-3)
+      parameter (rCeta=20d0/27d0+eta*f53)
+      parameter (rDp2=0.361d0)
 
       parameter (rRegu = (/ 1d0, -0.667d0, -0.4445555d0, 
      &                    -6.63086601049291d-1, 1.45129704448975d0,
@@ -182,10 +163,8 @@ c     functional derivatives above FFFFFFFFFFFF
      &             -3d0*6.63086601049291d-1, 4d0*1.45129704448975d0,
      &             -5d0*8.87998041596655d-1, 6d0*2.34528941478571d-1,
      &             -7d0*2.31858433223407d-2/) )
+      parameter (rC2 = -sum(rRegu1)*(1d0-rH0))
 
-      rB2=dsqrt(5913.d0/405000.d0)
-      rB1=(511.d0/13500.d0)/(2.d0*rB2)
-      rB4=rMu*rMu/rK1-1606.d0/18225.d0-rB1*rB1
 c
       pi=acos(-1d0)
       Ax = (-0.75d0)*(3d0/pi)**F13
@@ -217,27 +196,13 @@ c
             p   = g2/(4d0*Pconst*rho83)
             p14 = dsqrt(dsqrt(p))
 c
-            if (whichfx.eq.'orig') then
-              a=(tauN-tauW)/tauU
-              if(a.lt.0d0)  a=0d0
-              regalpha = a
-              dregalpha = 1d0
-            else if (whichfx.eq.'regu') then
-              a=(tauN-tauW)/(tauU + 1d-4*facttwo**f53)
-              if(a.lt.0d0)  a=0d0
-              regalpha = a**3/(a**2 + 1d-3)
-              dregalpha = a/(a**2+1d-3)*(3d0*a - 2d0*regalpha)
-            endif
+            alpha=(tauN-tauW)/(tauU + eta*tauW)
 
-            oma = 1d0 - regalpha
+            oma = 1d0 - alpha
             oma2 = oma*oma
             
-            exp1 = dexp(-rB4/rMu*p)
-            exp2 = dexp(-rB3*oma2)
-            x1 = rMu*p*(1d0 + rB4/rMu*p*exp1)
-            x2 = rB1*p + rB2*oma*exp2
-
-            x = x1 + x2*x2
+            exp1 = dexp(-p**2/rdp2**4)
+            x = rCeta*rC2*exp1*p + rMu*p
 
             Hden = rK1 + x
             Hnum = hden + rK1*x
@@ -249,33 +214,21 @@ c
               exp3 = dexp(-rA1/p14)
             endif
             G = 1d0 - exp3
-
 c
 c Switching function
 c
-            if (whichfx.eq.'orig') then
-              if (regalpha.ge.thr1) then
-                exp4 = 0d0
-              else
-                exp4 = dexp(-rC1*regalpha/oma)
-              end if
-              if (regalpha.le.thr2) then
-                exp5 = 0d0
-              else
-                exp5 = dexp(rC2/oma)
-              end if
-              Fa = exp4 - rD*exp5
-            else if (whichfx.eq.'regu') then
-              if (regalpha.lt.2.5d0) then
-                rtemp(0) = 1d0
-                do ifx=1,7
-                  rtemp(ifx) = rtemp(ifx-1)*regalpha
-                enddo
-                Fa = dot_product(rRegu,rtemp)
-              else
-                exp5 = dexp(rC2/oma)
-                Fa = -rD*exp5
-              end if
+            if (alpha.lt.0.0d0) then
+              exp4 = dexp(-rC1x*alpha/oma)
+              Fa = exp4
+            else if (alpha.lt.2.5d0) then
+              rtemp(0) = 1d0
+              do ifx=1,7
+                rtemp(ifx) = rtemp(ifx-1)*alpha
+              enddo
+              Fa = dot_product(rRegu,rtemp)
+            else
+              exp5 = dexp(rC2x/oma)
+              Fa = -rD*exp5
             end if
 
             Fx = G*(H + Fa*(rH0 - H))
@@ -288,15 +241,9 @@ c     functional derivatives FFFFFFFFFFFFFFFFFFFFFFFFFFFF
             dpdr = -F83*p*rrho
             dpdg = 1d0/(4d0*Pconst*rho83)
 
-            if (whichfx.eq.'orig') then
-              dadg = -F18*rrho/tauU
-              dadt = 1d0/tauU
-              dadr = F53*(p-a)*rrho
-            else if (whichfx.eq.'regu') then
-              dadg = -F18*rrho/(tauU + 1d-4*facttwo**f53)
-              dadt = 1d0/(tauU + 1d-4*facttwo**f53)
-              dadr = 5d0/3d0*(p - a)*tauU*rrho/(tauU +1d-4*facttwo**f53)
-            endif
+            dadt = 1d0/(tauU + eta*tauW)
+            dadg = -f18*rrho*(alpha*eta + 1d0)/(tauU + eta*tauW)
+            dadr = f53*tauU*rrho/(tauU + eta*tauW)*(p-alpha+eta*p*alpha)
 
             if (p14.lt.0.001d0) then
               dGdp = 0d0
@@ -304,34 +251,24 @@ c     functional derivatives FFFFFFFFFFFFFFFFFFFFFFFFFFFF
               dGdp = -0.25d0*rA1*exp3/(p*p14)
             end if
 
-            dx1dp = rMu + rB4*p*exp1*(2d0 - p*rB4/rMu)
-            dx2dp = rB1
-            dxdp = dx1dp + 2d0*x2*dx2dp
-            dxda = 2d0*rB2*exp2*x2*(2d0*rB3*oma2 - 1d0)*dregalpha
+            dxdp = rMu + rCeta*rC2*exp1*(1d0 - 2d0*p**2/rdp2**4)
 
             dHdx = (rK1/Hden)**2
             dHdp = dHdx*dxdp
-            dHda = dHdx*dxda
 
 c
 c Switching function
 c
-            if (whichfx.eq.'orig') then
-              if ((regalpha.ge.thr1).and.(regalpha.le.thr2)) then
-                dFada = 0d0
-              else
-                dFada = -(rC1*exp4 + rD*exp5*rC2)/oma2
-              end if
-            else if (whichfx.eq.'regu') then
-              if (regalpha.lt.2.5d0) then
-                dFada = dot_product(rRegu1,rtemp(0:6))*dregalpha
-              else
-                dFada = -rD*exp5*rC2/oma2*dregalpha
-              endif
+            if (alpha.lt.0.0d0) then
+               dFada = -rC1x*exp4/oma2
+            else if (alpha.lt.2.5d0) then
+               dFada = dot_product(rRegu1,rtemp(0:6))
+            else
+               dFada = -rD*exp5*rC2x/oma2
             endif
 
             dFxdp = dGdp*(H + Fa*(rH0 - H)) + G*dHdp*(1d0 - Fa)
-            dFxda = G*(dHda + dFada*(rH0 - H) - Fa*dHda)
+            dFxda = G*(dFada*(rH0 - H))
 
             dFxdr = dFxda*dadr + dFxdp*dpdr
             dFxdg = dFxda*dadg + dFxdp*dpdg
@@ -352,7 +289,7 @@ c
       return
       end
 
-      Subroutine xc_xscan_d2()
+      Subroutine xc_xr2scan_d2()
       call errquit(' xscan: d2 not coded ',0,0)
       return
       end

--- a/src/nwdft/xc/xc_xr2scanl.F
+++ b/src/nwdft/xc/xc_xr2scanl.F
@@ -1,0 +1,311 @@
+#include "dft2drv.fh"
+c     Deorbitalized version of the regularized and restored 
+c     strongly constrained and appropriately normed (r^2SCAN-L) 
+c     functional (exchange part only)
+c           META GGA
+C         utilizes ingredients:
+c                              rho   -  density
+c                              delrho - gradient of density
+c                              laprho - Laplacian of density
+c
+c     Written by:
+c     Daniel Mejia-Rodriguez
+c
+c     References:
+c     J.W. Furness, A.D. Kaplan, J. Ning, J.P. Perdew, J. Sun
+c     JPCLett 11, 8208-8215 (2020)
+c     DOI: 10.1021/acs.jpclett.0c02405
+c
+c     D. Mejia-Rodriguez, S.B. Trickey
+c     PRB 102, 121109(R) (2020)
+c     DOI: 10.1103/PhysRevB.102.121109
+
+      Subroutine xc_xr2scanl(tol_rho, fac,  rho, delrho, laprho,
+     &                    Amat, Cmat, Lmat, nq, ipol, Ex, 
+     &                    qwght, ldew, func)
+      implicit none
+c
+      double precision fac, Ex
+      integer nq, ipol
+      logical ldew
+      double precision func(*)  ! value of the functional [output]
+c
+c     Charge Density & Its Cube Root
+c
+      double precision rho(nq,ipol*(ipol+1)/2)
+c
+c     Charge Density Gradient
+c
+      double precision delrho(nq,3,ipol)
+c
+c     Charge Density Laplacian
+c
+      double precision laprho(nq,ipol)
+c
+c     Quadrature Weights
+c
+      double precision qwght(nq)
+c
+c     Sampling Matrices for the XC Potential & Energy
+c
+      double precision Amat(nq,ipol), Cmat(nq,*), Lmat(nq,ipol)
+c
+      double precision tol_rho
+c
+      integer ispin,cmatpos
+c
+      if (ipol.eq.1 )then
+c     
+c     SPIN-RESTRICTED
+c     Ex = Ex[n]
+c
+         call xc_xr2scanl_cs(tol_rho, fac,  rho, delrho, laprho,
+     &                    Amat, Cmat, Lmat, nq, Ex, 1d0,
+     &                    qwght, ldew, func)
+      else
+c     
+c     SPIN-UNRESTRICTED
+c     Ex = Ex[2n_up]/2 + Ex[2n_down]/2
+
+         do ispin=1,2
+            if (ispin.eq.1) cmatpos=D1_GAA
+            if (ispin.eq.2) cmatpos=D1_GBB
+            call xc_xr2scanl_cs(tol_rho, fac,  
+     R           rho(1,ispin+1), delrho(1,1,ispin), laprho(1,ispin),
+     &           Amat(1,ispin), Cmat(1,cmatpos), Lmat(1,ispin),
+     &           nq, Ex, 2d0,
+     &           qwght, ldew, func)
+         enddo
+
+      endif
+      return
+      end
+      Subroutine xc_xr2scanl_cs(tol_rho, fac,  rho, delrho, laprho,
+     &                     Amat, Cmat, Lmat, nq, Ex, facttwo,
+     &                     qwght, ldew, func)
+      implicit none
+c
+      double precision fac, Ex
+      integer nq
+      logical ldew
+      double precision func(*)  ! value of the functional [output]
+c
+c     Charge Density & Its Cube Root
+c
+      double precision rho(*)
+c
+c     Charge Density Gradient
+c
+      double precision delrho(nq,3)
+c
+c     Charge Density Laplacian
+c
+      double precision laprho(nq)
+c
+c     Quadrature Weights
+c
+      double precision qwght(nq)
+c
+c     Sampling Matrices for the XC Potential & Energy
+c
+      double precision Amat(nq), Cmat(nq), Lmat(nq)
+c
+      double precision facttwo, afact2 ! 2 for o.s. 1 for c.s.
+c
+      integer n, ifx
+      double precision tol_rho, pi
+      double precision rhoval, rrho, rho13, rho43, rho53, rho83
+      double precision tauN, tauW, tauU
+      double precision p, p14, a, g2
+
+      double precision F13, F23, F43, F53, F83, F18
+      double precision Ax, Pconst
+      double precision rH0, rK1, rA1, rC1x, rC2x, rD, rMu
+      double precision rCeta, rC2, eta, rDp2
+
+      double precision oma, oma2
+      double precision exp1, exp2, exp3, exp4, exp5
+      double precision rtemp(0:7), rRegu(0:7), rRegu1(7)
+      double precision regalpha, dregalpha
+      double precision x1, x2, x
+      double precision H, Hden, Hnum
+      double precision G
+      double precision Fx, Fa
+
+c     functional derivatives below FFFFFFFFFFFF
+
+      double precision derivr, derivg, derivl
+      double precision dFada
+      double precision dGdp, dHdp, dHdx, dHda
+      double precision dxdp, dx1dp, dx2dp, dxda
+      double precision dpdg, dpdr 
+      double precision dFxda, dFxdp, dFxdr, dFxdg, dFxdl
+      double precision dadp,dadg,dadt,dadr,alpha,dadq
+      double precision fs, dfsdp, dfsdq, dqdr, dqdl, q
+      double precision lapval
+      
+c     functional derivatives above FFFFFFFFFFFF
+      
+      parameter (F43=4.d0/3.d0, F13=1.d0/3.d0)
+      parameter (F83=8.d0/3.d0, F23=2.d0/3.d0)
+      parameter (F18=1.d0/8.d0, F53=5.d0/3.d0)
+
+      parameter (rH0=1.174d0)
+      parameter (rK1=0.065d0)
+      parameter (rA1=4.9479d0)
+      parameter (rC1x=0.667d0)
+      parameter (rC2x=0.8d0)
+      parameter (rD=1.24d0)
+      parameter (rMu=10.0d0/81.0d0)
+      parameter (eta=1d-3)
+      parameter (rCeta=20d0/27d0+eta*f53)
+      parameter (rDp2=0.361d0)
+
+      parameter (rRegu = (/ 1d0, -0.667d0, -0.4445555d0, 
+     &                    -6.63086601049291d-1, 1.45129704448975d0,
+     &                    -8.87998041596655d-1, 2.34528941478571d-1,
+     &                    -2.31858433223407d-2/) )
+      parameter (rRegu1 = (/ -0.667d0, -2d0*0.4445555d0,
+     &             -3d0*6.63086601049291d-1, 4d0*1.45129704448975d0,
+     &             -5d0*8.87998041596655d-1, 6d0*2.34528941478571d-1,
+     &             -7d0*2.31858433223407d-2/) )
+      parameter (rC2 = -sum(rRegu1)*(1d0-rH0))
+
+c
+      pi=acos(-1d0)
+      Ax = (-0.75d0)*(3d0/pi)**F13
+      Pconst = (3.d0*pi**2)**F23
+      afact2=1d0/facttwo
+c
+      do n = 1, nq
+         if (rho(n).ge.tol_rho) then
+
+            call ts_pc(tol_rho, rho(n), delrho(n,1:3), laprho(n),
+     &                 dfsdp, dfsdq, fs, facttwo)
+
+            rhoval=rho(n)*facttwo
+            rho43 = rhoval**F43  ! rho^4/3
+            rrho  = 1d0/rhoval   ! reciprocal of rho
+            rho13 = rho43*rrho 
+            rho83 = rho43*rho43
+            rho53 = rho43*rho13
+      
+      
+            g2 = delrho(n,1)*delrho(n,1) +
+     &           delrho(n,2)*delrho(n,2) +
+     &           delrho(n,3)*delrho(n,3)
+
+            g2 = g2 *facttwo*facttwo
+
+            lapval = laprho(n)*facttwo
+
+            tauW = F18*g2*rrho
+            tauU = 0.3d0*Pconst*rho53
+c     
+c     Evaluate the Fx
+c     
+            p   = g2/(4d0*Pconst*rho83)
+            p14 = dsqrt(dsqrt(p))
+            q = lapval/(4d0*Pconst*rho53)
+c
+            alpha = (fs - f53*p)/(1d0 + eta*f53*p)
+
+            oma = 1d0 - alpha
+            oma2 = oma*oma
+            
+            exp1 = dexp(-p**2/rdp2**4)
+            x = rCeta*rC2*exp1*p + rMu*p
+
+            Hden = rK1 + x
+            Hnum = hden + rK1*x
+            H = Hnum/Hden
+
+            if (p14.lt.0.002d0) then
+              exp3 = 0d0
+            else
+              exp3 = dexp(-rA1/p14)
+            endif
+            G = 1d0 - exp3
+c
+c Switching function
+c
+            if (alpha.lt.0.0d0) then
+              exp4 = dexp(-rC1x*alpha/oma)
+              Fa = exp4
+            else if (alpha.lt.2.5d0) then
+              rtemp(0) = 1d0
+              do ifx=1,7
+                rtemp(ifx) = rtemp(ifx-1)*alpha
+              enddo
+              Fa = dot_product(rRegu,rtemp)
+            else
+              exp5 = dexp(rC2x/oma)
+              Fa = -rD*exp5
+            end if
+
+            Fx = G*(H + Fa*(rH0 - H))
+
+            Ex = Ex + Fx*Ax*rho43*qwght(n)*fac*afact2
+            if (ldew)  func(n)= func(n) + Fx*Ax*rho43*fac*afact2
+
+c     functional derivatives FFFFFFFFFFFFFFFFFFFFFFFFFFFF
+         
+            dpdr = -F83*p*rrho
+            dpdg = 1d0/(4d0*Pconst*rho83)
+
+            dqdr = -F53*q*rrho
+            dqdl = 1.d0/(4d0*Pconst*rho53)
+
+            dadp = (dfsdp - f53 - alpha*eta*f53)/(1d0 + eta*f53*p)
+            dadq = dfsdq/(1d0 + eta*f53*p)
+
+            if (p14.lt.0.001d0) then
+              dGdp = 0d0
+            else
+              dGdp = -0.25d0*rA1*exp3/(p*p14)
+            end if
+
+            dxdp = rMu + rCeta*rC2*exp1*(1d0 - 2d0*p**2/rdp2**4)
+
+            dHdx = (rK1/Hden)**2
+            dHdp = dHdx*dxdp
+
+c
+c Switching function
+c
+            if (alpha.lt.0.0d0) then
+               dFada = -rC1x*exp4/oma2
+            else if (alpha.lt.2.5d0) then
+               dFada = dot_product(rRegu1,rtemp(0:6))
+            else
+               dFada = -rD*exp5*rC2x/oma2
+            endif
+
+            dFxdp = dGdp*(H + Fa*(rH0 - H)) + G*dHdp*(1d0 - Fa)
+            dFxda = G*(dFada*(rH0 - H))
+
+            dFxdr = dFxda*(dadp*dpdr + dadq*dqdr) + dFxdp*dpdr
+            dFxdg = dFxda*(dadp*dpdg) + dFxdp*dpdg
+            dFxdl = dFxda*dadq*dqdl
+
+            derivr = F43*Ax*rho13*Fx + Ax*rho43*dFxdr
+            derivg = Ax*rho43*dFxdg
+            derivl = Ax*rho43*dFxdl
+
+            Amat(n) = Amat(n) + derivr*fac
+c     
+c     4x factor comes from gamma_aa = gamma_total/4
+c     
+            Cmat(n)=  Cmat(n) + 2.0d0*derivg*fac
+            Lmat(n)=  Lmat(n) + derivl*fac
+         endif
+      enddo
+      return
+      end
+
+      Subroutine xc_xr2scanl_d2()
+      call errquit(' xr2scanl: d2 not coded ',0,0)
+      return
+      end
+
+


### PR DESCRIPTION
Implements the new `r2SCAN` [*J. Chem. Phys. Lett.* **11**, 8208(2020)](https://doi.org/10.1021/acs.jpclett.0c02405) and its deorbitalized version `r2SCAN-L` [*Phys. Rev. B* **102**, 121109(R) (2020)](10.1103/PhysRevB.102.121109).

Also fixes a small bug in the `rSCAN` correlation functional for spin-polarized systems. 