### PR TITLE
 MO energy decomposition plus two minor fixes (revisited)

### DIFF
--- a/src/cphf/cphf_solve3.F
+++ b/src/cphf/cphf_solve3.F
@@ -129,9 +129,10 @@ c     determine how many components we should treat:
       if (.not. rtdb_get(rtdb, 'cphf:ncomp', mt_int, 1, ncomp)) call
      &   errquit('cphf_solve3: failed to read ncomp ', 0, RTDB_ERR)
 
-      if (ncomp.gt.1 .and. lstatic) then ! something's fishy here
-        call errquit
-     &     ('cphf_solve3: static response but more than one component?',
+      if (ncomp.gt.1 .and. lstatic) then ! fishy ?
+        if (.not.lifetime) 
+     &    call errquit
+     &     ('cphf_solve3: static response no damping 2 compts.',
      &     ncomp, RTDB_ERR)
       elseif (ncomp.eq.1 .and. .not.lstatic) then ! fishy fishy
         call errquit

--- a/src/ddscf/uhf.F
+++ b/src/ddscf/uhf.F
@@ -696,6 +696,18 @@ cc AJL/Begin/SPIN ECPs
       external ecp_get_high_chan
 cc AJL/End
 c     
+c ... jochen 05/20: added an option to print contributions to
+c     the MO energies
+      logical epsana, master
+      integer l_diag, k_diag 
+      integer l_eps(2), k_eps(2)
+      integer imo, na, nb
+      double precision rtemp
+
+c     end of declarations
+c     -----------------------------------------------------------------
+
+c     
 c     Check
 c     
       odebug = util_print('uhf_debug', print_debug)
@@ -711,6 +723,23 @@ c
      &     'cphf_solve:cphf_uhf', mt_log, 1, cphf_uhf)) then
          cphf_uhf = .false.
       endif
+c ... analysis of orbital energies requested?      
+      master = (ga_nodeid().eq.0)
+      !if (master) write (6,*) 'hello from uhf_energy'
+      epsana = .false.
+      if (.not. rtdb_get(rtdb, 'dft:epscontributions',
+     &  mt_log, 1, epsana)) continue
+      
+      if (epsana) then               
+        if (.not.ma_push_get(MT_DBL,nbf,'uhf:diag',l_diag,k_diag))
+     &    call errquit('uhf: cannot allocate diag',1,MA_ERR)
+        if (.not.ma_push_get(MT_DBL,nbf,'uhf:eps1',l_eps(1),k_eps(1)))
+     &    call errquit('uhf: cannot allocate eps1',1,MA_ERR)
+        if (.not.ma_push_get(MT_DBL,nbf,'uhf:eps2',l_eps(2),k_eps(2)))
+     &    call errquit('uhf: cannot allocate eps2',1,MA_ERR)
+        call dfill(nbf, 0.0d0, dbl_mb(k_eps(1)), 1)
+        call dfill(nbf, 0.0d0, dbl_mb(k_eps(2)), 1)
+      end if ! epsana
 c     
 c     Arrays for AO density, coulomb and exchange matrices
 c
@@ -859,8 +888,10 @@ c
         call ga_dadd(1d0,f(4),1d0,g_tmp(4),f(4))   ! DFT xc part
 c
 c       destroy work space
-        if (.not. ga_destroy(g_tmp)) 
-     &   call errquit('uhf: ga corrupt?',0, GA_ERR)
+        do ifock = 1,nfock
+          if (.not. ga_destroy(g_tmp(ifock))) 
+     &      call errquit('uhf: ga corrupt?',0, GA_ERR)
+        end do
       end if  ! cam_exch
       call do_riscf (.true.)
 c
@@ -876,6 +907,91 @@ c
          e_b_xc = ga_ddot(g_b_dens,g_b_xc)
          etwo = etwo + e_a_xc + e_b_xc        
       endif
