### PR TITLE
OpenACC fixes

### DIFF
--- a/src/ccsd/GNUmakefile
+++ b/src/ccsd/GNUmakefile
@@ -112,7 +112,7 @@ endif
 ifdef USE_OPENACC_TRPDRV
   OBJ_OPTIMIZE += ccsd_trpdrv_openacc.o
   USES_BLAS    += ccsd_trpdrv_openacc.F
-  FOPTIONS += -acc -gpu=managed -cuda -cudalib=cublas
+  FOPTIONS += -acc -gpu=managed -cuda -cudalib=cublas -DUSE_OPENACC_TRPDRV
 endif
 
 

--- a/src/ccsd/aoccsd2.F
+++ b/src/ccsd/aoccsd2.F
@@ -983,25 +983,15 @@ c
 c
          else if (use_trpdrv_openacc) then
 #if defined(USE_OPENACC_TRPDRV)
-#ifndef USE_F90_ALLOCATABLE
-#error You must set USE_F90_ALLOCATABLE if USE_OPENACC_TRPDRV is set!
-#endif
          if (iam.eq.0.and.oprint) then
             write(luout,1808) nvpass,util_wallsec()
             call util_flush(luout)
          endif
- 1808    format(' commencing triples evaluation - openacc version',i8,
+ 1808    format(' commencing triples evaluation - OpenACC version',i8,
      I        ' at ',f20.2,' secs')
-         call ccsd_trpdrv_openacc(dbl_mb(k_t1),
-     $        f1n,f1t,f2n,f2t,f3n,f3t,f4n,f4t,
-     $        eorb,g_objo,g_objv,g_coul,g_exch,ncor,nocc,nvir,iprt,
-     $        empt(1),empt(2),oseg_lo,oseg_hi,kchunk,
-     $        dbl_mb(k_trp_Tij), dbl_mb(k_trp_Tkj), dbl_mb(k_trp_Tia),
-     $        dbl_mb(k_trp_Tka), dbl_mb(k_trp_Xia), dbl_mb(k_trp_Xka),
-     $        dbl_mb(k_trp_Jia), dbl_mb(k_trp_Jka), dbl_mb(k_trp_Kia),
-     $        dbl_mb(k_trp_Kka), dbl_mb(k_trp_Jij), dbl_mb(k_trp_Jkj),
-     $        dbl_mb(k_trp_Kij), dbl_mb(k_trp_Kkj), dbl_mb(k_trp_Dja),
-     $        dbl_mb(k_trp_Djka), dbl_mb(k_trp_Djia))
+         call ccsd_trpdrv_openacc(dbl_mb(k_t1),eorb,
+     $        g_objo,g_objv,g_coul,g_exch,ncor,nocc,nvir,iprt,
+     $        empt(1),empt(2),oseg_lo,oseg_hi,kchunk)
 #else
          call errquit('aoccsd: trpdrv_openacc disabled ',0,0)
 #endif

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -119,7 +119,7 @@
       if (ga_nodeid().eq.0) then
         write(6,99)
       endif
-   99 format(2x,'Using Fortran standard parallelism in CCSD(T)')
+   99 format(2x,'Using Fortran OpenACC+CUBLAS in CCSD(T)')
       tzero=util_wallsec()
       flopzero=perfm_flop()
 !

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -64,8 +64,8 @@
       integer :: klo, khi
       integer nxtask
       external nxtask
-      double precision perfm_flop,tzero,flopzero,t_flops,agg_flops
-      external perfm_flop
+      integer :: dgemm_flops, tengy_flops
+      double precision agg_flops
 !
 !  Dependencies (global array, local array, handle):
 !
@@ -106,10 +106,14 @@
       parameter(n_progr=20)
       logical i_progr(n_progr+1)
 !
+      integer(INT32) :: num_devices, use_ngpus, my_gpu
+      integer :: ppn, node_rank
+      character*255 :: char_use_ngpus
+!
       integer(INT32) :: shi
       type(cublasHandle) :: handle(8)
       integer(kind=cuda_stream_kind) :: stream(8)
-      double precision :: tt0, tt1
+      double precision :: tt0, tt1, tc0, tc1
 !
       integer(INT32) :: nv4, no4 ! cublasDgemm requires 32-bit integers
       integer(INT32) :: cu_op_n, cu_op_t
@@ -120,12 +124,49 @@
         write(6,99)
       endif
    99 format(2x,'Using Fortran OpenACC+CUBLAS in CCSD(T)')
-      tzero=util_wallsec()
-      flopzero=perfm_flop()
+      tt0 = util_wallsec()
+      agg_flops = 0
 !
 ! CUDA stuff
 !
-      tt0 = util_wallsec()
+      ! how many GPUs are detected
+      err = cudaGetDeviceCount(num_devices)
+      if (err.ne.0) call errquit('cudaGetDeviceCount',err,UNKNOWN_ERR)
+      if (num_devices.lt.1) call errquit('No GPU found!',0,UNKNOWN_ERR)
+      ! user prescribes how many to use
+      call util_getenv('NWCHEM_OPENACC_USE_NGPUS',char_use_ngpus)
+      if (ga_nodeid().eq.0) then
+        print*,'CU NWCHEM_OPENACC_USE_NGPUS=',trim(char_use_ngpus)
+      endif
+      if (len(trim(char_use_ngpus)).gt.0) then
+        read(char_use_ngpus,'(i255)') use_ngpus
+        if (use_ngpus.gt.num_devices) then
+          write(6,600) use_ngpus,num_devices
+          use_ngpus = num_devices
+        endif
+  600   format('CU you asked for ',
+     &         i2,' GPUs but only ',
+     &         i2,' are present')
+      else
+        use_ngpus=num_devices
+      endif
+      ! GA PPN undercounts with ARMCI-MPI
+      call util_getppn(ppn) ! THIS IS COLLECTIVE
+      ! this assumes PPN is constant across nodes (reasonable)
+      node_rank = modulo(ga_nodeid(),ppn)
+      ! assign GPUs to GA process ranks within a node (round-robin)
+      my_gpu = modulo(node_rank,use_ngpus)
+      if (ga_nodeid().lt.ppn) then
+        write(6,700) 'node_rank',node_rank
+        write(6,700) 'use_ngpus',use_ngpus
+        write(6,700) 'ppn      ',ppn
+        write(6,700) 'ga_nodeid',ga_nodeid()
+        write(6,700) 'my_gpu   ',my_gpu
+  700   format('CU ',a12,'=',i5)
+      endif
+      err = cudaSetDevice(my_gpu)
+      if (err.ne.0) call errquit('cudaSetDevice',my_gpu,UNKNOWN_ERR)
+      ! setup CUDA streams
       do shi=1,8
         err = cudaStreamCreate(stream(shi))
         if (err.ne.0) call errquit('cudaStreamCreate',shi,UNKNOWN_ERR)
@@ -275,6 +316,8 @@
                             call ga_nbwait(nbh_coul2)
                         endif
 
+                        tc0 = util_wallsec()
+
                         nv4 = nvir ! no possibility of overflow
                         no4 = nocc
 
@@ -414,8 +457,15 @@
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
 
-! this is necessary if OpenACC is not used below
-!                        err = cudaDeviceSynchronize()
+                        ! 8 pairs of DGEMM w/ VVV and VVO cost, 2 for FMA
+                        dgemm_flops = 8*nvir*nvir*(nocc+nvir)*2
+                        agg_flops = agg_flops + dgemm_flops
+
+                        ! this is necessary if OpenACC is not used below
+                        !err = cudaDeviceSynchronize()
+                        !if (err.ne.0) then
+                        !  call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
+                        !endif
 
                         do shi=1,8
                           err = cudaStreamSynchronize(stream(i))
@@ -438,11 +488,11 @@
      &                                    +eorb(ncor+k) )
 #ifdef USE_YFLOP
       flops_ycount = flops_ycount + nvir*nvir*(
-     D                       3 + 2*(
-     E                       12 +
-     E                       11 +
-     E                       11 ) +
-     5                       2*27 )
+     &                       3 + 2*(
+     &                       12 +
+     &                       11 +
+     &                       11 ) +
+     &                       2*27 )
 #endif
 
 !$acc parallel loop collapse(2) private(denom) 
