### PR TITLE
fixes to get hostid to work on nersc cray perlmutter

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3117,6 +3117,9 @@ ifdef COMM_LIBS
  CORE_LIBS += $(COMM_LIBS) 
 endif 
 #endif
+ifdef USE_CRAYSHASTA
+ CORE_LIBS += -lpmi2
+endif
 ifdef USE_LINUXAIO
  CORE_LIBS += -lrt
 endif

--- a/src/tools/GNUmakefile
+++ b/src/tools/GNUmakefile
@@ -560,6 +560,9 @@ GOTFREEBSD= $(shell uname -o 2>&1|awk ' /FreeBSD/ {print "1";exit}')
 ifdef USE_FPICF
   FFLAGS_FORGA += "-fPIC"
 endif
+ifdef USE_CRAYSHASTA
+  CFLAGS_FORGA += -D__CRAYXE
+endif
 ifeq ($(GOTCLANG),1)
   CFLAGS_FORGA += "-fPIC"
   ifeq ($(TARGET),MACX64)


### PR DESCRIPTION
requires the definition of the environment variable
`USE_CRAYSHASTA`