### PR TITLE
remove BGJ spaghetti code

### DIFF
--- a/src/nwchem.F
+++ b/src/nwchem.F
@@ -13,7 +13,6 @@
 #include "pstat.fh"
 #include "util.fh"
 #include "inp.fh"
-#include "bgj_common.fh"
 #include "stdio.fh"
       integer rtdb
       integer stack
@@ -257,10 +256,6 @@ C
 C     initialize nxtask
 C
       call nxtask_init(rtdb)
-c!!! BGJ
-      bgj_rtdb = rtdb
-c!!! BGJ
-c
 c
       
       if (ostartup.or.ocontinue) then

--- a/src/nwchem.dsp
+++ b/src/nwchem.dsp
@@ -114,7 +114,6 @@ SOURCE="$(InputPath)"
 
 SOURCE=.\nwchem.F
 DEP_F90_NWCHE=\
-	".\include\bgj_common.fh"\
 	".\include\inp.fh"\
 	".\include\printlevels.fh"\
 	".\include\pstat.fh"\

--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -234,7 +234,7 @@ endif
     LIBRARY = libnwcutil.a
     HEADERS = util.fh itri.fh msgids.fh  numerical_constants.fh stdio.fh \
               printlevels.fh bitops.fh bitops_decls.fh bitops_funcs.fh \
-              bgj.fh bgj_common.fh nwc_const.fh errquit.fh util_sgroup.fh \
+              bgj.fh nwc_const.fh errquit.fh util_sgroup.fh \
 	      util_params.fh utilc_nwchem_srcdir.fh
 #if USE_VTUNE
     HEADERS += vtune.fh

--- a/src/util/MakeFile
+++ b/src/util/MakeFile
@@ -135,7 +135,6 @@ HEADERS =      util.fh \
                bitops_decls.fh \
                bitops_funcs.fh \
                bgj.fh \
-               bgj_common.fh \
                errquit.fh \
                nwc_const.fh
 


### PR DESCRIPTION
BGJ added a bunch of spaghetti that serves no purpose.  This is the easiest and most important to remove.