@@ -487,6 +537,11 @@
      &                   -2*(f2t(b,c)+f3t(b,c)+f2n(c,b)))
              end do
            end do
+           tengy_flops = nvir*nvir*( 3 + 2*( 12 + 11 + 11 ) + 2*27 )
+           agg_flops = agg_flops + tengy_flops
+
+                         tc1 = util_wallsec()
+
                          if (occsdps) then
                             call pstat_off(ps_tengy)
                          else
@@ -508,18 +563,17 @@
                   next=nxtask(nodes, 1)
             if(ga_nodeid().eq.0) then
                pct_progr=(a-(ncor+nocc)+((klo-1)/kchunk)*nvir)*n_progr/
-     /          ((nocc/kchunk)*nvir)+1
+     &                   ((nocc/kchunk)*nvir)+1
                if(i_progr(pct_progr)) then
                   i_progr(pct_progr)=.false.
                write(6,4321) ' ccsd(t): done ',
-     A              a-(ncor+nocc)+((klo-1)/kchunk)*nvir,
-     O              ' out of ',(nocc/kchunk)*nvir,
-     O              ' progress: ',
-     O              ((a-(ncor+nocc)+((klo-1)/kchunk)*nvir)*100)/
-     D              ((nocc/kchunk)*nvir),
-     P            '%, Gflops=',(perfm_flop()-flopzero)/
-     D              (util_wallsec()-tzero),
-     P                 ' at ',(util_wallsec()-tzero),' secs'
+     &              a-(ncor+nocc)+((klo-1)/kchunk)*nvir,
+     &              ' out of ',(nocc/kchunk)*nvir,
+     &              ' progress: ',
+     &              ((a-(ncor+nocc)+((klo-1)/kchunk)*nvir)*100)/
+     &              ((nocc/kchunk)*nvir),
+     &            '%, Gflops=',1e-9*(dgemm_flops+tengy_flops)/(tc1-tc0),
+     &                 ' at ',(util_wallsec()-tt0),' secs'
                call util_flush(6)
  4321          format(a,i8,a,i8,a,i3,a,1pg11.4,a,0pf10.1,a)
                endif
@@ -530,13 +584,11 @@
       end do
       call ga_sync()
       next=nxtask(-nodes, 1)
-      t_flops=util_wallsec()-tzero
-      agg_flops=perfm_flop()-flopzero
+      tt1=util_wallsec()
       call ga_dgop(msg_cc_diis1,agg_flops,1, '+')
       if(ga_nodeid().eq.0) then
          write(6,4322) ' ccsd(t): 100% done, Aggregate Gflops=',
