### PR TITLE
fix O(N) output of "chop v2"

### DIFF
--- a/src/tce/tce_energy.F
+++ b/src/tce/tce_energy.F
@@ -1888,7 +1888,7 @@ c
          end if
 ! ==============
          if(model.ne.'ccsd_act') then
-            write(6,*) ' chop v2 '
+             if (nodezero) write(6,*) ' chop v2 '
           call  tce_mo2e_zones_4a_disk_ga_chop_N5(rtdb,d_v2,
      1                                  kax_v2_alpha_offset,size_2e)
          else 


### PR DESCRIPTION
Trivial fix for `chop v2` appearing nproc times in output files.

Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>