+c     
+c ... jochen: now that we have the C and XC Fock matrices,
+c     we can calculate their contributions to the orbital energies
+c     the arrays g_tmp(:) can be re-used for this purpose.
+c     
+      if (epsana) then
+        g_tmp(1) = ga_create_atom_blocked(geom, basis, 'tmp1')
+        g_tmp(2) = ga_create_atom_blocked(geom, basis, 'tmp2')
+c        
+c       Coulomb, alpha spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_a_coul, g_vecs(1), g_vecs(1),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        do imo = 1,nbf
+          dbl_mb(k_eps(1)+imo-1) = dbl_mb(k_diag+imo-1)
+        end do
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_b_coul, g_vecs(1), g_vecs(1),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        do imo = 1,nbf
+          dbl_mb(k_eps(1)+imo-1) = dbl_mb(k_eps(1)+imo-1)
+     &      + dbl_mb(k_diag+imo-1)
+        end do
+        if (master) write(6,*) 'V(C) alfa MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, dbl_mb(k_eps(1)+imo-1)
+        end do
+c
+c       Coulomb, beta spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_a_coul, g_vecs(2), g_vecs(2),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        do imo = 1,nbf
+          dbl_mb(k_eps(2)+imo-1) = dbl_mb(k_diag+imo-1)
+        end do
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_b_coul, g_vecs(2), g_vecs(2),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        do imo = 1,nbf
+          dbl_mb(k_eps(2)+imo-1) = dbl_mb(k_eps(2)+imo-1)
+     &      + dbl_mb(k_diag+imo-1)
+        end do
+        if (master) write(6,*) 'V(C) beta MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, dbl_mb(k_eps(2)+imo-1)
+        end do
+c        
+c       XC, alfa spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_a_exch, g_vecs(1), g_vecs(1),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        if (master) write(6,*) 'V(XC) alfa MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, -dbl_mb(k_diag+imo-1)
+        end do
+        do imo = 1,nbf
+          dbl_mb(k_eps(1)+imo-1) = dbl_mb(k_eps(1)+imo-1)
+     &      - dbl_mb(k_diag+imo-1)
+        end do
+c        
+c       XC, beta spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_b_exch, g_vecs(2), g_vecs(2),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        if (master) write(6,*) 'V(XC) beta MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, -dbl_mb(k_diag+imo-1)
+        end do
+        do imo = 1,nbf
+          dbl_mb(k_eps(2)+imo-1) = dbl_mb(k_eps(2)+imo-1)
+     &      - dbl_mb(k_diag+imo-1)
+        end do        
+      end if ! epsana
 c
       if (odebug .and. ga_nodeid().eq.0) then
          write(6,*) ' coulomb energies', e_a_coul, e_b_coul
@@ -934,6 +1050,31 @@ c     hack: use 'cphf:skew' to check this condition
         call ga_dadd(1.d0,g_a_hcore,1.d0,g_zora_Kinetic(1),g_a_hcore) ! zora kinetic
       endif
 
+      if (epsana) then
+c       MO energy analysis: print T contribs, but do not yet
+c       add to the accumulated MO energies
+c        
+c       T, alfa spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_a_hcore, g_vecs(1), g_vecs(1),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        if (master) write(6,*) 'T alfa MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+        end do
+c       T, beta spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_a_hcore, g_vecs(2), g_vecs(2),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        if (master) write(6,*) 'T beta MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+        end do
+      end if ! epsana
 cc If spin polarised ECP, split g_hcore
       if (ecp_channels.gt.1)
      &  call ga_copy(g_a_hcore,g_b_hcore)
@@ -947,6 +1088,42 @@ c      call int_1e_ga(basis, basis, g_hcore, 'potential', oskel) !potential
         call ga_copy(g_a_hcore,g_b_hcore)
       endif
 cc AJL/End
+
+      if (epsana) then
+c       MO energy analysis: 
+c        
+c       alfa spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_a_hcore, g_vecs(1), g_vecs(1),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        if (master) write(6,*) 'T+V(nuc) alfa MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+          dbl_mb(k_eps(1)+imo-1) = dbl_mb(k_eps(1)+imo-1)
+     &      + dbl_mb(k_diag+imo-1)
+        end do
+c        
+c       beta spin MOs
+        call ga_zero(g_tmp(1))
+        call ga_zero(g_tmp(2))
+        call two_index_transf(g_b_hcore, g_vecs(2), g_vecs(2),
+     &    g_tmp(1), g_tmp(2))
+        call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
+        if (master) write(6,*) 'T+V(nuc) beta MOs'
+        do imo=1,nbf
+          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+          dbl_mb(k_eps(2)+imo-1) = dbl_mb(k_eps(2)+imo-1)
+     &      + dbl_mb(k_diag+imo-1)
+        end do
+        if (master) write (6,'(//1x,a)')
+     &    'spin MO energies with T + V(nuc) + V(C) + V(XC)'
+        do imo = 1,nbf
+          if (master) write (6,*) imo,
+     &       dbl_mb(k_eps(1)+imo-1) ,  dbl_mb(k_eps(2)+imo-1)
+        end do
+      end if ! epsana      
 c
 c     cosmo charges, potential and energy contribution
 c