-     P        agg_flops/t_flops,
-     P                 ' in ',t_flops,' secs'
+     &        1e-9*agg_flops/(tt1-tt0),' in ',(tt1-tt0),' secs'
  4322    format(a,1pg11.4,a,0pf10.1,a)
          call util_flush(6)
       endif

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -50,7 +50,7 @@
 !
       double precision :: emp4i,emp5i,emp4k,emp5k
       double precision :: eaijk,denom
-      integer :: inode,next,nodes,iam
+      integer :: inode,next,nodes,me
       integer :: a,b,c,i,j,k,akold,av,nbf
       integer :: klo, khi
       integer nxtask
@@ -113,7 +113,10 @@
       cu_op_n = CUBLAS_OP_N ! 0
       cu_op_t = CUBLAS_OP_T ! 1
 !
-      if (ga_nodeid().eq.0) then
+      nodes = ga_nnodes()
+      me = ga_nodeid()
+!
+      if (me.eq.0) then
         write(6,99)
       endif
    99 format(2x,'Using Fortran OpenACC+CUBLAS in CCSD(T)')
@@ -121,7 +124,7 @@
       agg_flops = 0
 #if 0
 !
-! CUDA stuff
+! CUDA stuff (now handled in util_gpu_affinity called in main)
 !
       ! how many GPUs are detected
       err = cudaGetDeviceCount(num_devices)
@@ -129,7 +132,7 @@
       if (num_devices.lt.1) call errquit('No GPU found!',0,UNKNOWN_ERR)
       ! user prescribes how many to use
       call util_getenv('NWCHEM_OPENACC_USE_NGPUS',char_use_ngpus)
-      if (ga_nodeid().eq.0) then
+      if (me.eq.0) then
         print*,'CU NWCHEM_OPENACC_USE_NGPUS=',trim(char_use_ngpus)
       endif
       if (len(trim(char_use_ngpus)).gt.0) then
@@ -147,14 +150,14 @@
       ! GA PPN undercounts with ARMCI-MPI
       call util_getppn(ppn) ! THIS IS COLLECTIVE
       ! this assumes PPN is constant across nodes (reasonable)
-      node_rank = modulo(ga_nodeid(),ppn)
+      node_rank = modulo(me,ppn)
       ! assign GPUs to GA process ranks within a node (round-robin)
       my_gpu = modulo(node_rank,use_ngpus)
-      if (ga_nodeid().lt.ppn) then
+      if (me.lt.ppn) then
         write(6,700) 'node_rank',node_rank
         write(6,700) 'use_ngpus',use_ngpus
         write(6,700) 'ppn      ',ppn
-        write(6,700) 'ga_nodeid',ga_nodeid()
+        write(6,700) 'ga_nodeid',me
         write(6,700) 'my_gpu   ',my_gpu
   700   format('CU ',a12,'=',i5)
       endif
@@ -171,7 +174,7 @@
         if (err.ne.0) call errquit('cublasSetStream',shi,UNKNOWN_ERR)
       end do
       tt1 = util_wallsec()
-      if (ga_nodeid().eq.0) then
+      if (me.eq.0) then
         write(6,500) tt1-tt0
   500   format('CU init took ',e15.5,' seconds')
       endif
@@ -254,9 +257,6 @@
       if (alloc_error.ne.0) call errquit('Djka',115,MA_ERR)
       allocate( Djia(1:nvir*nocc), stat=alloc_error)
       if (alloc_error.ne.0) call errquit('Djia',116,MA_ERR)
-!
-      nodes = ga_nnodes()
-      iam = ga_nodeid()
 !
 !      call ga_sync() ! ga_sync called just before trpdrv in aoccsd2
 !
@@ -522,19 +522,26 @@
                         dgemm_flops = 8*nvir*nvir*(nocc+nvir)*2
                         agg_flops = agg_flops + dgemm_flops
 
-                        ! this is necessary if OpenACC is not used below
                         err = cudaDeviceSynchronize()
                         if (err.ne.0) then
                           call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
                         endif
 
-!                        do shi=1,8
-!                          err = cudaStreamSynchronize(stream(i))
-!                          if (err.ne.0) then
-!                            call errquit('cudaStreamSynchronize',err,
-!     &                                   UNKNOWN_ERR)
-!                          endif
-!                        end do
+#if 0
+! this segfaults
+                        do shi=1,8
+                          err = cudaStreamSynchronize(stream(i))
+                          if (err.ne.0) then
+                            call errquit('cudaStreamSynchronize',err,
+     &                                   UNKNOWN_ERR)
+                          endif
+                        end do
+#endif
+
+                        err = cudaDeviceSynchronize()
+                        if (err.ne.0) then
+                          call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
+                        endif
 
                         if (occsdps) then
                            call pstat_off(ps_doxxx)
@@ -618,11 +625,11 @@
                      end do    ! k
                   end do       ! i
                   if (iprt.gt.50)then
-                     write(6,1234)iam,a,j,emp4,emp5
- 1234                format(' iam aijk',3i5,2e15.5)
+                     write(6,1234)me,a,j,emp4,emp5
+ 1234                format(' me aijk',3i5,2e15.5)
                   end if
                   next=nxtask(nodes, 1)
-            if(ga_nodeid().eq.0) then
+            if(me.eq.0) then
                pct_progr=(a-(ncor+nocc)+((klo-1)/kchunk)*nvir)*n_progr/
      &                   ((nocc/kchunk)*nvir)+1
                if(i_progr(pct_progr)) then
