### PR TITLE
LibXC interface

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -226,6 +226,10 @@ endif
 #JN: under the new structure, tools should be listed first as
 # their header files are needed for dependency analysis of
 # other NWChem modules
+ifdef USE_LIBXC
+  NW_CORE_SUBDIRS += libext
+endif
+
 ifdef BUILD_OPENBLAS
   ifndef BLAS_SIZE
     BLAS_SIZE=8
@@ -267,6 +271,8 @@ NW_CORE_SUBDIRS += libext
       MPI_LIB     = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH)  $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_lib)
       LIBMPI      = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH) $(NWCHEM_TOP)/src/tools/guess-mpidefs --libmpi)
 endif
+
+
 ifndef EXTERNAL_GA_PATH
 NW_CORE_SUBDIRS += tools
 endif
@@ -2964,6 +2970,11 @@ ifdef SLURM
   EXTRA_LIBS += $(SLURMOPT)
 endif
 
+ifdef USE_LIBXC
+  EXTRA_LIBS += -L$(NWCHEM_TOP)/src/libext/libxc/install/lib -lxcf03 -lxc
+  DEFINES += -DUSE_LIBXC
+endif
+
 ifdef USE_SIMINT
 ifndef SIMINT_HOME
 SIMINT_HOME=$(NWCHEM_TOP)/src/NWints/simint/libsimint_source/simint_install
@@ -3118,6 +3129,7 @@ $(error )
       EXTRA_LIBS += -lnwclapack
       CORE_SUBDIRS_EXTRA = lapack
 endif
+
 
 #
 # Define known suffixes mostly so that .p files don\'t cause pc to be invoked

--- a/src/libext/GNUmakefile
+++ b/src/libext/GNUmakefile
@@ -15,7 +15,9 @@ endif
 ifdef BUILD_SCALAPACK
     SUBDIRS += scalapack
 endif
-
+ifdef USE_LIBXC
+    SUBDIRS += libxc
+endif
 
 include ../config/makelib.h
 

--- a/src/libext/libxc/GNUmakefile
+++ b/src/libext/libxc/GNUmakefile
@@ -1,0 +1,19 @@
+#$Id$
+# makefile,v 1.8 1994/12/05 20:37:08 og845 Exp
+
+# $Id: GNUmakefile 26876 2015-02-24 06:32:05Z edo $
+
+include ../../config/makefile.h
+
+install/lib/libxc.a:
+	./build_libxc.sh 
+
+LIB_TARGETS += libxc
+
+include ../../config/makelib.h
+
+clean:
+	@rm -rf  libxc* install 
+
+
+

--- a/src/libext/libxc/build_libxc.sh
+++ b/src/libext/libxc/build_libxc.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+VERSION=5.1.5
+
+if [[ -f "libxc-${VERSION}.tar.gz" ]]; then
+    echo "using exisiting  libxc-${VERSION}.tar.gz"
+else
+    echo "downloading libxc-${VERSION}.tar.gz"
+    curl -L https://gitlab.com/libxc/libxc/-/archive/${VERSION}/libxc-${VERSION}.tar.gz -o libxc-${VERSION}.tar.gz
+fi
+
+tar -xzf libxc-${VERSION}.tar.gz
+ln -s libxc-${VERSION} libxc
+
+cd libxc
+mkdir build
+
+cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=${NWCHEM_TOP}/src/libext/libxc/install -DCMAKE_C_COMPILER=$CC -DENABLE_FORTRAN=ON -DCMAKE_Fortran_COMPILER=$FC -DDISABLE_KXC=OFF
+
+cd build
+make -j2 | tee make.log
+make install
+

--- a/src/nwdft/GNUmakefile
+++ b/src/nwdft/GNUmakefile
@@ -7,7 +7,7 @@
 
  LIB_DEFINES =
 
-   SUBDIRS = include input_dft scf_dft scf_dft_cg so_dft coulomb xc util grid dftgrad lr_tddft lr_tddft_grad zora spec rt_tddft
+   SUBDIRS = include input_dft scf_dft scf_dft_cg so_dft coulomb xc util grid dftgrad lr_tddft lr_tddft_grad zora spec rt_tddft libxc
 LIB_INCLUDES = -I./include -I./grid
 
 HEADERS = ../ddscf/cosmo.fh

--- a/src/nwdft/include/cdft.fh
+++ b/src/nwdft/include/cdft.fh
@@ -46,7 +46,7 @@ cc AJL/End
      &     XCFIT, CDFIT, store_wght, ldelley, lcfac, nlcfac, lxfac, 
      &     nlxfac, xccomb, levelshift, damp, diis, direct, oskel, 
      &     oadapt, lssw, lkeeps,trunc_neigh, lb94, cs00, bqdontcare,
-     &     ncap,
+     &     ncap, libxcon,
 cc AJL/Begin/FDE
      &     frozemb, frozemb_fde, lcfac_fde, nlcfac_fde, lxfac_fde, 
      &     nlxfac_fde, xccomb_fde
@@ -97,7 +97,7 @@ c
      ,     nlcfac(numfunc),lxfac(numfunc), nlxfac(numfunc), 
      ,     xccomb(numfunc), levelshift, damp, diis, 
      &     direct, oskel, oadapt, lssw, lkeeps,trunc_neigh, 
-     &     lb94, cs00, bqdontcare, ncap,
+     &     lb94, cs00, bqdontcare, ncap, libxcon,
 cc AJL/Begin/FDE
      &     frozemb, frozemb_fde, lcfac_fde(numfunc), 
      &     nlcfac_fde(numfunc), lxfac_fde(numfunc), 

--- a/src/nwdft/input_dft/dft_inpana.F
+++ b/src/nwdft/input_dft/dft_inpana.F
@@ -60,6 +60,8 @@ c
       logical use_nwxc 
       logical dftmp2,out1
       double precision mp2fac
+
+      logical,external :: is_libxcon
 c     
       me=ga_nodeid()
 c     
@@ -257,6 +259,7 @@ c
 c     Analyze any user specified XC functionals ... set if none
 c     
       cksetd = .true.
+      cksetd = cksetd .and. .not. libxcon
 c     
 c     Check if user has specified some type of functional,
 c     if so, do not set defaults.
@@ -538,6 +541,7 @@ cFA
             write(LuOut,*)
             call util_print_centered
      &         (LuOut,'XC Information',20,.true.)
+            if (is_libxcon()) call nwchem_libxc_print_header()
 c     
 c           Write out XC info. Combo info first, than X components,
 c           than C components.
@@ -572,6 +576,8 @@ c
                   write(LuOut,9224) cname(n), cfac(n), nonlocal_c
                endif
             enddo
+
+            if (is_libxcon()) call nwchem_libxc_print()
 c     
 c           Check XC coefficients to make sure appropriate components
 c           sum to 1.0

--- a/src/nwdft/input_dft/dft_inpana.F
+++ b/src/nwdft/input_dft/dft_inpana.F
@@ -60,8 +60,6 @@ c
       logical use_nwxc 
       logical dftmp2,out1
       double precision mp2fac
-
-      logical,external :: is_libxcon
 c     
       me=ga_nodeid()
 c     
@@ -541,7 +539,7 @@ cFA
             write(LuOut,*)
             call util_print_centered
      &         (LuOut,'XC Information',20,.true.)