@@ -1037,6 +1214,381 @@ c
          call ga_print(cuhf_g_falpha)
          call ga_print(cuhf_g_fbeta)
       endif
+c
+       if (epsana) then
+c ... jochen: full MO energies, with all additional contributions
+         
+         call ga_get_diagonal(cuhf_g_falpha,dbl_mb(k_eps(1)))
+         call ga_get_diagonal(cuhf_g_fbeta,dbl_mb(k_eps(2)))
+         
+         if (master) write (6,'(//1x,a)')
+     &     'spin MO energies with all contributions (COSMO, etc.)'
+         do imo = 1,nbf
+           if (master) write (6,*) imo,
+     &       dbl_mb(k_eps(1)+imo-1) ,  dbl_mb(k_eps(2)+imo-1)
+         end do
+
+c ... jochen: for good measure, let's also calculate some ERIs
+c        for the frontier MOs. This is NOT efficient, but oh well ...
+c        we use g_?_dens etc for scratch and assign them to
+c        shorter variable names
+
+         d(1) = g_a_dens
+         d(2) = g_b_dens
+         f(1) = g_a_coul
+         f(2) = g_b_coul
+
+         na = nalpha
+         nb = nbeta
+
+         if (master) write(6,'(/1x,a/)')
+     &     'Some ERIs, Mulliken notation [1 1* | 2 2*]'
+
+c        ------------------------------------------------------         
+c        Fock 2e matrix from alfa HOMO-1 density
+         
+         call ga_matmul_patch('n','t', one,0d0,
+     &     g_vecs(1) ,1, nbf, na-1, na-1,
+     &     g_vecs(1) ,na-1, na-1, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)
+
+         jfac(1) = 1.0d0
+         kfac(1) = 0.0d0
+
+         call ga_zero (f(1))
+         call fock_2e(geom, basis, 1, jfac, kfac,
+     &     tol2e, oskel, d(1), f(1), .false.)
+
+         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+     $     d(2), f(2))
+
+         call ga_sync()
+         
+         call ga_get(f(2), na-1, na-1, na-1, na-1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na-1,na-1,na-1,na-1,rtemp
+
+         call ga_get(f(2), na, na, na, na, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na-1,na-1,na,na,rtemp         
+         
+         call ga_get(f(2), na+1, na+1, na+1, na+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na-1,na-1,na+1,na+1,rtemp
+
+         call two_index_transf(f(1), g_vecs(2), g_vecs(2),
+     $     d(2), f(2))
+
+         call ga_sync()
+         
+         call ga_get(f(2), nb, nb, nb, nb, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"b,",i3,"b]=",f15.8)'),
+     &     na-1,na-1,nb,nb,rtemp
+         
+         call ga_get(f(2), nb+1, nb+1, nb+1, nb+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"b,",i3,"b]=",f15.8)'),
+     &     na-1,na-1,nb+1,nb+1,rtemp            
+
+c        ------------------------------------------------------         
+c        Fock 2e matrix from alfa HOMO density
+         
+         call ga_matmul_patch('n','t', one,0d0,
+     &     g_vecs(1) ,1, nbf, na, na,
+     &     g_vecs(1) ,na, na, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)
+
+         jfac(1) = 1.0d0
+         kfac(1) = 0.0d0
+
+         call ga_zero (f(1))
+         call fock_2e(geom, basis, 1, jfac, kfac,
+     &     tol2e, oskel, d(1), f(1), .false.)
+
+         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+     $     d(2), f(2))
+
+         call ga_sync()
+         
+         call ga_get(f(2), na-1, na-1, na-1, na-1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na,na,na-1,na-1,rtemp
+         
+         call ga_get(f(2), na, na, na, na, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na,na,na,na,rtemp
+         
+         call ga_get(f(2), na+1, na+1, na+1, na+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na,na,na+1,na+1,rtemp
+
+         call two_index_transf(f(1), g_vecs(2), g_vecs(2),
+     $     d(2), f(2))
+
+         call ga_sync()
+         
+         call ga_get(f(2), nb, nb, nb, nb, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"b,",i3,"b]=",f15.8)'),
+     &     na,na,nb,nb,rtemp
+         
+         call ga_get(f(2), nb+1, nb+1, nb+1, nb+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"b,",i3,"b]=",f15.8)'),
+     &     na,na,nb+1,nb+1,rtemp         
+
+         
+c        ------------------------------------------------------
+c        Fock 2e matrix from alfa LUMO density
+         na = nalpha
+         call ga_matmul_patch('n','t', one,0d0,
+     &     g_vecs(1) ,1, nbf, na+1, na+1,
+     &     g_vecs(1) ,na+1, na+1, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)
+
+         jfac(1) = 1.0d0
+         kfac(1) = 0.0d0
+
+         call ga_zero (f(1))
+         call fock_2e(geom, basis, 1, jfac, kfac,
+     &     tol2e, oskel, d(1), f(1), .false.)
+
+         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+     $     d(2), f(2))
+
+         call ga_sync()
+         
+         call ga_get(f(2), na-1, na-1, na-1, na-1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na+1,na+1,na-1,na-1,rtemp         
+
+         call ga_get(f(2), na, na, na, na, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na+1,na+1,na,na,rtemp         
+
+         call ga_get(f(2), na+1, na+1, na+1, na+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na+1,na+1,na+1,na+1,rtemp         
+
+         call two_index_transf(f(1), g_vecs(2), g_vecs(2),
+     $     d(2), f(2))
+
+         call ga_sync()
+         
+         call ga_get(f(2), nb, nb, nb, nb, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"b,",i3,"b]=",f15.8)'),
+     &     na+1,na+1,nb,nb,rtemp
+         
+         call ga_get(f(2), nb+1, nb+1, nb+1, nb+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"b,",i3,"b]=",f15.8)'),
+     &     na+1,na+1,nb+1,nb+1,rtemp             
+
+
+c        ------------------------------------------------------
+c        Fock 2e matrix from SYMMETRIZED alfa HOMO-HOMO-1 product
+         na = nalpha
+         call ga_matmul_patch('n','t', one,0d0,
+     &     g_vecs(1) ,1, nbf, na, na,
+     &     g_vecs(1) ,na-1, na-1, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)
+
+         call ga_matmul_patch('n','t', 0.5d0,0.5d0,
+     &     g_vecs(1) ,1, nbf, na-1, na-1,
+     &     g_vecs(1) ,na, na, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)         
+
+         jfac(1) = 1.0d0
+         kfac(1) = 0.0d0
+
+         call ga_zero (f(1))
+         call fock_2e(geom, basis, 1, jfac, kfac,
+     &     tol2e, oskel, d(1), f(1), .false.)
+
+         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+     $     d(2), f(2))
+
+         call ga_sync()
+
+         rtemp = zero
+         call ga_get(f(2), na-1, na-1, na, na, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na,na-1,na,na-1,rtemp
+         
+         rtemp = zero
+         call ga_get(f(2), na, na, na-1, na-1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na-1,na,na-1,na,rtemp
+
+
+c        ------------------------------------------------------
+c        Fock 2e matrix from SYMMETRIZED alfa LUMO-HOMO-1 product
+         na = nalpha
+         call ga_matmul_patch('n','t', one,0d0,
+     &     g_vecs(1) ,1, nbf, na+1, na+1,
+     &     g_vecs(1) ,na-1, na-1, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)
+
+         call ga_matmul_patch('n','t', 0.5d0,0.5d0,
+     &     g_vecs(1) ,1, nbf, na-1, na-1,
+     &     g_vecs(1) ,na+1, na+1, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)         
+
+         jfac(1) = 1.0d0
+         kfac(1) = 0.0d0
+
+         call ga_zero (f(1))
+         call fock_2e(geom, basis, 1, jfac, kfac,
+     &     tol2e, oskel, d(1), f(1), .false.)
+
+         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+     $     d(2), f(2))
+         
+         rtemp = zero
+         call ga_get(f(2), na-1, na-1, na+1, na+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na+1,na-1,na+1,na-1,rtemp         
+
+         rtemp = zero
+         call ga_get(f(2), na+1, na+1, na-1, na-1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na-1,na+1,na-1,na+1,rtemp  
+         
+c        ------------------------------------------------------
+c        Fock 2e matrix from SYMMETRIZED alfa LUMO-HOMO product
+         na = nalpha
+         call ga_matmul_patch('n','t', one,0d0,
+     &     g_vecs(1) ,1, nbf, na+1, na+1,
+     &     g_vecs(1) ,na, na, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)
+
+         call ga_matmul_patch('n','t', 0.5d0,0.5d0,
+     &     g_vecs(1) ,1, nbf, na, na,
+     &     g_vecs(1) ,na+1, na+1, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)         
+
+         jfac(1) = 1.0d0
+         kfac(1) = 0.0d0
+
+         call ga_zero (f(1))
+         call fock_2e(geom, basis, 1, jfac, kfac,
+     &     tol2e, oskel, d(1), f(1), .false.)
+
+         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+     $     d(2), f(2))
+
+         call ga_sync()
+
+         rtemp = zero
+         call ga_get(f(2), na, na, na+1, na+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na+1,na,na+1,na,rtemp
+
+         rtemp = zero
+         call ga_get(f(2), na+1, na+1, na, na, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)'),
+     &     na,na+1,na,na+1,rtemp
+
+
+c        ------------------------------------------------------
+c        Fock 2e matrix from SYMMETRIZED beta LUMO-HOMO product
+         na = nalpha
+         call ga_matmul_patch('n','t', one,0d0,
+     &     g_vecs(2) ,1, nbf, nb+1, nb+1,
+     &     g_vecs(2) ,nb, nb, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)
+
+         call ga_matmul_patch('n','t', 0.5d0,0.5d0,
+     &     g_vecs(2) ,1, nbf, nb, nb,
+     &     g_vecs(2) ,nb+1, nb+1, 1, nbf,
+     &     d(1)      ,1,nbf,1,nbf)         
+
+         jfac(1) = 1.0d0
+         kfac(1) = 0.0d0
+
+         call ga_zero (f(1))
+         call fock_2e(geom, basis, 1, jfac, kfac,
+     &     tol2e, oskel, d(1), f(1), .false.)
+
+         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+     $     d(2), f(2))
+
+         call ga_sync()
+
+         rtemp = zero
+         call ga_get(f(2), nb, nb, nb+1, nb+1, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"b,",i3,"b |",i3,"b,",i3,"b]=",f15.8)'),
+     &     nb+1,nb,nb+1,nb,rtemp
+
+         rtemp = zero
+         call ga_get(f(2), nb+1, nb+1, nb, nb, rtemp,1)
+         if (master) write
+     &     (6,'(1x,"[",i3,"b,",i3,"b |",i3,"b,",i3,"b]=",f15.8)'),
+     &     nb,nb+1,nb,nb+1,rtemp
+         
+         
+c        ------------------------------------------------------
+c        Fock 2e matrix from alfa HOMO + exchange setting
+c        This gives exactly the same exchange integral as when I
+c        call the routine with jfac instead and a symmetrized
+c        transition density. However, this only works OK when
+c        the functional is hfexch so we'll leaver this commented out
+c$$$         na = nalpha
+c$$$         call ga_matmul_patch('n','t', one,0d0,
+c$$$     &     g_vecs(1) ,1, nbf, na, na,
+c$$$     &     g_vecs(1) ,na, na, 1, nbf,
+c$$$     &     d(1)      ,1,nbf,1,nbf)
+c$$$       
+c$$$         jfac(1) = 0.0d0
+c$$$         kfac(1) = 1.0d0
+c$$$
+c$$$         call ga_zero (f(1))
+c$$$         call fock_2e(geom, basis, 1, jfac, kfac,
+c$$$     &     tol2e, oskel, d(1), f(1), .false.)
+c$$$
+c$$$         call two_index_transf(f(1), g_vecs(1), g_vecs(1),
+c$$$     $     d(2), f(2))
+c$$$
+c$$$         call ga_sync()
+c$$$
+c$$$         rtemp = zero
+c$$$         call ga_get(f(2), na, na, na, na, rtemp,1)
+c$$$         if (master) write(6,'(1x,"[",3(i3,"a,"),i3,"a]=",f15.8)'),
+c$$$     &     na,na,na,na,rtemp
+c$$$
+c$$$         rtemp = zero
+c$$$         call ga_get(f(2), na+1, na+1, na+1, na+1, rtemp,1)
+c$$$         if (master) write(6,'(1x,"[",3(i3,"a,"),i3,"a]=",f15.8)'),
+c$$$     &     na,na+1,na,na+1,rtemp
+         
+      
+
+c        clean up memory used for MO energy decomposition:
+         if (.not.ma_chop_stack(l_diag)) call
+     &     errquit('uhf: ma_chop_stack failed k_diag',l_diag,MA_ERR)
+         if (.not. ga_destroy(g_tmp(1))) 
+     &     call errquit('uhf: ga corrupt?',0, GA_ERR)
+         if (.not. ga_destroy(g_tmp(2))) 
+     &     call errquit('uhf: ga corrupt?',0, GA_ERR)
+       end if
 c
 c     Free up dead global arrays
 c

--- a/src/property/aoresponse_driver_new.F
+++ b/src/property/aoresponse_driver_new.F
@@ -578,18 +578,20 @@ c     determine frequency and number of components
       lstatic = (abs(omega).lt.tenm8) ! static response or not
       ncomp = 2                 ! no. of Fourier components to treat
       if (lstatic) ncomp = 1
-c  jbecca START: static and damping do not work properly. Instead of 
-c     trying to fix this fringe case of little value, make sure
-c     if static, do not run with damping.
+
+c     static response with lifetime setting: make sure it is 
+c     routed through the dynamic response solver. We put a warning
+c     in the output, as this was potentially not the intended 
+c     setup for the calculation
       if (lstatic .and. lifetime) then
-         write(luout,*)'***********************************************'
-         write(luout,*)'Damping was requested with static frequency'
-         write(luout,*)'Turning off damping and sending to the static'
-         write(luout,*)'routine to save computational time'
-         write(luout,*)'***********************************************'
-         lifetime = .false.
+         write(luout,*)'***************************************'
+         write(luout,*)'Damping was requested with static field'
+         write(luout,*)'Please make sure that this is intended'
+         write(luout,*)'***************************************'
+         lstatic = .false.
+         ncomp = 2
       endif
-c  jbecca END
+
 c  jbecca START
       if (use_dimqm) then
          call dimqm_used(ldimqm)

--- a/src/property/giaofock.F
+++ b/src/property/giaofock.F
@@ -920,10 +920,10 @@ c
 c     call int_acc_std()
 
       next = nxtask(-nproc,task_size)
-      if(ga_nodeid().eq.0)
-     c     write(6,'(i5,a,f10.2,a)') ga_nodeid(),
-     G     ' giaofock schwarz done = ',
-     C     (100d0*shells_done)/shells_tot,'%'
+c      if(ga_nodeid().eq.0)
+c     c     write(6,'(i5,a,f10.2,a)') ga_nodeid(),
+c     G     ' giaofock schwarz done = ',
+c     C     (100d0*shells_done)/shells_tot,'%'
       call ga_sync()
       if(dorepl) then
          call util_mirrstop(g_densrep)


### PR DESCRIPTION
1. make sure one can run the response module with damping and a
   frequency of zero, to get polarizability for imaginary frequencies
2. added some code to ddscf/uhf.F to print T, V(nuc), V(coul) and
   V(xc) contributions to the orbital energies, and to calculate
   a few ERIs involving HOMO-1, HOMO, and LUMO, if
   dft:epscontributions is set to .true. in the rtdb and a response
   calculation is requested. In this case, ddscf/uhf.F gets called
   in an open-shell dft property calculation. The MO energy analysis is not
   supposed to be done by default, and therefore this hack will do for
   the few occasions that we want to see MO energy contributions.