@@ -647,7 +654,7 @@
       next=nxtask(-nodes, 1)
       tt1=util_wallsec()
       call ga_dgop(msg_cc_diis1,agg_flops,1, '+')
-      if(ga_nodeid().eq.0) then
+      if(me.eq.0) then
          write(6,4322) ' ccsd(t): 100% done, Aggregate Gflops=',
      &        1e-9*agg_flops/(tt1-tt0),' in ',(tt1-tt0),' secs'
  4322    format(a,1pg11.4,a,0pf10.1,a)

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -96,22 +96,14 @@
       integer n_progr,pct_progr
       parameter(n_progr=20)
       logical i_progr(n_progr+1)
-!
-#if 0
-      integer(INT32) :: num_devices, use_ngpus, my_gpu
-      integer :: ppn, node_rank
-      character*255 :: char_use_ngpus
-#endif
-!
+      ! timers
+      double precision :: tt0, tt1, tc0, tc1
       integer(INT32) :: shi
       type(cublasHandle) :: handle(8)
       integer(kind=cuda_stream_kind) :: stream(8)
-      double precision :: tt0, tt1, tc0, tc1
-!
       integer(INT32) :: nv4, no4 ! cublasDgemm requires 32-bit integers
-      integer(INT32) :: cu_op_n, cu_op_t
-      cu_op_n = CUBLAS_OP_N ! 0
-      cu_op_t = CUBLAS_OP_T ! 1
+      integer(INT32), parameter :: cu_op_n = CUBLAS_OP_N
+      integer(INT32), parameter :: cu_op_t = CUBLAS_OP_T
 !
       nodes = ga_nnodes()
       me = ga_nodeid()
@@ -122,56 +114,14 @@
    99 format(2x,'Using Fortran OpenACC+CUBLAS in CCSD(T)')
       tt0 = util_wallsec()
       agg_flops = 0
-#if 0
-!
-! CUDA stuff (now handled in util_gpu_affinity called in main)
-!
-      ! how many GPUs are detected
-      err = cudaGetDeviceCount(num_devices)
-      if (err.ne.0) call errquit('cudaGetDeviceCount',err,UNKNOWN_ERR)
-      if (num_devices.lt.1) call errquit('No GPU found!',0,UNKNOWN_ERR)
-      ! user prescribes how many to use
-      call util_getenv('NWCHEM_OPENACC_USE_NGPUS',char_use_ngpus)
-      if (me.eq.0) then
-        print*,'CU NWCHEM_OPENACC_USE_NGPUS=',trim(char_use_ngpus)
-      endif
-      if (len(trim(char_use_ngpus)).gt.0) then
-        read(char_use_ngpus,'(i255)') use_ngpus
-        if (use_ngpus.gt.num_devices) then
-          write(6,600) use_ngpus,num_devices
-          use_ngpus = num_devices
-        endif
-  600   format('CU you asked for ',
-     &         i2,' GPUs but only ',
-     &         i2,' are present')
-      else
-        use_ngpus=num_devices
-      endif
-      ! GA PPN undercounts with ARMCI-MPI
-      call util_getppn(ppn) ! THIS IS COLLECTIVE
-      ! this assumes PPN is constant across nodes (reasonable)
-      node_rank = modulo(me,ppn)
-      ! assign GPUs to GA process ranks within a node (round-robin)
-      my_gpu = modulo(node_rank,use_ngpus)
-      if (me.lt.ppn) then
-        write(6,700) 'node_rank',node_rank
-        write(6,700) 'use_ngpus',use_ngpus
-        write(6,700) 'ppn      ',ppn
-        write(6,700) 'ga_nodeid',me
-        write(6,700) 'my_gpu   ',my_gpu
-  700   format('CU ',a12,'=',i5)
-      endif
-      err = cudaSetDevice(my_gpu)
-      if (err.ne.0) call errquit('cudaSetDevice',my_gpu,UNKNOWN_ERR)
-#endif
       ! setup CUDA streams
       do shi=1,8
         err = cudaStreamCreate(stream(shi))
-        if (err.ne.0) call errquit('cudaStreamCreate',shi,UNKNOWN_ERR)
+        if (err.ne.0) call errquit('cudaStreamCreate',err,UNKNOWN_ERR)
         err = cublasCreate(handle(shi))
-        if (err.ne.0) call errquit('cublasCreate',shi,UNKNOWN_ERR)
+        if (err.ne.0) call errquit('cublasCreate',err,UNKNOWN_ERR)
         err = cublasSetStream(handle(shi), stream(shi))
-        if (err.ne.0) call errquit('cublasSetStream',shi,UNKNOWN_ERR)
+        if (err.ne.0) call errquit('cublasSetStream',err,UNKNOWN_ERR)
       end do
       tt1 = util_wallsec()
       if (me.eq.0) then
@@ -518,30 +468,14 @@
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
 
+                        err = cudaDeviceSynchronize()
+                        if (err.ne.0) then
+                          call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
+                        endif
+
                         ! 8 pairs of DGEMM w/ VVV and VVO cost, 2 for FMA
                         dgemm_flops = 8*nvir*nvir*(nocc+nvir)*2
                         agg_flops = agg_flops + dgemm_flops
