### PR TITLE
use  python@3.10 on MacOS Github Actions

### DIFF
--- a/travis/build_env.sh
+++ b/travis/build_env.sh
@@ -73,6 +73,9 @@ esac
 	 $FC --version
 	 gfortran --version
      fi
+     #hack to get 3.10 as default
+     brew install python@3.10
+     brew link --force --overwrite python@3.10
 #  if [[ "$MPI_IMPL" == "openmpi" ]]; then
 #      HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install scalapack
 #  fi


### PR DESCRIPTION
This should replace https://github.com/nwchemgit/nwchem/pull/473 since use of actions/setup-python@v2 does not seem to trigger the use of python 3.10
https://github.com/nwchemgit/nwchem/runs/4061949438?check_suite_focus=true#step:9:28269