-            if (is_libxcon()) call nwchem_libxc_print_header()
+            if (libxcon) call nwchem_libxc_print_header()
 c     
 c           Write out XC info. Combo info first, than X components,
 c           than C components.
@@ -577,7 +575,7 @@ c
                endif
             enddo
 
-            if (is_libxcon()) call nwchem_libxc_print()
+            if (libxcon) call nwchem_libxc_print()
 c     
 c           Check XC coefficients to make sure appropriate components
 c           sum to 1.0

--- a/src/nwdft/input_dft/dft_rdinput.F
+++ b/src/nwdft/input_dft/dft_rdinput.F
@@ -1269,6 +1269,11 @@ c
      $     call errquit('dft_scf: put of bgj:scf_type failed',0,
      &       RTDB_ERR)
 c
+c
+      if (.not.rtdb_get(rtdb, 'dft:libxcon', mt_log,1,libxcon))
+     $  libxcon = .false.
+      if (libxcon) call nwchem_libxc_rdinput(rtdb,'dft') 
+c
       if (.not. MA_Pop_Stack(lznuc))
      &   call errquit('dft_rdinput: pop stack failed.',0, MA_ERR)
       if (.not. MA_Pop_Stack(ltags))

--- a/src/nwdft/input_dft/xc_inp.F
+++ b/src/nwdft/input_dft/xc_inp.F
@@ -140,7 +140,7 @@ c     xperde86 ==> 9520
 c
 c     hcth147@tz2p ==> 1947
 c
-      integer num_dirs, ind, mlen, iline, n
+      integer num_dirs, ind, mlen, iline, n, itemp
       parameter (num_dirs=159)
 c
       character*15 dirs(num_dirs)
@@ -152,6 +152,9 @@ c
       logical  lcfac(numfunc),  lxfac(numfunc), ck_local
       logical nlcfac(numfunc), nlxfac(numfunc)
       logical xccomb(numfunc)
+      logical success
+      logical,external :: nwchem_libxc_init
+      logical,external :: is_libxcon
 c
 c     XC functionals coefficients
 c     
@@ -210,6 +213,8 @@ c     Grab the current input line and dump the functional specification
 c     onto the RTDB. This way external programs can pick the actual
 c     functional definition up as it was entered.
 c
+      success = nwchem_libxc_init()
+
       if (.not.inp_line(test)) then
          write(*,*)'xc_input: Could not read functional specification'
       endif
@@ -244,6 +249,9 @@ c
  10   if (.not. inp_a(test)) goto 1999
 c     
       if (.not. inp_match(num_dirs, .false., test, dirs, ind)) then
+        call nwchem_libxc_read(rtdb,test,success,xfac,lxfac,
+     $                         nlxfac)
+        if (success) goto 10
 c     
 c        Does not match a keyword ... 
 c     
@@ -272,6 +280,8 @@ c
      &  1947,
      &  9410,9420,9430,
      &     1999 ) ind
+
+
       call errquit('xc_inp: unimplemented directive', ind, INPUT_ERR)
 c     
 c     acm; adiabatic connection method
@@ -4378,6 +4388,13 @@ c
      &   call errquit('xc_inp: rtdb_put failed', 7, RTDB_ERR)
 
 cc AJL/End
+
+      if (is_libxcon()) then
+        if (.not.(rtdb_put(rtdb, module(1:mlen)//':libxcon',
+     $                     mt_log,1,.true.)))
+     $   call errquit('xc_inp: rtdb_put failed', 8, RTDB_ERR)
+        call nwchem_libxc_rtdbput(rtdb,module(1:mlen))
+      endif   
 c
       return
 c     

--- a/src/nwdft/libxc/GNUmakefile
+++ b/src/nwdft/libxc/GNUmakefile
@@ -1,0 +1,16 @@
+# $Id$
+
+HEADERS = libxc.fh
+
+OBJ = nwchem_libxc_read.o \
+      nwchem_libxc_util.o
+OBJ_OPTIMIZE = nwchem_libxc_compute.o
+
+USES_BLAS = nwchem_libxc_compute.o
+
+LIBRARY = libnwdft.a
+
+LIB_INCLUDES = -I../include -I../../libext/libxc/install/include -I.
+
+include ../../config/makefile.h
+include ../../config/makelib.h

--- a/src/nwdft/libxc/libxc.fh
+++ b/src/nwdft/libxc/libxc.fh
@@ -1,0 +1,11 @@
+      integer, parameter :: maxfunc = 100
+
+      integer :: libxc_nfuncs
+      integer(c_int),dimension(maxfunc) :: libxc_family
+      integer(c_int),dimension(maxfunc) :: libxc_funcs
+      integer(c_int),dimension(maxfunc) :: libxc_kind
+      integer(c_int),dimension(maxfunc) :: libxc_flags
+      double precision,dimension(maxfunc) :: libxc_facts
+
+      common /libxc/ libxc_nfuncs,libxc_family,libxc_funcs,libxc_kind,
+     $               libxc_flags,libxc_facts

