### PR TITLE
CCSD(T) TRPDRV OpenACC CUBLAS version

### DIFF
--- a/src/ccsd/GNUmakefile
+++ b/src/ccsd/GNUmakefile
@@ -109,6 +109,12 @@ ifeq ($(HAVE_SET_GA_PROPERTY),Y)
       LIB_DEFINES += -DHAVE_SET_GA_PROPERTY
 endif
 
+ifdef USE_OPENACC_TRPDRV
+  OBJ_OPTIMIZE += ccsd_trpdrv_openacc.o
+  USES_BLAS    += ccsd_trpdrv_openacc.F
+  FOPTIONS += -acc -gpu=managed -cuda -cudalib=cublas
+endif
+
 
 ifeq ($(ARMCI_NETWORK),MPI-PR)
    LIB_DEFINES += -DACC_STRIPS

--- a/src/ccsd/aoccsd2.F
+++ b/src/ccsd/aoccsd2.F
@@ -720,7 +720,7 @@ C
      2    use_trpdrv_omp_mp=.false.
       if (.not. rtdb_get(rtdb, 'ccsd:use_trpdrv_openacc', mt_log, 1,
      1                   use_trpdrv_openacc))
-     2    use_trpdrv_offload=.false.
+     2    use_trpdrv_openacc=.false.
       if (.not. rtdb_get(rtdb, 'ccsd:use_trpdrv_offload', mt_log, 1,
      1                   use_trpdrv_offload))
      2    use_trpdrv_offload=.false.

--- a/src/ccsd/aoccsd2.F
+++ b/src/ccsd/aoccsd2.F
@@ -16,6 +16,7 @@ c
       logical oconverged, occd, use_trpdrv_nb
       logical use_trpdrv_omp, use_trpdrv_bgp2
       logical use_trpdrv_omp_mp
+      logical use_trpdrv_openacc
       logical use_trpdrv_offload
 c
 #include "ccsd_len.fh"
@@ -717,6 +718,9 @@ C
       if (.not. rtdb_get(rtdb, 'ccsd:use_trpdrv_omp_mp', mt_log, 1,
      1                   use_trpdrv_omp_mp))
      2    use_trpdrv_omp_mp=.false.
+      if (.not. rtdb_get(rtdb, 'ccsd:use_trpdrv_openacc', mt_log, 1,
+     1                   use_trpdrv_openacc))
+     2    use_trpdrv_offload=.false.
       if (.not. rtdb_get(rtdb, 'ccsd:use_trpdrv_offload', mt_log, 1,
      1                   use_trpdrv_offload))
      2    use_trpdrv_offload=.false.
@@ -976,6 +980,31 @@ c
      $        dbl_mb(k_trp_Kka), dbl_mb(k_trp_Jij), dbl_mb(k_trp_Jkj),
      $        dbl_mb(k_trp_Kij), dbl_mb(k_trp_Kkj), dbl_mb(k_trp_Dja),
      $        dbl_mb(k_trp_Djka), dbl_mb(k_trp_Djia))