-
-                        err = cudaDeviceSynchronize()
-                        if (err.ne.0) then
-                          call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
-                        endif
-
-#if 0
-! this segfaults
-                        do shi=1,8
-                          err = cudaStreamSynchronize(stream(i))
-                          if (err.ne.0) then
-                            call errquit('cudaStreamSynchronize',err,
-     &                                   UNKNOWN_ERR)
-                          endif
-                        end do
-#endif
-
-                        err = cudaDeviceSynchronize()
-                        if (err.ne.0) then
-                          call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
-                        endif
 
                         if (occsdps) then
                            call pstat_off(ps_doxxx)
@@ -738,9 +672,9 @@
 !
       do shi=1,8
         err = cublasDestroy(handle(shi))
-        if (err.ne.0) call errquit('cublasDestroy',shi,UNKNOWN_ERR)
+        if (err.ne.0) call errquit('cublasDestroy',err,UNKNOWN_ERR)
         err = cudaStreamDestroy(stream(shi))
-        if (err.ne.0) call errquit('cudaStreamDestroy',shi,UNKNOWN_ERR)
+        if (err.ne.0) call errquit('cudaStreamDestroy',err,UNKNOWN_ERR)
       end do
 !
       end

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -1,10 +1,7 @@
-      subroutine ccsd_trpdrv_openacc(t1,
-     &     f1n,f1t,f2n,f2t,f3n,f3t,f4n,f4t,eorb,
+      subroutine ccsd_trpdrv_openacc(t1,xeorb,
      &     g_objo,g_objv,g_coul,g_exch,
      &     ncor,nocc,nvir,iprt,emp4,emp5,
-     &     oseg_lo,oseg_hi, kchunk,
-     &     Tij, Tkj, Tia, Tka, Xia, Xka, Jia, Jka, Kia, Kka,
-     &     Jij, Jkj, Kij, Kkj, Dja, Djka, Djia)
+     &     oseg_lo,oseg_hi, kchunk)
       use iso_fortran_env
       use cudafor
       use cublas
@@ -20,27 +17,28 @@
 !
       double precision, intent(inout) :: emp4,emp5
       double precision, intent(in) :: t1(*)
+      double precision, intent(in) :: xeorb(*)
       integer, intent(in) :: ncor,nocc,nvir
       integer, intent(in) :: iprt
       integer, intent(in) :: g_objo,g_objv,g_coul,g_exch
       integer, intent(in) :: oseg_lo,oseg_hi, kchunk
-      double precision, intent(in), managed :: f1n(nvir,nvir)
-      double precision, intent(in), managed :: f2n(nvir,nvir)
-      double precision, intent(in), managed :: f3n(nvir,nvir)
-      double precision, intent(in), managed :: f4n(nvir,nvir)
-      double precision, intent(in), managed :: f1t(nvir,nvir)
-      double precision, intent(in), managed :: f2t(nvir,nvir)
-      double precision, intent(in), managed :: f3t(nvir,nvir)
-      double precision, intent(in), managed :: f4t(nvir,nvir)
-      double precision, intent(in), managed :: eorb(*)
-      double precision, intent(in), managed :: Tij(*), Tkj(*)
-      double precision, intent(in), managed :: Tia(*), Tka(*)
-      double precision, intent(in), managed :: Xia(*), Xka(*)
-      double precision, intent(in), managed :: Jia(*), Jka(*)
-      double precision, intent(in), managed :: Jij(*), Jkj(*)
-      double precision, intent(in), managed :: Kia(*), Kka(*)
-      double precision, intent(in), managed :: Kij(*), Kkj(*)
-      double precision, intent(in), managed :: Dja(*), Djka(*), Djia(*)
+      double precision, allocatable, device :: eorb(:)
+      double precision, allocatable, device :: f1n(:,:)
+      double precision, allocatable, device :: f2n(:,:)
+      double precision, allocatable, device :: f3n(:,:)
+      double precision, allocatable, device :: f4n(:,:)
+      double precision, allocatable, device :: f1t(:,:)
+      double precision, allocatable, device :: f2t(:,:)
+      double precision, allocatable, device :: f3t(:,:)
+      double precision, allocatable, device :: f4t(:,:)
+      double precision, allocatable, managed :: Tij(:), Tkj(:)
+      double precision, allocatable, managed :: Tia(:), Tka(:)
+      double precision, allocatable, managed :: Xia(:), Xka(:)
+      double precision, allocatable, managed :: Jia(:), Jka(:)
+      double precision, allocatable, managed :: Jij(:), Jkj(:)
+      double precision, allocatable, managed :: Kia(:), Kka(:)
+      double precision, allocatable, managed :: Kij(:), Kkj(:)
+      double precision, allocatable, managed :: Dja(:), Djka(:), Djia(:)
 ! used to make inline threaded tengy correct - for now
 ! it is correct that dint[cx]1 are paired with t1v2 and vice versa
 ! in the inlined tengy loops.  see ccsd_tengy in ccsd_trpdrv.F for
@@ -53,14 +51,7 @@
       double precision :: emp4i,emp5i,emp4k,emp5k
       double precision :: eaijk,denom
       integer :: inode,next,nodes,iam
-      integer :: a,b,c,i,j,k,akold,av
-      ! chunking is the loop blocking size in the loop nest
-      ! formerly associated with the tengy routine.
-      ! we have not explored this paramater space but 32 is
-      ! optimal for TLB blocking in matrix transpose on most
-      ! architectures (especially x86).
-      integer, parameter :: chunking = 32
-      integer :: bb,cc
+      integer :: a,b,c,i,j,k,akold,av,nbf
       integer :: klo, khi
       integer nxtask
       external nxtask