--- a/src/nwdft/libxc/nwchem_libxc_compute.F
+++ b/src/nwdft/libxc/nwchem_libxc_compute.F
@@ -1,0 +1,470 @@
+      subroutine nwchem_libxc_compute(nq,ex,ec,qwght,rho,delrho,ttau,
+     $                                laprho,Amat,Amat2,Amat3,Cmat,
+     $                                Cmat2,Cmat3,
+     $                                Mmat,Lmat,func,
+     $                                ksgrad,kske,kslap,ldew,
+     $                                do_2nd, do_3rd)
+      use, intrinsic :: iso_c_binding
+
+#ifdef USE_LIBXC
+      use xc_f03_lib_m
+#endif
+      implicit none
+
+#include "libxc.fh"
+#include "mafdecls.fh"
+#include "errquit.fh"
+#include "cdft.fh"
+#include "dft2drv.fh"
+#include "dft3drv.fh"
+
+      logical :: ksgrad, kske, kslap, ldew, do_2nd, do_3rd
+
+      integer :: q,nq
+      integer :: ifunc
+      integer :: size1, size2
+      integer :: lexc,kexc
+      integer :: lrho,krho,lvrho,kvrho
+      integer :: lsigma,ksigma,lvsigma,kvsigma
+      integer :: ltau,ktau,lvtau,kvtau
+      integer :: llapl,klapl,lvlapl,kvlapl
+
+      integer :: kv2rho2,lv2rho2
+      integer :: kv2sig2,lv2sig2
+      integer :: kv2rhosig,lv2rhosig
+
+      integer :: kv3rho3,lv3rho3
+      integer :: kv3sig3,lv3sig3
+      integer :: kv3rho2sig,lv3rho2sig
+      integer :: kv3rhosig2,lv3rhosig2
+
+      integer(c_int) :: polarized
+
+      double precision :: ex,ec,func(nq),qwght(nq)
+      double precision :: rho(nq,(ipol*(ipol+1))/2)
+      double precision :: delrho(nq,3,ipol)
+      double precision :: laprho(nq,ipol)
+      double precision :: ttau(nq,ipol)
+
+      double precision :: Amat(nq,ipol)
+      double precision :: Cmat(nq,3)
+      double precision :: Mmat(nq,ipol)
+      double precision :: Lmat(nq,ipol)
+
+      double precision :: Amat2(nq,NCOL_AMAT2)
+      double precision :: Cmat2(nq,NCOL_CMAT2)
+
+      double precision :: Amat3(nq,NCOL_AMAT3)
+      double precision :: Cmat3(nq,NCOL_CMAT3)
+
+      double precision :: fac 
+
+      double precision, external :: ddot
+      logical gga,mgga,dolap
+      logical,external :: nwchem_libxc_family
+
+      integer(c_size_t) :: nqs
+#ifdef USE_LIBXC      
+      type(xc_f03_func_t) :: xcfunc      
+
+      gga = .false.
+      mgga = .false.
+      dolap = .false.
+
+      nqs = nq
+      size1 = nq*ipol
+      size2 = nq*(ipol*(ipol+1))/2
+
+      if (.not.(ma_push_get(mt_dbl,size1,'rhoval',lrho,krho)))
+     $  call errquit(" could not allocate",0,ma_err) 
+      if (.not.(ma_push_get(mt_dbl,size1,'vrho',lvrho,kvrho)))
+     $  call errquit(" could not allocate",0,ma_err) 
+      if (.not.(ma_push_get(mt_dbl,nq,'exc',lexc,kexc)))
+     $  call errquit(" could not allocate",0,ma_err)
+
+      if (ksgrad) then
+        if (.not.(ma_push_get(mt_dbl,size2,'sigma',lsigma,ksigma)))
+     $    call errquit(" could not allocate",0,ma_err) 
+        if (.not.(ma_push_get(mt_dbl,size2,'vsigma',lvsigma,kvsigma)))
+     $    call errquit(" could not allocate",0,ma_err) 
+      endif
+
+      if (kske.or.kslap) then
+          if (.not.(ma_push_get(mt_dbl,size2,'tau',ltau,ktau)))
+     $      call errquit(" could not allocate",0,ma_err) 
+          if (.not.(ma_push_get(mt_dbl,size2,'vtau',lvtau,kvtau)))
+     $      call errquit(" could not allocate",0,ma_err) 
+          if (.not.(ma_push_get(mt_dbl,size2,'lapl',llapl,klapl)))
+     $      call errquit(" could not allocate",0,ma_err) 
+          if (.not.(ma_push_get(mt_dbl,size2,'vlapl',lvlapl,kvlapl)))
+     $      call errquit(" could not allocate",0,ma_err) 
+      endif
+
+      if (do_2nd .or. do_3rd) then
+        if (.not.(ma_push_get(mt_dbl,3*nq,'v2rho2',lv2rho2,kv2rho2)))
+     $    call errquit(" could not allocate v2rho2",0,ma_err)
+        if (ksgrad) then
+          if (.not.(ma_push_get(mt_dbl,6*nq,'v2rhosig',lv2rhosig,
+     $                                                 kv2rhosig)))
+     $      call errquit(" could not allocate v2rhosig",0,ma_err)
+          if (.not.(ma_push_get(mt_dbl,6*nq,'v2sig2',lv2sig2,kv2sig2)))
+     $      call errquit(" could not allocate v2sig2",0,ma_err)
+        endif
+      endif
+
+      if (do_3rd) then
+        if (.not.(ma_push_get(mt_dbl,4*nq,'v3rho3',lv3rho3,kv3rho3)))
+     $    call errquit(" could not allocate v3rho3",0,ma_err)
+        if (ksgrad) then
+          if (.not.(ma_push_get(mt_dbl,9*nq,'v3rho2sig',lv3rho2sig,
+     $                                                   kv3rho2sig)))
+     $      call errquit(" could not allocate v3rho2sig",0,ma_err)
+          if (.not.(ma_push_get(mt_dbl,12*nq,'v3rhosig2',lv3rhosig2,
+     $                                                   kv3rhosig2)))
+     $      call errquit(" could not allocate v3rhosig2",0,ma_err)
+          if (.not.(ma_push_get(mt_dbl,10*nq,'v3sig3',lv3sig3,kv3sig3)))
+     $      call errquit(" could not allocate v3sig3",0,ma_err)     
+        endif
+      endif
+
+      if (kske) call dcopy(nq,ttau,1,dbl_mb(ktau),ipol)
+      if (kslap) call dcopy(nq,laprho,1,dbl_mb(klapl),ipol)
+
+      if (ipol.eq.1) then
+        polarized = xc_unpolarized
+
+        call dcopy(nq,rho,1,dbl_mb(krho),1)
+        if (ksgrad) then
+          do q=1,nq
+            dbl_mb(ksigma+q-1) = delrho(q,1,1)**2 +
+     $                           delrho(q,2,1)**2 +
+     $                           delrho(q,3,1)**2
+          enddo       
+        endif
+      else
+        polarized = xc_polarized
+        call dcopy(nq,rho(1,2),1,dbl_mb(krho),2)
+        call dcopy(nq,rho(1,3),1,dbl_mb(krho+1),2)
+        if (ksgrad) then
+          do q=1,nq
+            dbl_mb(ksigma+3*(q-1)) = delrho(q,1,1)**2 +
+     $                               delrho(q,2,1)**2 +
+     $                               delrho(q,3,1)**2
+            dbl_mb(ksigma+3*(q-1)+1) = delrho(q,1,1)*delrho(q,1,2) +
+     $                                 delrho(q,2,1)*delrho(q,2,2) +
+     $                                 delrho(q,3,1)*delrho(q,3,2)
+            dbl_mb(ksigma+3*(q-1)+2) = delrho(q,1,2)**2 +
+     $                                 delrho(q,2,2)**2 +
+     $                                 delrho(q,3,2)**2
+          enddo
+        endif
+        if (kske) call dcopy(nq,ttau(1,2),1,dbl_mb(ktau+1),ipol)
+        if (kslap) call dcopy(nq,laprho(1,2),1,dbl_mb(klapl+1),ipol)
+      endif
+
+      do ifunc=1,libxc_nfuncs
+
+        fac = libxc_facts(ifunc)
+
+        call xc_f03_func_init(xcfunc,libxc_funcs(ifunc),polarized)
+        call xc_f03_func_set_dens_threshold(xcfunc, tol_rho)
+
+        select case(libxc_family(ifunc))
+        case (XC_FAMILY_LDA, XC_FAMILY_HYB_LDA)
+
+          if ((.not.do_2nd) .and. (.not.do_3rd)) then
+            call xc_f03_lda_exc_vxc(xcfunc,nqs,
+     $            dbl_mb(krho),dbl_mb(kexc),dbl_mb(kvrho))
+          elseif (.not.do_3rd) then
+            call xc_f03_lda_exc_vxc_fxc(xcfunc,nqs,dbl_mb(krho),
+     $            dbl_mb(kexc),dbl_mb(kvrho),dbl_mb(kv2rho2))
+          else
+            call xc_f03_lda_exc_vxc_fxc_kxc(xcfunc,nqs,dbl_mb(krho),
+     $            dbl_mb(kexc),dbl_mb(kvrho),dbl_mb(kv2rho2),
+     $            dbl_mb(kv3rho3))
+          endif
+
+
+        case (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA)
+
+          gga = .true.
+
+          if (iand(libxc_flags(ifunc),xc_flags_have_exc).eq.
+     $                                xc_flags_have_exc) then
+
+            if ((.not.do_2nd).and.(.not.do_3rd)) then
+              call xc_f03_gga_exc_vxc(xcfunc,nqs,
+     $                                dbl_mb(krho),dbl_mb(ksigma),
+     $                                dbl_mb(kexc),
+     $                                dbl_mb(kvrho),dbl_mb(kvsigma))
+            elseif (.not.do_3rd) then
+              call xc_f03_gga_exc_vxc_fxc(xcfunc,nqs,
+     $             dbl_mb(krho),dbl_mb(ksigma),dbl_mb(kexc),
+     $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
+     $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2))
+            else
+              call xc_f03_gga_exc_vxc_fxc_kxc(xcfunc,nqs,
+     $             dbl_mb(krho),dbl_mb(ksigma),dbl_mb(kexc),
+     $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
+     $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2),
+     $             dbl_mb(kv3rho3),dbl_mb(kv3rho2sig),
+     $             dbl_mb(kv3rhosig2),dbl_mb(kv3sig3))
+            endif
+          else
+            if ((.not.do_2nd).and.(.not.do_3rd)) then
+              call xc_f03_gga_vxc(xcfunc,nqs,
+     $                            dbl_mb(krho),dbl_mb(ksigma),
+     $                            dbl_mb(kvrho),dbl_mb(kvsigma))
+            elseif (.not.do_3rd) then
+              call xc_f03_gga_vxc_fxc(xcfunc,nqs,
+     $             dbl_mb(krho),dbl_mb(ksigma),
+     $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
+     $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2))
+            else
+              call xc_f03_gga_vxc_fxc_kxc(xcfunc,nqs,
+     $             dbl_mb(krho),dbl_mb(ksigma),
+     $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
+     $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2),
+     $             dbl_mb(kv3rho3),dbl_mb(kv3rho2sig),
+     $             dbl_mb(kv3rhosig2),dbl_mb(kv3sig3))
+            endif
+            call dfill(nq,0d0,dbl_mb(kexc),1)
+          endif
+
+        case (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
+          gga = .true.
+          mgga = .true.
+          dolap = .true.
+
+          
+          if (iand(libxc_flags(ifunc),xc_flags_have_exc).eq.
+     $                                xc_flags_have_exc) then
+
+            call xc_f03_mgga_exc_vxc(xcfunc,nqs,
+     $       dbl_mb(krho),dbl_mb(ksigma),dbl_mb(klapl),dbl_mb(ktau),
+     $       dbl_mb(kexc),
+     $       dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kvlapl),dbl_mb(kvtau))
+          else
+            call xc_f03_mgga_vxc(xcfunc,nqs,
+     $       dbl_mb(krho),dbl_mb(ksigma),dbl_mb(klapl),dbl_mb(ktau),
+     $       dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kvlapl),dbl_mb(kvtau))
+            call dfill(nq,0d0,dbl_mb(kexc),1)
+          endif
+
+        end select
+
+        call xc_f03_func_end(xcfunc)
+
+        do q=1,nq
+          if (ldew) func(q) = func(q) + fac*dbl_mb(kexc+q-1)*rho(q,1)
+          dbl_mb(kexc+q-1) = dbl_mb(kexc+q-1)*qwght(q)
+        enddo
+
+        if (libxc_kind(ifunc).eq.xc_exchange .or. 
+     $      libxc_kind(ifunc).eq.xc_exchange_correlation) then
+          ex = ex + fac*ddot(nq,dbl_mb(kexc),1,rho,1)
+        elseif(libxc_kind(ifunc).eq.xc_correlation) then
+          ec = ec + fac*ddot(nq,dbl_mb(kexc),1,rho,1)
+        endif
+
+        call daxpy(nq,fac,dbl_mb(kvrho),ipol,Amat,1)
+        if (mgga) call daxpy(nq,0.5d0*fac,dbl_mb(kvtau),ipol,Mmat,1)
+        if (dolap) call daxpy(nq,fac,dbl_mb(kvlapl),ipol,Lmat,1)
+        
+        if ((polarized.eq.xc_unpolarized) .and. (gga)) then
+          call daxpy(nq,fac,dbl_mb(kvsigma),1,Cmat(1,D1_GAA),1)
+          call daxpy(nq,2d0*fac,dbl_mb(kvsigma),1,Cmat(1,D1_GAB),1)
+        elseif (polarized.eq.xc_polarized) then
+          call daxpy(nq,fac,dbl_mb(kvrho+1),2,Amat(1,2),1)
+          if (mgga) call daxpy(nq,0.5d0*fac,dbl_mb(kvtau+1),2,
+     $                         Mmat(1,2),1)
+          if (dolap) call daxpy(nq,fac,dbl_mb(kvlapl+1),2,Lmat(1,2),1)
+          if (gga) then
+            call daxpy(nq,fac,dbl_mb(kvsigma),3,Cmat(1,D1_GAA),1)
+            call daxpy(nq,fac,dbl_mb(kvsigma+1),3,Cmat(1,D1_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kvsigma+2),3,Cmat(1,D1_GBB),1)
+          endif
+        endif
+
+        if (do_2nd .or. do_3rd) then
+          if (polarized.eq.xc_unpolarized) then
+            call daxpy(nq,fac,dbl_mb(kv2rho2),1,Amat2(1,D2_RA_RA),1)
+            call daxpy(nq,fac,dbl_mb(kv2rho2),1,Amat2(1,D2_RA_RB),1)
+            if (gga) then
+              call daxpy(nq,fac,dbl_mb(kv2rhosig),1,
+     $                   Cmat2(1,D2_RA_GAA),1)
+              call daxpy(nq,2d0*fac,dbl_mb(kv2rhosig),1,
+     $                   Cmat2(1,D2_RA_GAB),1)
+              call daxpy(nq,fac,dbl_mb(kv2rhosig),1,
+     $                   Cmat2(1,D2_RA_GBB),1)
+              call daxpy(nq,fac,dbl_mb(kv2sig2),1,
+     $                   Cmat2(1,D2_GAA_GAA),1)
+              call daxpy(nq,2d0*fac,dbl_mb(kv2sig2),1,
+     $                   Cmat2(1,D2_GAA_GAB),1)
+              call daxpy(nq,fac,dbl_mb(kv2sig2),1,
+     $                   Cmat2(1,D2_GAA_GBB),1)
+              call daxpy(nq,4d0*fac,dbl_mb(kv2sig2),1,
+     $                   Cmat2(1,D2_GAB_GAB),1)
+            endif
+          else
+            call daxpy(nq,fac,dbl_mb(kv2rho2),3,Amat2(1,D2_RA_RA),1)
+            call daxpy(nq,fac,dbl_mb(kv2rho2+1),3,Amat2(1,D2_RA_RB),1)
+            call daxpy(nq,fac,dbl_mb(kv2rho2+2),3,Amat2(1,D2_RB_RB),1)
+            if (gga) then
+              call daxpy(nq,fac,dbl_mb(kv2rhosig),6,
+     $                   Cmat2(1,D2_RA_GAA),1)
+              call daxpy(nq,fac,dbl_mb(kv2rhosig+1),6,
+     $                   Cmat2(1,D2_RA_GAB),1)
+              call daxpy(nq,fac,dbl_mb(kv2rhosig+2),6,
+     $                   Cmat2(1,D2_RA_GBB),1)
+              call daxpy(nq,fac,dbl_mb(kv2rhosig+3),6,
+     $                   Cmat2(1,D2_RB_GAA),1)
+              call daxpy(nq,fac,dbl_mb(kv2rhosig+4),6,
+     $                   Cmat2(1,D2_RB_GAB),1)
+              call daxpy(nq,fac,dbl_mb(kv2rhosig+5),6,
+     $                   Cmat2(1,D2_RB_GBB),1)
+
+              call daxpy(nq,fac,dbl_mb(kv2sig2),6,
+     $                   Cmat2(1,D2_GAA_GAA),1)
+              call daxpy(nq,fac,dbl_mb(kv2sig2+1),6,
+     $                   Cmat2(1,D2_GAA_GAB),1)
+              call daxpy(nq,fac,dbl_mb(kv2sig2+2),6,
+     $                   Cmat2(1,D2_GAA_GBB),1)
+              call daxpy(nq,fac,dbl_mb(kv2sig2+3),6,
+     $                   Cmat2(1,D2_GAB_GAB),1)
+              call daxpy(nq,fac,dbl_mb(kv2sig2+4),6,
+     $                   Cmat2(1,D2_GAB_GBB),1)
+              call daxpy(nq,fac,dbl_mb(kv2sig2+5),6,
+     $                   Cmat2(1,D2_GBB_GBB),1)
+            endif
+          endif
+        endif
+
+        if (do_3rd) then
+          if (polarized.eq.xc_unpolarized) then
+           call daxpy(nq,fac,dbl_mb(kv3rho3),1,Amat3(1,D3_RA_RA_RA),1)
+           call daxpy(nq,fac,dbl_mb(kv3rho3),1,Amat3(1,D3_RA_RA_RB),1)
+           call daxpy(nq,fac,dbl_mb(kv3rho3),1,Amat3(1,D3_RA_RB_RB),1)
+           if (gga) then
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig),1,
+     $                 Cmat3(1,D3_RA_RA_GAA),1)
+            call daxpy(nq,2d0*fac,dbl_mb(kv3rho2sig),1,
+     $                 Cmat3(1,D3_RA_RA_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig),1,
+     $                 Cmat3(1,D3_RA_RA_GBB),1)
+
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig),1,
+     $                 Cmat3(1,D3_RA_RB_GAA),1)
+            call daxpy(nq,2d0*fac,dbl_mb(kv3rho2sig),1,
+     $                 Cmat3(1,D3_RA_RB_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig),1,
+     $                 Cmat3(1,D3_RA_RB_GBB),1)
+
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2),1,
+     $                 Cmat3(1,D3_RA_GAA_GAA),1)
+            call daxpy(nq,2d0*fac,dbl_mb(kv3rhosig2),1,
+     $                 Cmat3(1,D3_RA_GAA_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2),1,
+     $                 Cmat3(1,D3_RA_GAA_GBB),1)
+            call daxpy(nq,4d0*fac,dbl_mb(kv3rhosig2),1,
+     $                 Cmat3(1,D3_RA_GAB_GAB),1)
+            call daxpy(nq,2d0*fac,dbl_mb(kv3rhosig2),1,
+     $                 Cmat3(1,D3_RA_GAB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2),1,
+     $                 Cmat3(1,D3_RA_GBB_GBB),1)
+
+            call daxpy(nq,fac,dbl_mb(kv3sig3),1,
+     $                 Cmat3(1,D3_GAA_GAA_GAA),1)
+            call daxpy(nq,2d0*fac,dbl_mb(kv3sig3),1,
+     $                 Cmat3(1,D3_GAA_GAA_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3),1,
+     $                 Cmat3(1,D3_GAA_GAA_GBB),1)
+            call daxpy(nq,4d0*fac,dbl_mb(kv3sig3),1,
+     $                 Cmat3(1,D3_GAA_GAB_GAB),1)
+            call daxpy(nq,2d0*fac,dbl_mb(kv3sig3),1,
+     $                 Cmat3(1,D3_GAA_GAB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3),1,
+     $                 Cmat3(1,D3_GAA_GBB_GBB),1)
+            call daxpy(nq,8d0*fac,dbl_mb(kv3sig3),1,
+     $                 Cmat3(1,D3_GAB_GAB_GAB),1)
+           endif
+          elseif (polarized.eq.xc_polarized) then
+           call daxpy(nq,fac,dbl_mb(kv3rho3),4,Amat3(1,D3_RA_RA_RA),1)
+           call daxpy(nq,fac,dbl_mb(kv3rho3+1),4,Amat3(1,D3_RA_RA_RB),1)
+           call daxpy(nq,fac,dbl_mb(kv3rho3+2),4,Amat3(1,D3_RA_RB_RB),1)
+           call daxpy(nq,fac,dbl_mb(kv3rho3+3),4,Amat3(1,D3_RB_RB_RB),1)
+           if (gga) then
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig),9,
+     $                 Cmat3(1,D3_RA_RA_GAA),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+1),9,
+     $                 Cmat3(1,D3_RA_RA_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+2),9,
+     $                 Cmat3(1,D3_RA_RA_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+3),9,
+     $                 Cmat3(1,D3_RA_RB_GAA),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+4),9,
+     $                 Cmat3(1,D3_RA_RB_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+5),9,
+     $                 Cmat3(1,D3_RA_RB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+6),9,
+     $                 Cmat3(1,D3_RB_RB_GAA),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+7),9,
+     $                 Cmat3(1,D3_RB_RB_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rho2sig+8),9,
+     $                 Cmat3(1,D3_RB_RB_GBB),1)
+
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2),12,
+     $                 Cmat3(1,D3_RA_GAA_GAA),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+1),12,
+     $                 Cmat3(1,D3_RA_GAA_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+2),12,
+     $                 Cmat3(1,D3_RA_GAA_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+3),12,
+     $                 Cmat3(1,D3_RA_GAB_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+4),12,
+     $                 Cmat3(1,D3_RA_GAB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+5),12,
+     $                 Cmat3(1,D3_RA_GBB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+6),12,
+     $                 Cmat3(1,D3_RB_GAA_GAA),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+7),12,
+     $                 Cmat3(1,D3_RB_GAA_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+8),12,
+     $                 Cmat3(1,D3_RB_GAA_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+9),12,
+     $                 Cmat3(1,D3_RB_GAB_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+10),12,
+     $                 Cmat3(1,D3_RB_GAB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3rhosig2+11),12,
+     $                 Cmat3(1,D3_RB_GBB_GBB),1)
+
+            call daxpy(nq,fac,dbl_mb(kv3sig3),10,
+     $                 Cmat3(1,D3_GAA_GAA_GAA),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+1),10,
+     $                 Cmat3(1,D3_GAA_GAA_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+2),10,
+     $                 Cmat3(1,D3_GAA_GAA_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+3),10,
+     $                 Cmat3(1,D3_GAA_GAB_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+4),10,
+     $                 Cmat3(1,D3_GAA_GAB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+5),10,
+     $                 Cmat3(1,D3_GAA_GBB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+6),10,
+     $                 Cmat3(1,D3_GAB_GAB_GAB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+7),10,
+     $                 Cmat3(1,D3_GAB_GAB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+8),10,
+     $                 Cmat3(1,D3_GAB_GBB_GBB),1)
+            call daxpy(nq,fac,dbl_mb(kv3sig3+9),10,
+     $                 Cmat3(1,D3_GBB_GBB_GBB),1)
+           endif
+          endif
+        endif
+
+      enddo
+
+      if (.not.ma_chop_stack(lrho))
+     $    call errquit(" could not chop stack",0,ma_err)
+#endif
+      end subroutine

