### PR TITLE
fix for nvfortran 21.7

### DIFF
--- a/src/geom/geom_hnd.F
+++ b/src/geom/geom_hnd.F
@@ -4777,10 +4777,11 @@ C
       R1=R12+TEMP
       R2=R12-TEMP
       DIF=  ABS(A2-R1)-  ABS(A2-R2)
-      IF(DIF.LT.ZERO) GO TO 420
-      SHIFT=R2
-      GO TO 310
-  420 SHIFT=R1
+      IF(DIF.ge.ZERO) then
+         SHIFT=R2
+      else
+         SHIFT=R1
+      endif
       GO TO 310
   430 EIG(1)=GAMMA(1)+SUM
       DO 440 J=1,N

--- a/travis/build_env.sh
+++ b/travis/build_env.sh
@@ -148,7 +148,7 @@ fi
     if [[ "$FC" == "nvfortran" ]]; then
 	sudo apt-get -y install lmod g++ libtinfo5 libncursesw5 lua-posix lua-filesystem lua-lpeg lua-luaossl
 	nv_major=21
-	nv_minor=3
+	nv_minor=7
 	nverdot="$nv_major"."$nv_minor"
 	nverdash="$nv_major"-"$nv_minor"
 	arch_dpkg=`dpkg --print-architecture`

--- a/travis/nwchem.bashrc
+++ b/travis/nwchem.bashrc
@@ -36,7 +36,7 @@ if [[ "$FC" == "nvfortran" ]]; then
 #    module load nvhpc
      export BUILD_MPICH=1
      nv_major=21
-     nv_minor=3
+     nv_minor=7
      nverdot="$nv_major"."$nv_minor"
      export PATH=/opt/nvidia/hpc_sdk/Linux_"$arch"/"$nverdot"/compilers/bin:$PATH
      export LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_"$arch"/"$nverdot"/compilers/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
simplified conditionals/gotos maze to avoid nvfortran 21.7 to generate erroneous code at -O2