@@ -185,18 +176,84 @@
   500   format('CU init took ',e15.5,' seconds')
       endif
 !
+! device-only temp arrays
+! produced by DGEMM, consumed by TENGY
+!
+      allocate( f1n(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f1n',1,MA_ERR)
+      allocate( f2n(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f2n',2,MA_ERR)
+      allocate( f3n(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f3n',3,MA_ERR)
+      allocate( f4n(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f4n',4,MA_ERR)
+      allocate( f1t(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f1t',5,MA_ERR)
+      allocate( f2t(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f2t',6,MA_ERR)
+      allocate( f3t(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f3t',7,MA_ERR)
+      allocate( f4t(1:nvir,1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f4t',8,MA_ERR)
+!
+! device-only copy of input eorb
+!
+      nbf = ncor + nocc + nvir
+      allocate( eorb(1:nbf), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('eorb',10,MA_ERR)
+      eorb(1:nbf) = xeorb(1:nbf)
+!
+! for TENGY
+!
       allocate( dintc1(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintc1',1,MA_ERR)
+      if (alloc_error.ne.0) call errquit('dintc1',11,MA_ERR)
       allocate( dintx1(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintx1',2,MA_ERR)
+      if (alloc_error.ne.0) call errquit('dintx1',12,MA_ERR)
       allocate( t1v1(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('t1v1',3,MA_ERR)
+      if (alloc_error.ne.0) call errquit('t1v1',13,MA_ERR)
       allocate( dintc2(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintc2',4,MA_ERR)
+      if (alloc_error.ne.0) call errquit('dintc2',14,MA_ERR)
       allocate( dintx2(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintx2',5,MA_ERR)
+      if (alloc_error.ne.0) call errquit('dintx2',15,MA_ERR)
       allocate( t1v2(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('t1v2',6,MA_ERR)
+      if (alloc_error.ne.0) call errquit('t1v2',16,MA_ERR)
+!
+! UM arrays, produced by GA Get, consumed by DGEMM
+!
+      allocate( Tij(1:lnvv), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tij',100,MA_ERR)
+      allocate( Tkj(1:kchunk*lnvv), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tkj',101,MA_ERR)
+      allocate( Tia(1:lnov*nocc), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tia',102,MA_ERR)
+      allocate( Tka(1:kchunk*lnov), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tka',103,MA_ERR)
+      allocate( Xia(1:lnov*nocc), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Xia',104,MA_ERR)
+      allocate( Xka(1:kchunk*lnov), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Xka',105,MA_ERR)
+      allocate( Jia(1:lnvv), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jia',106,MA_ERR)
+      allocate( Jka(1:kchunk*lnvv), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jka',107,MA_ERR)
+      allocate( Kia(1:lnvv), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kia',108,MA_ERR)
+      allocate( Kka(1:kchunk*lnvv), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kka',109,MA_ERR)
+      allocate( Jij(1:lnov*nocc), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jij',110,MA_ERR)
+      allocate( Jkj(1:kchunk*lnov), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jkj',111,MA_ERR)
+      allocate( Kij(1:lnov*nocc), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kij',112,MA_ERR)
+      allocate( Kkj(1:kchunk*lnov), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kkj',113,MA_ERR)
+      allocate( Dja(1:lnov), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Dja',114,MA_ERR)
+      allocate( Djka(1:nvir*kchunk), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Djka',115,MA_ERR)
+      allocate( Djia(1:nvir*nocc), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Djia',116,MA_ERR)
 !
       nodes = ga_nnodes()
       iam = ga_nodeid()
@@ -603,6 +660,25 @@
          call qexit('trpdrv',0)
       endif
 !
+      deallocate( f1n, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f1n',1,MA_ERR)
+      deallocate( f2n, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f2n',2,MA_ERR)
+      deallocate( f3n, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f3n',3,MA_ERR)
+      deallocate( f4n, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f4n',4,MA_ERR)
+      deallocate( f1t, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f1t',5,MA_ERR)
+      deallocate( f2t, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f2t',6,MA_ERR)
+      deallocate( f3t, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f3t',7,MA_ERR)
+      deallocate( f4t, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f4t',8,MA_ERR)
+
+      deallocate( eorb, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('eorb',10,MA_ERR)
       deallocate( dintc1, stat=alloc_error)
       if (alloc_error.ne.0) call errquit('dintc1',11,MA_ERR)
       deallocate( dintx1, stat=alloc_error)
@@ -615,6 +691,41 @@
       if (alloc_error.ne.0) call errquit('dintx2',15,MA_ERR)
       deallocate( t1v2, stat=alloc_error)
       if (alloc_error.ne.0) call errquit('t1v2',16,MA_ERR)
+
+      deallocate( Tij, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tij',100,MA_ERR)
+      deallocate( Tkj, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tkj',101,MA_ERR)
+      deallocate( Tia, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tia',102,MA_ERR)
+      deallocate( Tka, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Tka',103,MA_ERR)
+      deallocate( Xia, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Xia',104,MA_ERR)
+      deallocate( Xka, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Xka',105,MA_ERR)
+      deallocate( Jia, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jia',106,MA_ERR)
+      deallocate( Jka, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jka',107,MA_ERR)
+      deallocate( Kia, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kia',108,MA_ERR)
+      deallocate( Kka, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kka',109,MA_ERR)
+      deallocate( Jij, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jij',110,MA_ERR)
+      deallocate( Jkj, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Jkj',111,MA_ERR)
+      deallocate( Kij, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kij',112,MA_ERR)
+      deallocate( Kkj, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Kkj',113,MA_ERR)
+      deallocate( Dja, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Dja',114,MA_ERR)
+      deallocate( Djka, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Djka',115,MA_ERR)
+      deallocate( Djia, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('Djia',116,MA_ERR)
 !
 ! CUDA stuff
 !

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -106,9 +106,11 @@
       parameter(n_progr=20)
       logical i_progr(n_progr+1)
 !
+#if 0
       integer(INT32) :: num_devices, use_ngpus, my_gpu
       integer :: ppn, node_rank
       character*255 :: char_use_ngpus
+#endif
 !
       integer(INT32) :: shi
       type(cublasHandle) :: handle(8)
@@ -126,6 +128,7 @@
    99 format(2x,'Using Fortran OpenACC+CUBLAS in CCSD(T)')
       tt0 = util_wallsec()
       agg_flops = 0
+#if 0
 !
 ! CUDA stuff
 !
@@ -166,6 +169,7 @@
       endif
       err = cudaSetDevice(my_gpu)
       if (err.ne.0) call errquit('cudaSetDevice',my_gpu,UNKNOWN_ERR)
+#endif
       ! setup CUDA streams
       do shi=1,8
         err = cudaStreamCreate(stream(shi))

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -466,18 +466,18 @@
                         agg_flops = agg_flops + dgemm_flops
 
                         ! this is necessary if OpenACC is not used below
-                        !err = cudaDeviceSynchronize()
-                        !if (err.ne.0) then
-                        !  call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
-                        !endif
+                        err = cudaDeviceSynchronize()
+                        if (err.ne.0) then
+                          call errquit('cudaDeviceSync',err,UNKNOWN_ERR)
+                        endif
 
-                        do shi=1,8
-                          err = cudaStreamSynchronize(stream(i))
-                          if (err.ne.0) then
-                            call errquit('cudaStreamSynchronize',err,
-     &                                   UNKNOWN_ERR)
-                          endif
-                        end do
+!                        do shi=1,8
+!                          err = cudaStreamSynchronize(stream(i))
+!                          if (err.ne.0) then
+!                            call errquit('cudaStreamSynchronize',err,
+!     &                                   UNKNOWN_ERR)
+!                          endif
+!                        end do
 
                         if (occsdps) then
                            call pstat_off(ps_doxxx)

--- a/src/nwchem.F
+++ b/src/nwchem.F
@@ -136,6 +136,8 @@ c
 c     Initialize local memory allocator & global array tools
 C
       call ga_initialize_ltd(ma_sizeof(mt_dbl,global,mt_byte))
+      ! this must happen after GA and before MA!
+      call util_setup_gpu_affinity()
       if ( ga_uses_ma() ) then
         if (.not.ma_init(mt_dbl, stack, heap+global))
      &      call errquit('nwchem.F: ma_init failed (ga_uses_ma=T)',911,

--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -224,7 +224,7 @@ endif
               util_intrsc2008.o util_fadvise.o  util_scalapack_info.o\
               ga_conjg.o nwmolden.o ao_1prdm_read.o ao_1prdm_write.o\
               util_strips.o util_poltensor.o  util_mygop.o util_isnan.o \
-              util_blasthreads.o \
+              util_blasthreads.o util_gpu_affinity.o \
               $(EXTRA_OBJ)
 ifndef USE_MLIB
               OBJ_OPTIMIZE += icopy.o dsum.o dgefa.o zsum.o
@@ -304,6 +304,10 @@ endif
 ifdef TCE_HIP
   LIB_DEFINES += $(HIP_INCLUDE)
   OBJ += util_cuda_support.o
+endif
+
+ifdef USE_OPENACC_TRPDRV
+  FOPTIONS += -cuda -DUSE_CUDA_AFFINITY
 endif
 
 ifdef USE_FORTRAN2003

--- a/src/util/util_getppn.c
+++ b/src/util/util_getppn.c
@@ -11,14 +11,6 @@
 #include "ga-mpi.h"
 #include "typesf2c.h"
 
-#if defined(__bgq__)
-#include <process.h>
-#include <location.h>
-#include <personality.h>
-#elif defined(__CRAYXT) || defined(__CRAYXE) || defined(__CRAYXC)
-#include <pmi.h>
-#endif
-
 static inline int util_mpi_check(int rc, char * name)
 {
   if (rc != MPI_SUCCESS) {
@@ -32,11 +24,7 @@ static short int ppn_initialized=0;
 static int ppn=0;
 void FATR util_getppn_(Integer *ppn_out){
 
-#if defined(__bgq__)
-  *ppn_out = (Integer) Kernel_ProcessCount();
-  return;
-  if(0) {
-#elif MPI_VERSION >= 3
+#if MPI_VERSION >= 3
 
     int err;
     MPI_Comm comm_node;

--- a/src/util/util_gpu_affinity.F
+++ b/src/util/util_gpu_affinity.F
@@ -2,12 +2,15 @@
 #ifdef USE_CUDA_AFFINITY
       use iso_fortran_env
       use cudafor
+      use openacc
 #include "errquit.fh"
 #include "global.fh"
       integer(INT32) :: num_devices, use_ngpus, my_gpu
       integer :: ppn, node_rank, me
       character*255 :: char_use_ngpus
+      integer(acc_device_kind) :: devicetype
       me = ga_nodeid()
+      devicetype = NVIDIA
       !
       ! CUDA stuff
       !
@@ -48,6 +51,6 @@
       endif
       err = cudaSetDevice(my_gpu)
       if (err.ne.0) call errquit('cudaSetDevice',my_gpu,UNKNOWN_ERR)
-#else BAD
+      call acc_set_device_num(my_gpu,devicetype)
 #endif
       end subroutine util_setup_gpu_affinity

--- a/src/util/util_gpu_affinity.F
+++ b/src/util/util_gpu_affinity.F
@@ -1,0 +1,50 @@
+      subroutine util_setup_gpu_affinity
+#ifdef USE_CUDA_AFFINITY
+      use iso_fortran_env
+      use cudafor
+      integer(INT32) :: num_devices, use_ngpus, my_gpu
+      integer :: ppn, node_rank
+      character*255 :: char_use_ngpus
+      !
+      ! CUDA stuff
+      !
+      ! how many GPUs are detected
+      err = cudaGetDeviceCount(num_devices)
+      if (err.ne.0) call errquit('cudaGetDeviceCount',err,UNKNOWN_ERR)
+      if (num_devices.lt.1) call errquit('No GPU found!',0,UNKNOWN_ERR)
+      ! user prescribes how many to use
+      call util_getenv('NWCHEM_OPENACC_USE_NGPUS',char_use_ngpus)
+      if (ga_nodeid().eq.0) then
+        print*,'CU NWCHEM_OPENACC_USE_NGPUS=',trim(char_use_ngpus)
+      endif
+      if (len(trim(char_use_ngpus)).gt.0) then
+        read(char_use_ngpus,'(i255)') use_ngpus
+        if (use_ngpus.gt.num_devices) then
+          write(6,600) use_ngpus,num_devices
+          use_ngpus = num_devices
+        endif
+  600   format('CU you asked for ',
+     &         i2,' GPUs but only ',
+     &         i2,' are present')
+      else
+        use_ngpus=num_devices
+      endif
+      ! GA PPN undercounts with ARMCI-MPI
+      call util_getppn(ppn) ! THIS IS COLLECTIVE
+      ! this assumes PPN is constant across nodes (reasonable)
+      node_rank = modulo(ga_nodeid(),ppn)
+      ! assign GPUs to GA process ranks within a node (round-robin)
+      my_gpu = modulo(node_rank,use_ngpus)
+      if (ga_nodeid().lt.ppn) then
+        write(6,700) 'node_rank',node_rank
+        write(6,700) 'use_ngpus',use_ngpus
+        write(6,700) 'ppn      ',ppn
+        write(6,700) 'ga_nodeid',ga_nodeid()
+        write(6,700) 'my_gpu   ',my_gpu
+  700   format('CU ',a12,'=',i5)
+      endif
+      err = cudaSetDevice(my_gpu)
+      if (err.ne.0) call errquit('cudaSetDevice',my_gpu,UNKNOWN_ERR)
+#else BAD
+#endif
+      end subroutine util_setup_gpu_affinity

--- a/src/util/util_gpu_affinity.F
+++ b/src/util/util_gpu_affinity.F
@@ -2,9 +2,12 @@
 #ifdef USE_CUDA_AFFINITY
       use iso_fortran_env
       use cudafor
+#include "errquit.fh"
+#include "global.fh"
       integer(INT32) :: num_devices, use_ngpus, my_gpu
-      integer :: ppn, node_rank
+      integer :: ppn, node_rank, me
       character*255 :: char_use_ngpus
+      me = ga_nodeid()
       !
       ! CUDA stuff
       !
@@ -14,7 +17,7 @@
       if (num_devices.lt.1) call errquit('No GPU found!',0,UNKNOWN_ERR)
       ! user prescribes how many to use
       call util_getenv('NWCHEM_OPENACC_USE_NGPUS',char_use_ngpus)
-      if (ga_nodeid().eq.0) then
+      if (me.eq.0) then
         print*,'CU NWCHEM_OPENACC_USE_NGPUS=',trim(char_use_ngpus)
       endif
       if (len(trim(char_use_ngpus)).gt.0) then
@@ -32,14 +35,14 @@
       ! GA PPN undercounts with ARMCI-MPI
       call util_getppn(ppn) ! THIS IS COLLECTIVE
       ! this assumes PPN is constant across nodes (reasonable)
-      node_rank = modulo(ga_nodeid(),ppn)
+      node_rank = modulo(me,ppn)
       ! assign GPUs to GA process ranks within a node (round-robin)
       my_gpu = modulo(node_rank,use_ngpus)
-      if (ga_nodeid().lt.ppn) then
+      if (me.lt.ppn) then
         write(6,700) 'node_rank',node_rank
         write(6,700) 'use_ngpus',use_ngpus
         write(6,700) 'ppn      ',ppn
-        write(6,700) 'ga_nodeid',ga_nodeid()
+        write(6,700) 'ga_nodeid',me
         write(6,700) 'my_gpu   ',my_gpu
   700   format('CU ',a12,'=',i5)
       endif


### PR DESCRIPTION
1) set GPU affinity immediately after GA init and before MA init so that MA unified memory is allocated on the right GPU
2) pull all allocation of buffers into the TRPDRV routine.  it's cleaner on many levels.
3) remove Blue Gene/Q code that belongs in a museum.

we should do 2 in all the TRPDRV implementations but i'll do that in a separate commit.