--- a/src/nwdft/libxc/nwchem_libxc_compute.F
+++ b/src/nwdft/libxc/nwchem_libxc_compute.F
@@ -168,6 +168,8 @@
 
         call xc_f03_func_init(xcfunc,libxc_funcs(ifunc),polarized)
         call xc_f03_func_set_dens_threshold(xcfunc, tol_rho)
+        call xc_f03_func_set_sigma_threshold(xcfunc, tol_rho**2)
+        call xc_f03_func_set_zeta_threshold(xcfunc, 1d-10)
 
         select case(libxc_family(ifunc))
         case (XC_FAMILY_LDA, XC_FAMILY_HYB_LDA)

--- a/src/nwdft/libxc/nwchem_libxc_read.F
+++ b/src/nwdft/libxc/nwchem_libxc_read.F
@@ -1,0 +1,108 @@
+      subroutine nwchem_libxc_read(rtdb,funname,success,
+     $           fac,lfac,nlfac)
+#ifdef USE_LIBXC
+      use,intrinsic :: iso_c_binding
+      use xc_f03_lib_m
+#endif
+      implicit none
+#include "rtdb.fh"
+#include "errquit.fh"
+#include "cdft.fh"
+#include "case.fh"
+#include "inp.fh"
+#ifdef USE_LIBXC
+#include "libxc.fh"
+      type(xc_f03_func_t) :: xcfunc
+      type(xc_f03_func_info_t) :: xcinfo
+      integer(c_int) :: funcid, xcflags, xckind, xcfamily
+      real(c_double) :: alpha
+      integer(c_int),parameter :: error = -1
+#endif
+      double precision fact
+      double precision fac(numfunc)
+      logical lfac(numfunc),nlfac(numfunc)
+      integer rtdb
+      character*(*) :: funname
+      logical :: success
+      success = .false.
+
+#ifdef USE_LIBXC
+
+      funcid = xc_f03_functional_get_number(trim(funname))
+      if (funcid.eq.error) return
+
+      if (.not.(inp_f(fact))) fact=1d0
+
+      call xc_f03_func_init(xcfunc,funcid,XC_UNPOLARIZED)
+
+      xcinfo = xc_f03_func_get_info(xcfunc)
+      xckind = xc_f03_func_info_get_kind(xcinfo)
+      xcflags = xc_f03_func_info_get_flags(xcinfo)
+      xcfamily = xc_f03_func_info_get_family(xcinfo)
+
+      select case(xcfamily)
+      case (XC_FAMILY_LDA, XC_FAMILY_HYB_LDA)
+      case (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA)
+      case (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
+      case default
+        call errquit('nwchem_libxc_read: unknown functional family',
+     $                xcfamily,input_err)
+      endselect
+
+      select case(xcfamily)
+      case (XC_FAMILY_HYB_LDA, XC_FAMILY_HYB_GGA, XC_FAMILY_HYB_MGGA)
+        if (iand(xcflags,xc_flags_hyb_cam).eq.xc_flags_hyb_cam) then
+          call xc_f03_hyb_cam_coef(xcfunc,cam_omega,cam_alpha,cam_beta)
+
+          cam_exch = .true.
+          if (cam_alpha.eq.0d0) then
+            lfac(1) = .true.
+            nlfac(1) = .true.
+            fac(1) = cam_beta
+            cam_beta = 1d0
+            cam_srhf = .true.
+          else
+            cam_alpha = cam_alpha + cam_beta
+            cam_beta = -cam_beta
+            lfac(1) = .true.
+            nlfac(1) = .true.
+            fac(1) = 1.0d0
+            cam_srhf = .false.
+          endif
+          call xc_setcamparam(rtdb,cam_exch,cam_srhf,cam_omega,
+     $                        cam_alpha,cam_beta)
+        else
+          alpha = xc_f03_hyb_exx_coef(xcfunc)
+          lfac(1) = .true.
+          nlfac(1) = .true.
+          fac(1) = alpha
+        endif
+      endselect
+
+      if (iand(xcflags,xc_flags_hyb_camy).eq.xc_flags_hyb_camy) goto 10
+      if (iand(xcflags,xc_flags_hyb_lcy).eq.xc_flags_hyb_lcy) goto 10
+      if (iand(xcflags,xc_flags_vv10).eq.xc_flags_vv10) goto 20
+
+      success = .true.
+      libxcon = .true.
+
+      libxc_nfuncs = libxc_nfuncs + 1
+      libxc_funcs(libxc_nfuncs) = funcid
+      libxc_family(libxc_nfuncs) = xcfamily
+      libxc_kind(libxc_nfuncs) = xckind
+      libxc_flags(libxc_nfuncs) = xcflags
+      libxc_facts(libxc_nfuncs) = fact
+
+      call xc_f03_func_end(xcfunc)
+
+      return
+
+   10 call errquit('nwchem_libxc_read: Yukawa kernel is not available',
+     $              0,input_err) 
+   20 call errquit('nwchem_libxc_read: VV10 kernel is not available',
+     $              0,input_err) 
+#endif
+      end subroutine
+
+
+

--- a/src/nwdft/libxc/nwchem_libxc_util.F
+++ b/src/nwdft/libxc/nwchem_libxc_util.F
@@ -25,9 +25,7 @@
       character*(*) family
       integer ifunc
 
-#ifdef USE_LIBXC
 #include "libxc.fh"
-#endif
 
       nwchem_libxc_family = .false.
 
@@ -109,8 +107,8 @@
       end subroutine
 
       subroutine nwchem_libxc_print_header
-#ifdef USE_LIBXC
       use,intrinsic :: iso_c_binding
+#ifdef USE_LIBXC
       use xc_f03_lib_m, only: xc_f03_version_string,
      $                        xc_f03_reference,
      $                        xc_f03_functional_get_name

--- a/src/nwdft/libxc/nwchem_libxc_util.F
+++ b/src/nwdft/libxc/nwchem_libxc_util.F
@@ -1,0 +1,223 @@
+      logical function nwchem_libxc_init()
+      use,intrinsic :: iso_c_binding
+#include "cdft.fh"
+#include "libxc.fh"
+      libxcon = .false.
+      libxc_nfuncs = 0
+      nwchem_libxc_init = .true.
+      end function
+
+      logical function is_libxcon()
+      use,intrinsic :: iso_c_binding
+#include "cdft.fh"
+      is_libxcon = libxcon
+      end function
+
+
+      logical function nwchem_libxc_family(family)
+      use,intrinsic :: iso_c_binding
+#ifdef USE_LIBXC
+      use xc_f03_lib_m
+#endif
+
+      implicit none
+
+      character*(*) family
+      integer ifunc
+
+#ifdef USE_LIBXC
+#include "libxc.fh"
+#endif
+
+      nwchem_libxc_family = .false.
+
+#ifdef USE_LIBXC
+      do ifunc=1,libxc_nfuncs
+        if (family.eq."gga") then
+          select case(libxc_family(ifunc))
+          case(xc_family_gga,xc_family_hyb_gga,xc_family_mgga,
+     $         xc_family_hyb_mgga)
+            nwchem_libxc_family = .true.
+          case default
+            nwchem_libxc_family = .false.
+          end select            
+        else if (familY.eq."mgga") then
+          select case(libxc_family(ifunc))
+          case(xc_family_mgga,xc_family_hyb_mgga)
+            nwchem_libxc_family = .true.
+          case default
+            nwchem_libxc_family = .false.
+          end select
+        elseif (family.eq."lapl") then
+          nwchem_libxc_family = iand(libxc_flags(ifunc),
+     $                           xc_flags_needs_laplacian).eq.
+     $                           xc_flags_needs_laplacian
+        elseif (family.eq."exc") then
+          nwchem_libxc_family = iand(libxc_flags(ifunc),
+     $                           xc_flags_have_exc).eq.
+     $                           xc_flags_have_exc
+          if (.not.nwchem_libxc_family) return
+        elseif (family.eq."fxc") then
+          nwchem_libxc_family = iand(libxc_flags(ifunc),
+     $                           xc_flags_have_fxc).eq.
+     $                           xc_flags_have_fxc
+          if (.not.nwchem_libxc_family) return
+        elseif (family.eq."kxc") then
+          nwchem_libxc_family = iand(libxc_flags(ifunc),
+     $                           xc_flags_have_kxc).eq.
+     $                           xc_flags_have_kxc
+          if (.not.nwchem_libxc_family) return
+        endif
+      enddo
+#endif
+      end function
+
+      subroutine nwchem_libxc_print
+      use,intrinsic :: iso_c_binding
+#ifdef USE_LIBXC
+      use xc_f03_lib_m, only: xc_f03_version_string,
+     $                        xc_f03_reference,
+     $                        xc_f03_functional_get_name
+#endif
+      implicit none
+
+#include "libxc.fh"
+#include "stdio.fh"
+#include "global.fh"
+
+      character(len=1024) :: namexc,version
+      character(len=5) :: blanks
+      integer :: ifunc
+      double precision :: fact
+
+
+#ifdef USE_LIBXC
+      if (ga_nodeid().eq.0) then
+
+        do ifunc=1,libxc_nfuncs
+          namexc = xc_f03_functional_get_name(libxc_funcs(ifunc))
+          fact = libxc_facts(ifunc)
+          write(blanks,'(I5)') 50-len_trim(namexc)
+          write(luOut,'(a'//adjustl(blanks)//')',advance='no') 
+          write(luOut,100) trim(namexc),fact
+        enddo
+
+      endif
+
+  100 format(A50,1x,f6.3)
+#endif
+      end subroutine
+
+      subroutine nwchem_libxc_print_header
+#ifdef USE_LIBXC
+      use,intrinsic :: iso_c_binding
+      use xc_f03_lib_m, only: xc_f03_version_string,
+     $                        xc_f03_reference,
+     $                        xc_f03_functional_get_name
+#endif
+      implicit none
+
+#include "libxc.fh"
+#include "stdio.fh"
+#include "global.fh"
+
+      character(len=1024) :: namexc,version
+      character(len=5) :: blanks
+      integer :: ifunc
+      double precision :: fact
+
+
+#ifdef USE_LIBXC
+      if (ga_nodeid().eq.0) then
+
+        call xc_f03_version_string(version)
+        write(luOut,100) trim(adjustl(version))
+
+      endif
+
+  100 format(10X,'Using LibXC version ',A10)
+#endif
+      end subroutine
+
+      subroutine nwchem_libxc_rtdbput(rtdb,modname)
+      use, intrinsic :: iso_c_binding
+      implicit none
+#include "libxc.fh"
+#include "errquit.fh"
+#include "rtdb.fh"
+#include "mafdecls.fh"
+      integer rtdb
+      character(len=*) modname
+      integer :: itemp(maxfunc)
+
+      if (.not.rtdb_put(rtdb,modname//':libxc_nfuncs',mt_int,1,
+     $    libxc_nfuncs))
+     $  call errquit(' libxc_rtdbput: rtdb_put failed',1,RTDB_ERR)
+
+      itemp(:) = libxc_funcs(:)
+      if (.not.rtdb_put(rtdb,modname//':libxc_funcs',mt_int,
+     $    libxc_nfuncs,itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_put failed',1,RTDB_ERR)
+
+      itemp(:) = libxc_family(:)
+      if (.not.rtdb_put(rtdb,modname//':libxc_family',mt_int,
+     $    libxc_nfuncs,itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_put failed',2,RTDB_ERR)
+
+      itemp(:) = libxc_kind(:)
+      if (.not.rtdb_put(rtdb,modname//':libxc_kind',mt_int,
+     $    libxc_nfuncs,itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_put failed',3,RTDB_ERR)
+
+      itemp(:) = libxc_flags(:)
+      if (.not.rtdb_put(rtdb,modname//':libxc_flags',mt_int,
+     $    libxc_nfuncs,itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_put failed',4,RTDB_ERR)
+
+      if (.not.rtdb_put(rtdb,modname//':libxc_facs',mt_dbl,libxc_nfuncs,
+     $    libxc_facts))
+     $  call errquit(' libxc_rtdbput: rtdb_put failed',5,RTDB_ERR)
+
+      end subroutine
+
+
+      subroutine nwchem_libxc_rdinput(rtdb,modname)
+      use, intrinsic :: iso_c_binding
+      implicit none
+#include "libxc.fh"
+#include "errquit.fh"
+#include "rtdb.fh"
+#include "mafdecls.fh"
+      integer rtdb
+      character(len=*) modname
+      integer :: itemp(maxfunc)
+
+      if (.not.rtdb_get(rtdb,modname//':libxc_nfuncs',mt_int,1,
+     $    libxc_nfuncs))
+     $  call errquit(' libxc_rtdbput: rtdb_get failed',1,RTDB_ERR)
+
+      if (.not.rtdb_get(rtdb,modname//':libxc_funcs',mt_int,
+     $    libxc_nfuncs,itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_get failed',1,RTDB_ERR)
+      libxc_funcs(:libxc_nfuncs) = int(itemp(:libxc_nfuncs),kind=c_int)
+
+      if (.not.rtdb_get(rtdb,modname//':libxc_family',mt_int,
+     $    libxc_nfuncs,itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_get failed',2,RTDB_ERR)
+      libxc_family(:libxc_nfuncs) = int(itemp(:libxc_nfuncs),kind=c_int)
+
+      if (.not.rtdb_get(rtdb,modname//':libxc_kind',mt_int,libxc_nfuncs,
+     $    itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_get failed',3,RTDB_ERR)
+      libxc_kind(:libxc_nfuncs) = int(itemp(:libxc_nfuncs),kind=c_int)
+
+      if (.not.rtdb_get(rtdb,modname//':libxc_flags',mt_int,
+     $    libxc_nfuncs,itemp))
+     $  call errquit(' libxc_rtdbput: rtdb_get failed',4,RTDB_ERR)
+      libxc_flags(:libxc_nfuncs) = int(itemp(:libxc_nfuncs),kind=c_int)
+
+      if (.not.rtdb_get(rtdb,modname//':libxc_facs',mt_dbl,libxc_nfuncs,
+     $    libxc_facts))
+     $  call errquit(' libxc_rtdbput: rtdb_get failed',5,RTDB_ERR)
+
+      end subroutine

--- a/src/nwdft/lr_tddft/tddft_init.F
+++ b/src/nwdft/lr_tddft/tddft_init.F
@@ -116,6 +116,7 @@ c
       external ga_create_atom_blocked
       logical xc_got2nd, xc_gotxc
       external xc_got2nd, xc_gotxc
+      logical, external :: is_libxcon
 c
       nodezero=(ga_nodeid().eq.0)
 c
@@ -402,6 +403,7 @@ c --------------------------
       do n=1,numfunc
         a=a+dabs(cfac(n))
       enddo
+      if (is_libxcon()) a = a + 1d0
       if ((a.gt.1.0d-8).and.(dabs(xfac(1)).le.1.0d-8)) then
 c Pure DFT
         ldft=.true.

--- a/src/nwdft/lr_tddft/tddft_init.F
+++ b/src/nwdft/lr_tddft/tddft_init.F
@@ -615,6 +615,7 @@ c
         write(LuOut,*)
         call util_print_centered
      1    (LuOut,'XC Information',20,.true.)
+        if (is_libxcon()) call nwchem_libxc_print_header()
         do n=1,numfunc
           if (xccomb(n)) write(LuOut,9300) xcname(n)
         enddo
@@ -638,6 +639,7 @@ c
             write(LuOut,9310) cname(n),cfac(n),'non-local'
           endif
         enddo
+        if (is_libxcon()) call nwchem_libxc_print()
 c
         if (cam_exch)
      &        write(LuOut,9500)cam_alpha,cam_beta,cam_omega

--- a/src/nwdft/lr_tddft_grad/tddft_grad_init.F
+++ b/src/nwdft/lr_tddft_grad/tddft_grad_init.F
@@ -127,6 +127,8 @@ c
 c
       logical xc_ngot3rd
       external xc_ngot3rd
+
+      logical,external :: is_libxcon
 c
 c     preliminaries: general parameters
       nao     = 0
@@ -240,6 +242,7 @@ c     get calculation type
       do n=1,numfunc
         xca=xca+dabs(cfac(n))
       enddo
+      if (is_libxcon()) xca = xca + 1d0
       if ((xca.gt.1.0d-8).and.(dabs(xfac(1)).le.1.0d-8)) then
 c       Pure DFT
         ldft=.true.

--- a/src/nwdft/xc/xc_eval_fnl.F
+++ b/src/nwdft/xc/xc_eval_fnl.F
@@ -227,6 +227,8 @@ c gradients.  ldew2 is for the dVxc*P term in the TDDFT gradients.
         endif
         return
       endif
+
+
 c      if (ldew.or.ldew3) call dfill(nq, 0.d0, func, 1)
 c      if (ldew) call dfill(nq, 0.d0, func, 1)
 c
@@ -1756,6 +1758,12 @@ c
             call xc_cr2scanl_d2()
          endif
       endif
+c
+c     libxc potential and energy
+c
+      call nwchem_libxc_compute(nq,Ex,Ec,qwght,rho,delrho,ttau,
+     $     laprho,Amat,Amat2,Amat3,Cmat,Cmat2,Cmat3,Mmat,Lmat,func,
+     $     grad,kske,kslap,ldew,do_2nd,do_3rd)
 c
 c     Calculate the steric energy
 c

--- a/src/nwdft/xc/xc_util.F
+++ b/src/nwdft/xc/xc_util.F
@@ -14,6 +14,7 @@ c
 c     see if any Gradient Corrected Functional is not null
 c
       logical out1,out2
+      logical,external :: nwchem_libxc_family
       double precision tot,eps
       parameter(eps=1.d-10)
 c
@@ -93,6 +94,9 @@ c
          call nwxc_getvals("nwxc_is_mgga",out2)
          xc_chkgrad = xc_chkgrad .or. out1.or.out2
       endif
+      out1 = nwchem_libxc_family("gga")
+      out2 = nwchem_libxc_family("mgga")
+      xc_chkgrad = xc_chkgrad .or. out1 .or. out2
 c
       return
       end
@@ -120,6 +124,8 @@ cc AJL/End
          call nwxc_getvals("nwxc_has_xc",out1)
         xc_gotxc = xc_gotxc.or.out1
       endif
+      if (libxcon) xc_gotxc = .true.
+
       return
       end
       logical function xc_gothfx()
@@ -154,6 +160,7 @@ c
 #include "cdft.fh"
 #include "util.fh"
       logical out1
+      logical, external :: nwchem_libxc_family
 c
       xc_got2nd=.not.(
 c
@@ -245,6 +252,10 @@ cwb97 should have 2nds
          call nwxc_getvals("nwxc_has_2nd",out1)
         xc_got2nd = xc_got2nd .or. out1
       endif
+
+      if (libxcon .and. xc_got2nd) then
+        xc_got2nd = xc_got2nd .and. nwchem_libxc_family("fxc")
+      endif
 c
       return
       end
@@ -263,6 +274,7 @@ c
 C  note in cdft.fh,they define cfac(numfunc) and xfac(numfunc)
 c 
       logical out1
+      logical,external :: nwchem_libxc_family
       double precision tot,eps
       parameter(eps=1.d-10)
       tot = xfac(18) + cfac(25) + xfac(21) + cfac(27) +
@@ -298,6 +310,8 @@ c
          call nwxc_getvals("nwxc_is_mgga",out1)
          xc_chktau = xc_chktau .or. out1
       endif
+      out1 = nwchem_libxc_family("mgga")
+      xc_chktau = xc_chktau .or. out1
       return
       end
 c
@@ -460,6 +474,7 @@ c     return true for functionals without 3rds
 c
       logical function xc_ngot3rd()
       implicit none
+      logical,external :: nwchem_libxc_family
 c
 #include "cdft.fh"
 c
@@ -571,6 +586,10 @@ c
      .     cfac(78).ne.0d0      ! wb97x-d3
      .                )
 c
+      if (libxcon .and. .not.xc_ngot3rd) then
+        xc_ngot3rd = xc_ngot3rd .and. (.not.nwchem_libxc_family("kxc"))
+      endif
+
       return
       end
 C
@@ -578,8 +597,10 @@ C
       implicit none
 #include "cdft.fh"
 #include "util.fh"
+      logical out1,nwchem_libxc_family
       double precision tot,eps
       parameter(eps=1.d-10)
+      external nwchem_libxc_family
       tot = xfac(67) + cfac(67) + xfac(74) + cfac(74)
 
       if (abs(tot).gt.eps) then
@@ -587,6 +608,8 @@ C
       else
         xc_chklap = .false.
       end if
+      out1 = nwchem_libxc_family("lapl")
+      xc_chklap = xc_chklap .or. out1
       return
       end
       logical function xc_chkdelrq()


### PR DESCRIPTION
LibXC 5.1.5 is downloaded and compiled using `cmake`. Third-order derivatives are enabled.