+c
+         else if (use_trpdrv_openacc) then
+#if defined(USE_OPENACC_TRPDRV)
+#ifndef USE_F90_ALLOCATABLE
+#error You must set USE_F90_ALLOCATABLE if USE_OPENACC_TRPDRV is set!
+#endif
+         if (iam.eq.0.and.oprint) then
+            write(luout,1808) nvpass,util_wallsec()
+            call util_flush(luout)
+         endif
+ 1808    format(' commencing triples evaluation - openacc version',i8,
+     I        ' at ',f20.2,' secs')
+         call ccsd_trpdrv_openacc(dbl_mb(k_t1),
+     $        f1n,f1t,f2n,f2t,f3n,f3t,f4n,f4t,
+     $        eorb,g_objo,g_objv,g_coul,g_exch,ncor,nocc,nvir,iprt,
+     $        empt(1),empt(2),oseg_lo,oseg_hi,kchunk,
+     $        dbl_mb(k_trp_Tij), dbl_mb(k_trp_Tkj), dbl_mb(k_trp_Tia),
+     $        dbl_mb(k_trp_Tka), dbl_mb(k_trp_Xia), dbl_mb(k_trp_Xka),
+     $        dbl_mb(k_trp_Jia), dbl_mb(k_trp_Jka), dbl_mb(k_trp_Kia),
+     $        dbl_mb(k_trp_Kka), dbl_mb(k_trp_Jij), dbl_mb(k_trp_Jkj),
+     $        dbl_mb(k_trp_Kij), dbl_mb(k_trp_Kkj), dbl_mb(k_trp_Dja),
+     $        dbl_mb(k_trp_Djka), dbl_mb(k_trp_Djia))
+#else
+         call errquit('aoccsd: trpdrv_openacc disabled ',0,0)
+#endif
 c
          elseif (use_trpdrv_omp_mp) then
 #ifndef TRPMIXP_OFF

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -1,0 +1,572 @@
+      subroutine ccsd_trpdrv_openacc(t1,
+     &     f1n,f1t,f2n,f2t,f3n,f3t,f4n,f4t,eorb,
+     &     g_objo,g_objv,g_coul,g_exch,
+     &     ncor,nocc,nvir,iprt,emp4,emp5,
+     &     oseg_lo,oseg_hi, kchunk,
+     &     Tij, Tkj, Tia, Tka, Xia, Xka, Jia, Jka, Kia, Kka,
+     &     Jij, Jkj, Kij, Kkj, Dja, Djka, Djia)
+      use iso_fortran_env
+      use cudafor
+      use cublas
+      implicit none
+!
+#include "errquit.fh"
+#include "global.fh"
+#include "ccsd_len.fh"
+#include "ccsdps.fh"
+#include "util.fh"
+#include "msgids.fh"
+#include "yflop.fh"
+!
+      double precision, intent(inout) :: emp4,emp5
+      double precision, intent(in) :: t1(*)
+      integer, intent(in) :: ncor,nocc,nvir
+      integer, intent(in) :: iprt
+      integer, intent(in) :: g_objo,g_objv,g_coul,g_exch
+      integer, intent(in) :: oseg_lo,oseg_hi, kchunk
+      double precision, intent(in), managed :: f1n(nvir,nvir)
+      double precision, intent(in), managed :: f2n(nvir,nvir)
+      double precision, intent(in), managed :: f3n(nvir,nvir)
+      double precision, intent(in), managed :: f4n(nvir,nvir)
+      double precision, intent(in), managed :: f1t(nvir,nvir)
+      double precision, intent(in), managed :: f2t(nvir,nvir)
+      double precision, intent(in), managed :: f3t(nvir,nvir)
+      double precision, intent(in), managed :: f4t(nvir,nvir)
+      double precision, intent(in), managed :: eorb(*)
+      double precision, intent(in), managed :: Tij(*), Tkj(*)
+      double precision, intent(in), managed :: Tia(*), Tka(*)
+      double precision, intent(in), managed :: Xia(*), Xka(*)
+      double precision, intent(in), managed :: Jia(*), Jka(*)
+      double precision, intent(in), managed :: Jij(*), Jkj(*)
+      double precision, intent(in), managed :: Kia(*), Kka(*)
+      double precision, intent(in), managed :: Kij(*), Kkj(*)
+      double precision, intent(in), managed :: Dja(*), Djka(*), Djia(*)
+! used to make inline threaded tengy correct - for now
+! it is correct that dint[cx]1 are paired with t1v2 and vice versa
+! in the inlined tengy loops.  see ccsd_tengy in ccsd_trpdrv.F for
+! verification of the i-k and k-i pairing of these.
+      double precision, allocatable, managed :: dintc1(:),dintc2(:)
+      double precision, allocatable, managed :: dintx1(:),dintx2(:)
+      double precision, allocatable, managed :: t1v1(:),t1v2(:)
+      integer :: alloc_error, err
+!
+      double precision :: emp4i,emp5i,emp4k,emp5k
+      double precision :: eaijk,denom
+      integer :: inode,next,nodes,iam
+      integer :: a,b,c,i,j,k,akold,av
+      ! chunking is the loop blocking size in the loop nest
+      ! formerly associated with the tengy routine.
+      ! we have not explored this paramater space but 32 is
+      ! optimal for TLB blocking in matrix transpose on most
+      ! architectures (especially x86).
+      integer, parameter :: chunking = 32
+      integer :: bb,cc
+      integer :: klo, khi
+      integer nxtask
+      external nxtask
+      double precision perfm_flop,tzero,flopzero,t_flops,agg_flops
+      external perfm_flop
+!
+!  Dependencies (global array, local array, handle):
+!
+!  These are waited on first
+!
+!      g_objv, Dja,  nbh_objv1
+!      g_objv, Djka(1+(k-klo)*nvir), nbh_objv4(k)
+!      g_objv, Djia, nbh_objv5
+!
+!  These are waited on later
+!
+!      g_objv, Tka,  nbh_objv2
+!      g_objv, Xka,  nbh_objv3
+!      g_objv, Tia,  nbh_objv6
+!      g_objv, Xia,  nbh_objv7
+!      g_objo, Tkj,  nbh_objo1
+!      g_objo, Jkj,  nbh_objo2
+!      g_objo, Kkj,  nbh_objo3
+!      g_objo, Tij,  nbh_objo4
+!      g_objo, Jij,  nbh_objo5
+!      g_objo, Kij,  nbh_objo6
+!      g_exch, Kka,  nbh_exch1
+!      g_exch, Kia,  nbh_exch2
+!      g_coul, Jka,  nbh_coul1
+!      g_coul, Jia,  nbh_coul2
+!
+!  non-blocking handles
+!
+      integer nbh_objv1,nbh_objv2,nbh_objv3
+      integer nbh_objv5,nbh_objv6,nbh_objv7
+      integer nbh_objv4(nocc)
+!
+      integer nbh_objo1,nbh_objo2,nbh_objo3
+      integer nbh_objo4,nbh_objo5,nbh_objo6
+!
+      integer nbh_exch1,nbh_exch2,nbh_coul1,nbh_coul2
+      integer n_progr,pct_progr
+      parameter(n_progr=20)
+      logical i_progr(n_progr+1)
+!
+      integer(INT32) :: shi
+      type(cublasHandle) :: handle(8)
+      integer(kind=cuda_stream_kind) :: stream(8)
+      double precision :: tt0, tt1
+!
+      integer(INT32) :: nv4, no4 ! cublasDgemm requires 32-bit integers
+      integer(INT32) :: cu_op_n, cu_op_t
+      cu_op_n = CUBLAS_OP_N ! 0
+      cu_op_t = CUBLAS_OP_T ! 1
+!
+      if (ga_nodeid().eq.0) then
+        write(6,99)
+      endif
+   99 format(2x,'Using Fortran standard parallelism in CCSD(T)')
+      tzero=util_wallsec()
+      flopzero=perfm_flop()
+!
+! CUDA stuff
+!
+      tt0 = util_wallsec()
+      do shi=1,8
+        err = cudaStreamCreate(stream(shi))
+        if (err.ne.0) call errquit('cudaStreamCreate',shi,UNKNOWN_ERR)
+        err = cublasCreate(handle(shi))
+        if (err.ne.0) call errquit('cublasCreate',shi,UNKNOWN_ERR)
+        err = cublasSetStream(handle(shi), stream(shi))
+        if (err.ne.0) call errquit('cublasSetStream',shi,UNKNOWN_ERR)
+      end do
+      tt1 = util_wallsec()
+      if (ga_nodeid().eq.0) then
+        write(6,500) tt1-tt0
+  500   format('CU init took ',e15.5,' seconds')
+      endif
+!
+      allocate( dintc1(1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintc1',1,MA_ERR)
+      allocate( dintx1(1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintx1',2,MA_ERR)
+      allocate( t1v1(1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('t1v1',3,MA_ERR)
+      allocate( dintc2(1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintc2',4,MA_ERR)
+      allocate( dintx2(1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintx2',5,MA_ERR)
+      allocate( t1v2(1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('t1v2',6,MA_ERR)
+!
+      nodes = ga_nnodes()
+      iam = ga_nodeid()
+!
+!      call ga_sync() ! ga_sync called just before trpdrv in aoccsd2
+!
+      if (occsdps) then
+         call pstat_on(ps_trpdrv)
+      else
+         call qenter('trpdrv',0)
+      endif
+       do klo=1,n_progr+1
+          i_progr(klo)=.true.
+       enddo
+      inode=-1
+      next=nxtask(nodes, 1)
+      do klo = 1, nocc, kchunk
+         akold=0
+         khi = min(nocc, klo+kchunk-1)
+         do a=oseg_lo,oseg_hi
+            av=a-ncor-nocc
+            do j=1,nocc
+               inode=inode+1
+               if (inode.eq.next)then
+
+                  call ga_nbget(g_objv,1+(j-1)*lnov,j*lnov,av,av,Dja,
+     &                          lnov,nbh_objv1)
+                  do k = klo, khi
+                     call ga_nbget(g_objv,1+(j-1)*nvir+(k-1)*lnov,
+     &                    j*nvir+(k-1)*lnov,av,av,
+     &                    Djka(1+(k-klo)*nvir),nvir,nbh_objv4(k))
+                  enddo
+                  call ga_nbget(g_objo,(klo-1)*lnvv+1,khi*lnvv,j,j,Tkj,
+     &                          (khi-klo+1)*lnvv,nbh_objo1)
+                  call ga_nbget(g_objo,lnovv+(klo-1)*lnov+1,
+     &                          lnovv+khi*lnov,j,j,Jkj,
+     &                          (khi-klo+1)*lnov,nbh_objo2)
+                  call ga_nbget(g_objo,lnovv+lnoov+(klo-1)*lnov+1,
+     &                          lnovv+lnoov+khi*lnov,j,j,Kkj,
+     &                          (khi-klo+1)*lnov,nbh_objo3)
+                  if (akold .ne. a) then
+                     akold = a
+                     call ga_nbget(g_coul,1,lnvv,(a-oseg_lo)*nocc+klo,
+     &                    (a-oseg_lo)*nocc+khi,Jka,lnvv,nbh_coul1)
+                     call ga_nbget(g_exch,1,lnvv,(a-oseg_lo)*nocc+klo,
+     &                    (a-oseg_lo)*nocc+khi,Kka,lnvv,nbh_exch1)
+                     call ga_nbget(g_objv,1+lnoov+(klo-1)*lnov,
+     &                    lnoov+khi*lnov,av,av,Tka,(khi-klo+1)*lnov,
+     &                    nbh_objv2)
+                     call ga_nbget(g_objv,1+2*lnoov+(klo-1)*lnov,
+     &                    2*lnoov+khi*lnov,av,av,Xka,(khi-klo+1)*lnov,
+     &                    nbh_objv3)
+                  endif
+
+                  do i=1,nocc
+
+                     call ga_nbget(g_objv,1+(j-1)*nvir+(i-1)*lnov,
+     &                    j*nvir+(i-1)*lnov,av,av,Djia,nvir,nbh_objv5)
+                     call ga_nbget(g_objo,(i-1)*lnvv+1,i*lnvv,j,j,Tij,
+     &                    lnvv,nbh_objo4)
+                     call ga_nbget(g_objo,lnovv+(i-1)*lnov+1,
+     &                    lnovv+i*lnov,j,j,Jij,lnov,nbh_objo5)
+                     call ga_nbget(g_objo,lnovv+lnoov+(i-1)*lnov+1,
+     &                    lnovv+lnoov+i*lnov,j,j,Kij,lnov,nbh_objo6)
+                     call ga_nbget(g_coul,1,lnvv,(a-oseg_lo)*nocc+i,
+     &                    (a-oseg_lo)*nocc+i,Jia,lnvv,nbh_coul2)
+                     call ga_nbget(g_exch,1,lnvv,(a-oseg_lo)*nocc+i,
+     &                    (a-oseg_lo)*nocc+i,Kia,lnvv,nbh_exch2)
+                     call ga_nbget(g_objv,1+lnoov+(i-1)*lnov,
+     &                    lnoov+i*lnov,av,av,Tia,lnov,nbh_objv6)
+                     call ga_nbget(g_objv,1+2*lnoov+(i-1)*lnov,
+     &                    2*lnoov+i*lnov,av,av,Xia,lnov,nbh_objv7)
+
+!                     call dcopy(nvir,t1((i-1)*nvir+1),1,t1v2,1)
+                     t1v2(:) = t1((i-1)*nvir+1:i*nvir)
+                     call ga_nbwait(nbh_objv1) ! Dja
+!                     call dcopy(nvir,Dja(1+(i-1)*nvir),1,dintc1,1)
+                     dintc1(:) = Dja(1+(i-1)*nvir:i*nvir)
+                     call ga_nbwait(nbh_objv5) ! Djia
+!                     call dcopy(nvir,Djia,1,dintx1,1)
+                     dintx1(:) = Djia(1:nvir)
+
+                     do k=klo,min(khi,i)
+
+                        !call dcopy(nvir,t1((k-1)*nvir+1),1,t1v1,1)
+                        t1v1(:) = t1((k-1)*nvir+1:k*nvir)
+                        !call dcopy(nvir,Dja(1+(k-1)*nvir),1,dintc2,1)
+                        dintc2(:) = Dja(1+(k-1)*nvir:k*nvir)
+                        call ga_nbwait(nbh_objv4(k)) ! Djka
+                        !call dcopy(nvir,Djka(1+(k-klo)*nvir),1,dintx2,1)
+                        dintx2(:) = Djka(1+(k-klo)*nvir:(k-klo+1)*nvir)
+                        emp4i = 0.0d0
+                        emp5i = 0.0d0
+                        emp4k = 0.0d0
+                        emp5k = 0.0d0
+                        if (occsdps) then
+                           call pstat_on(ps_doxxx)
+                        else
+                           call qenter('doxxx',0)
+                        endif
+!
+!  These are the input dependencies for the DGEMM calls below.
+!  We wait on all of them here because GA is not even remotely thread-safe.
+!  All of these are independent of k, so we wait on them only
+!  at the first trip of the loop.
+!
+                        if (k.eq.klo) then
+                            call ga_nbwait(nbh_objv2)
+                            call ga_nbwait(nbh_objv3)
+                            call ga_nbwait(nbh_objv6)
+                            call ga_nbwait(nbh_objv7)
+                            call ga_nbwait(nbh_objo1)
+                            call ga_nbwait(nbh_objo2)
+                            call ga_nbwait(nbh_objo3)
+                            call ga_nbwait(nbh_objo4)
+                            call ga_nbwait(nbh_objo5)
+                            call ga_nbwait(nbh_objo6)
+                            call ga_nbwait(nbh_exch1)
+                            call ga_nbwait(nbh_exch2)
+                            call ga_nbwait(nbh_coul1)
+                            call ga_nbwait(nbh_coul2)
+                        endif
+
+                        nv4 = nvir ! no possibility of overflow
+                        no4 = nocc
+
+                        err = cublasDgemm_v2(handle(1),
+     &                        cu_op_n,cu_op_t,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Jia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        f1n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(1),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Tia,nv4,Kkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        f1n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                       
+                        err = cublasDgemm_v2(handle(2),
+     &                        cu_op_n,cu_op_t,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Kia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        f2n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(2),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Xia,nv4,Kkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        f2n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                       
+                        err = cublasDgemm_v2(handle(3),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Jia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        f3n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(3),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Tia,nv4,Jkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        f3n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                       
+                        err = cublasDgemm_v2(handle(4),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Kia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        f4n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(4),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Xia,nv4,Jkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        f4n,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                       
+                        err = cublasDgemm_v2(handle(5),
+     &                        cu_op_n,cu_op_t,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Jka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        f1t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(5),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Tka(1+(k-klo)*lnov),nv4,Kij,no4,1.0d0,
+     &                        f1t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                       
+                        err = cublasDgemm_v2(handle(6),
+     &                        cu_op_n,cu_op_t,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Kka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        f2t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(6),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Xka(1+(k-klo)*lnov),nv4,Kij,no4,1.0d0,
+     &                        f2t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                       
+                        err = cublasDgemm_v2(handle(7),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Jka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        f3t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(7),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Tka(1+(k-klo)*lnov),nv4,Jij,no4,1.0d0,
+     &                        f3t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                       
+                        err = cublasDgemm_v2(handle(8),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,nv4,1.0d0,
+     &                        Kka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        f4t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+                        err = cublasDgemm_v2(handle(8),
+     &                        cu_op_n,cu_op_n,
+     &                        nv4,nv4,no4,-1.0d0,
+     &                        Xka(1+(k-klo)*lnov),nv4,Jij,no4,1.0d0,
+     &                        f4t,nv4)
+                        if (err.ne.0) then
+                          call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
+                        endif
+
+! this is necessary if OpenACC is not used below
+!                        err = cudaDeviceSynchronize()
+
+                        do shi=1,8
+                          err = cudaStreamSynchronize(stream(i))
+                          if (err.ne.0) then
+                            call errquit('cudaStreamSynchronize',err,
+     &                                   UNKNOWN_ERR)
+                          endif
+                        end do
+
+                        if (occsdps) then
+                           call pstat_off(ps_doxxx)
+                           call pstat_on(ps_tengy)
+                        else
+                           call qexit('doxxx',0)
+                           call qenter('tengy',0)
+                        endif
+
+                        eaijk=eorb(a) - (  eorb(ncor+i)
+     &                                    +eorb(ncor+j)
+     &                                    +eorb(ncor+k) )
+#ifdef USE_YFLOP
+      flops_ycount = flops_ycount + nvir*nvir*(
+     D                       3 + 2*(
+     E                       12 +
+     E                       11 +
+     E                       11 ) +
+     5                       2*27 )
+#endif
+
+!$acc parallel loop collapse(2) private(denom) 
+!$acc&         reduction(+:emp4i,emp4k,emp5i,emp5k)
+           do b=1,nvir
+             do c=1,nvir
+                   denom=-1.0d0/( eorb(ncor+nocc+b)
+     &                           +eorb(ncor+nocc+c)+eaijk )
+                   emp4i=emp4i+denom*
+     &                  (f1t(b,c)+f1n(c,b)+f2t(c,b)+f3n(b,c)+f4n(c,b))*
+     &                  (f1t(b,c)-2*f2t(b,c)-2*f3t(b,c)+f4t(b,c))
+     &                        -denom*
+     &                  (f1n(b,c)+f1t(c,b)+f2n(c,b)+f3n(c,b))*
+     &                  (2*f1t(b,c)-f2t(b,c)-f3t(b,c)+2*f4t(b,c))
+     &                        +3*denom*(
+     &                  f1n(b,c)*(f1n(b,c)+f3n(c,b)+2*f4t(c,b))+
+     &                  f2n(b,c)*f2t(c,b)+f3n(b,c)*f4t(b,c))
+                   emp4k=emp4k+denom*
+     &                  (f1n(b,c)+f1t(c,b)+f2n(c,b)+f3t(b,c)+f4t(c,b))*
+     &                  (f1n(b,c)-2*f2n(b,c)-2*f3n(b,c)+f4n(b,c))
+     &                        -denom*
+     &                  (f1t(b,c)+f1n(c,b)+f2t(c,b)+f3t(c,b))*
+     &                  (2*f1n(b,c)-f2n(b,c)-f3n(b,c)+2*f4n(b,c))
+     &                        +3*denom*(
+     &                  f1t(b,c)*(f1t(b,c)+f3t(c,b)+2*f4n(c,b))+
+     &                  f2t(b,c)*f2n(c,b)+f3t(b,c)*f4n(b,c))
+                   emp5i=emp5i+denom*t1v1(b)*dintx1(c)*
+     &                 (    f1t(b,c)+f2n(b,c)+f4n(c,b)
+     &                  -2*(f3t(b,c)+f4n(b,c)+f2n(c,b)+
+     &                      f1n(b,c)+f2t(b,c)+f3n(c,b))
+     &                  +4*(f3n(b,c)+f4t(b,c)+f1n(c,b)))
+     &                        +denom*t1v1(b)*dintc1(c)*
+     &                 (     f1n(b,c)+f4n(b,c)+f1t(c,b)
+     &                   -2*(f2n(b,c)+f3n(b,c)+f2t(c,b)))
+                   emp5k=emp5k+denom*t1v2(b)*dintx2(c)*
+     &                 (    f1n(b,c)+f2t(b,c)+f4t(c,b)
+     &                  -2*(f3n(b,c)+f4t(b,c)+f2t(c,b)+
+     &                      f1t(b,c)+f2n(b,c)+f3t(c,b))
+     &                  +4*(f3t(b,c)+f4n(b,c)+f1t(c,b)))
+     &                        +denom*t1v2(b)*dintc2(c)*
+     &                 (     f1t(b,c)+f4t(b,c)+f1n(c,b)
+     &                   -2*(f2t(b,c)+f3t(b,c)+f2n(c,b)))
+             end do
+           end do
+                         if (occsdps) then
+                            call pstat_off(ps_tengy)
+                         else
+                            call qexit('tengy',0)
+                         endif
+
+                         emp4 = emp4 + emp4i
+                         emp5 = emp5 + emp5i
+                         if (i.ne.k) then
+                             emp4 = emp4 + emp4k
+                             emp5 = emp5 + emp5k
+                         end if ! (i.ne.k)
+                     end do    ! k
+                  end do       ! i
+                  if (iprt.gt.50)then
+                     write(6,1234)iam,a,j,emp4,emp5
+ 1234                format(' iam aijk',3i5,2e15.5)
+                  end if
+                  next=nxtask(nodes, 1)
+            if(ga_nodeid().eq.0) then
+               pct_progr=(a-(ncor+nocc)+((klo-1)/kchunk)*nvir)*n_progr/
+     /          ((nocc/kchunk)*nvir)+1
+               if(i_progr(pct_progr)) then
+                  i_progr(pct_progr)=.false.
+               write(6,4321) ' ccsd(t): done ',
+     A              a-(ncor+nocc)+((klo-1)/kchunk)*nvir,
+     O              ' out of ',(nocc/kchunk)*nvir,
+     O              ' progress: ',
+     O              ((a-(ncor+nocc)+((klo-1)/kchunk)*nvir)*100)/
+     D              ((nocc/kchunk)*nvir),
+     P            '%, Gflops=',(perfm_flop()-flopzero)/
+     D              (util_wallsec()-tzero),
+     P                 ' at ',(util_wallsec()-tzero),' secs'
+               call util_flush(6)
+ 4321          format(a,i8,a,i8,a,i3,a,1pg11.4,a,0pf10.1,a)
+               endif
+            endif
+               end if
+            end do
+         end do
+      end do
+      call ga_sync()
+      next=nxtask(-nodes, 1)
+      t_flops=util_wallsec()-tzero
+      agg_flops=perfm_flop()-flopzero
+      call ga_dgop(msg_cc_diis1,agg_flops,1, '+')
+      if(ga_nodeid().eq.0) then
+         write(6,4322) ' ccsd(t): 100% done, Aggregate Gflops=',
+     P        agg_flops/t_flops,
+     P                 ' in ',t_flops,' secs'
+ 4322    format(a,1pg11.4,a,0pf10.1,a)
+         call util_flush(6)
+      endif
+      call ga_sync()
+      if (occsdps) then
+         call pstat_off(ps_trpdrv)
+      else
+         call qexit('trpdrv',0)
+      endif
+!
+      deallocate( dintc1, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintc1',11,MA_ERR)
+      deallocate( dintx1, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintx1',12,MA_ERR)
+      deallocate( t1v1, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('t1v1',13,MA_ERR)
+      deallocate( dintc2, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintc2',14,MA_ERR)
+      deallocate( dintx2, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('dintx2',15,MA_ERR)
+      deallocate( t1v2, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('t1v2',16,MA_ERR)
+!
+! CUDA stuff
+!
+      do shi=1,8
+        err = cublasDestroy(handle(shi))
+        if (err.ne.0) call errquit('cublasDestroy',shi,UNKNOWN_ERR)
+        err = cudaStreamDestroy(stream(shi))
+        if (err.ne.0) call errquit('cudaStreamDestroy',shi,UNKNOWN_ERR)
+      end do
+!
+      end

--- a/src/ccsd/convert_single_double.F
+++ b/src/ccsd/convert_single_double.F
@@ -9,10 +9,9 @@
       real(kind=dp), intent(out) :: a64(n)
       !
       integer :: i
-      !$OMP SIMD
-      do i=1, n
+      do concurrent (i=1:n)
           a64(i) = real(a32(i), kind=dp)
-      enddo
+      end do
       end subroutine
 
       subroutine copy_64_to_32(n, a64, a32)
@@ -26,10 +25,9 @@
       real(kind=sp), intent(out) :: a32(n)
       !
       integer :: i
-      !$OMP SIMD
-      do i=1, n
+      do concurrent (i=1:n)
           a32(i) = real(a64(i), kind=sp)
-      enddo
+      end do
       end subroutine
 
       subroutine add_32_to_64(n, a32, a64)
@@ -43,10 +41,9 @@
       real(kind=dp), intent(inout) :: a64(n)
       !
       integer :: i
-      !$OMP SIMD
-      do i=1, n
+      do concurrent (i=1:n)
           a64(i) = a64(i) + real(a32(i), kind=dp)
-      enddo
+      end do
       end subroutine
 
       subroutine add_64_to_32(n, a64, a32)
@@ -60,8 +57,7 @@
       real(kind=sp), intent(inout) :: a32(n)
       !
       integer :: i
-      !$OMP SIMD
-      do i=1, n
+      do concurrent (i=1:n)
           a32(i) = a32(i) + real(a64(i), kind=sp)
-      enddo
+      end do
       end subroutine

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -2828,7 +2828,7 @@ else
 endif
 
 ifdef NWCHEM_LINK_CUDA
-CORE_LIBS += -stdpar -acc -gpu=managed -cuda -cudalib=cublas
+CORE_LIBS += -acc -gpu=managed -cuda -cudalib=cublas
 endif
 
 ifdef BLASOPT

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -2827,6 +2827,10 @@ else
     CORE_LIBS += $(BLASOPT)
 endif
 
+ifdef NWCHEM_LINK_CUDA
+CORE_LIBS += -stdpar -acc -gpu=managed -cuda -cudalib=cublas
+endif
+
 ifdef BLASOPT
 BLAS_SUPPLIED=Y
 endif

--- a/src/tools/GNUmakefile
+++ b/src/tools/GNUmakefile
@@ -630,6 +630,10 @@ ifndef ARMCI_NETWORK
     ARMCI_NETWORK=MPI-TS
     MAYBE_ARMCI = --with-mpi-ts
 endif
+# CUDA UM support
+ifdef NWCHEM_LINK_CUDA
+    MAYBE_ARMCI +=  --enable-cuda-mem
+endif
 #
 # Apparently weak bindings do not work with CYGWIN64 at the moment. There seems
 # to be an issue with the COFF object format that gets in the way (with ELF


### PR DESCRIPTION
at build time, you must specify USE_OPENACC_TRPDRV=1 and NWCHEM_LINK_CUDA=1.
the former turns on the OpenACC+CUBLAS compilation in TRPDRV.
the latter turns on the use of CUDA managed memory in GA.

for now, you must specify DEV_GA=1 at build time, until GlobalArrays/ga#210 is part of GA release version NWChem uses.

at run time, you must specify MA_USE_CUDA_MEM=1
this causes MA to use CUDA managed memory, without which the code will crash, if the OS does not support system unified memory.

this code does not yet deal with how MPI and multi-GPU systems interact.

this only works with NVHPC compilers, because the Fortran interface to CUBLAS requires that.