### PR TITLE
fix for NVHPC BLAS

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3177,6 +3177,10 @@ endif
 ifeq ($(shell echo $(BLASOPT) |awk '/openblas/ {print "Y"; exit}'),Y)
       DEFINES += -DOPENBLAS
 endif
+# NVHPC compilers are distributed wtih OpenBLAS named as libblas/liblapack
+ifeq ($(shell echo $(BLASOPT) |awk '/\/nvidia\/hpc_sdk\// {print "Y"; exit}'),Y)
+      DEFINES += -DOPENBLAS
+endif
 ifeq ($(shell echo $(BLASOPT) |awk '/mkl/ {print "Y"; exit}'),Y)
       DEFINES += -DMKL
 endif


### PR DESCRIPTION
Trivial fix but otherwise I have to edit the source every time I link with OpenBLAS distributed with NVHPC SDK.

Signed-off-by: Jeff Hammond <jehammond@nvidia.com>