### PR TITLE
add Apple Accelerate to the list of BLAS libraries

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3076,6 +3076,9 @@ endif
 ifeq ($(shell echo $(BLASOPT) |awk '/flexiblas/ {print "Y"; exit}'),Y)
       DEFINES += -DFLEXIBLAS
 endif
+ifeq ($(shell echo $(BLASOPT) |awk '/Accelerate/ {print "Y"; exit}'),Y)
+      DEFINES += -DACCELERATE
+endif
 
 #
 # Define known suffixes mostly so that .p files don\'t cause pc to be invoked

--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -157,6 +157,10 @@ ifdef USE_VTUNE
   EXTRA_OBJ += vtune_bind.o vtune.o
 endif
 
+ifeq ($(shell echo $(BLASOPT) |awk '/Accelerate/ {print "Y"; exit}'),Y)
+  EXTRA_OBJ += veclib_threads.o
+endif
+
        BLAS = dfill.o ifill.o  mabyte_fill.o zfill.o
 
    LIB_TARGETS = testsolve testecce

--- a/src/util/util_blasthreads.F
+++ b/src/util/util_blasthreads.F
@@ -45,6 +45,10 @@ c     return value=-1 -> threading not enabled
       external flexiblas_get_num_threads
       integer flexiblas_get_num_threads
       nt=flexiblas_get_num_threads()
+#elif defined(ACCELERATE)
+      external veclib_get_num_threads
+      integer veclib_get_num_threads
+      nt=veclib_get_num_threads()
 #elif defined(INTERNALBLAS)
       nt=1
 #else

--- a/src/util/util_blasthreads.F
+++ b/src/util/util_blasthreads.F
@@ -10,6 +10,8 @@ c
       call bli_thread_set_num_threads(nt)
 #elif defined(FLEXIBLAS)
       call flexiblas_set_num_threads(nt)
+#elif defined(ACCELERATE)
+! unnecessary?
 #elif defined(INTERNALBLAS)
 c do nothing      
 #else

--- a/src/util/util_blasthreads.F
+++ b/src/util/util_blasthreads.F
@@ -11,7 +11,7 @@ c
 #elif defined(FLEXIBLAS)
       call flexiblas_set_num_threads(nt)
 #elif defined(ACCELERATE)
-! unnecessary?
+      call veclib_set_num_threads(nt)
 #elif defined(INTERNALBLAS)
 c do nothing      
 #else

--- a/src/util/veclib_threads.c
+++ b/src/util/veclib_threads.c
@@ -1,0 +1,22 @@
+/* the environment variable VECLIB_MAXIMUM_THREADS is used to set the no. of threads for Apple*/
+/* Accelerate framework. See man 3 Accelerate  for more details */
+#include <stdio.h>
+#include <stdlib.h>
+#include "typesf2c.h"
+
+void FATR veclib_set_num_threads_(Integer *n){
+    char var[256];
+    sprintf(var, "%ld", *n);
+    setenv("VECLIB_MAXIMUM_THREADS", var, 1);
+  }
+Integer FATR veclib_get_num_threads_(){
+  const char* value;
+  int n=0;
+  value = getenv("VECLIB_MAXIMUM_THREADS");
+  if (NULL != value) {
+    n=atol(value);
+  }else{
+    n=1;
+  }
+  return (Integer) n;
+}


### PR DESCRIPTION
Without this patch, NWChem dies in `util_blas_set_num_threads`.  There is currently no thread get/set API for Apple Accelerate but GCD should minimize oversubscription issues should they exist due to MPI (according to an Apple expert).

Tests are passing on Apple M1 with the following configuration:
```sh
export USE_MPI=y

export NWCHEM_TOP=${HOME}/Work/NWCHEM/github
export NWCHEM_MODULES=all
export NWCHEM_TARGET=MACX64

export CC=gcc
export CXX=g++
export FC=gfortran

export USE_64TO32=y
export BLAS_SIZE=4
export BLASOPT="-framework Accelerate"
export BLAS_LIB=${BLASOPT}
export LAPACK_LIB=${BLASOPT}
```

Signed-off-by: Jeff Hammond <jeff.science@gmail.com>