### PR TITLE
Fix bash shebangs: make /usr/bin/env find bash in paths

### DIFF
--- a/QA/Nightly_Jobscripts/EMSL_Cascade
+++ b/QA/Nightly_Jobscripts/EMSL_Cascade
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #MSUB -A mscfops
 #MSUB -l "walltime=8:00:00"
 #MSUB -l "nodes=1:ppn=8"

--- a/QA/Nightly_Jobscripts/EMSL_Chinook
+++ b/QA/Nightly_Jobscripts/EMSL_Chinook
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #MSUB -A mscfops
 #MSUB -l "walltime=8:00:00"
 #MSUB -l "nodes=2:ppn=8"

--- a/QA/Nightly_Jobscripts/PNNL_Olympus
+++ b/QA/Nightly_Jobscripts/PNNL_Olympus
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #SBATCH -A NWCHEM
 #SBATCH -t 08:00:00
 #SBATCH -N 1 

--- a/QA/doNightlyTests.mpi
+++ b/QA/doNightlyTests.mpi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/QA/doafewqmtests.mpi
+++ b/QA/doafewqmtests.mpi
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 #
 # $Id$
 #

--- a/QA/doalltests.mpi
+++ b/QA/doalltests.mpi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/QA/dolibxctests.mpi
+++ b/QA/dolibxctests.mpi
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 #
 # $Id$
 #

--- a/QA/domdtests.mpi
+++ b/QA/domdtests.mpi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/QA/domknwchemenv
+++ b/QA/domknwchemenv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/QA/domknwchemrc
+++ b/QA/domknwchemrc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/QA/doqmmmtests.mpi
+++ b/QA/doqmmmtests.mpi
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 #
 # $Id$
 #

--- a/QA/doqmtests.mpi
+++ b/QA/doqmtests.mpi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/QA/doqmtests_bash
+++ b/QA/doqmtests_bash
@@ -1,4 +1,4 @@
-#!/bin/bash -f
+#!/usr/bin/env bash -f
 #
 # $Id: doqmtests.mpi 25922 2014-07-18 22:40:13Z edo $
 #

--- a/QA/dotcetests
+++ b/QA/dotcetests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/QA/round_esp.sh
+++ b/QA/round_esp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 input_file=$1
 read -r line < "$input_file"
 echo "$line"

--- a/QA/runtests.mpi.unix_bash
+++ b/QA/runtests.mpi.unix_bash
@@ -1,4 +1,4 @@
-#!/bin/bash  -f
+#!/usr/bin/env bash  -f
 CWD=`pwd`
 SCRATCHDIR=$CWD/scratchdir
 TESTOUTPUTS=$CWD/testoutputs

--- a/QA/sleep_loopqa.sh
+++ b/QA/sleep_loopqa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #echo "starting sleep_loop.sh for command: " ${@} >& /tmp/out
 for last_arg in $@; do :; done
 # echo "last arg of ${#} is $last_arg" >& /tmp/out

--- a/QA/tests/nwxc_ad_nwdft_bnzp/check
+++ b/QA/tests/nwxc_ad_nwdft_bnzp/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec=/home/d3y133/nwchem-dev/nwchem-ref/QA/tests/nwxc_nwdft_4n
 tkdiff $exec/4n_b1b95.out  4n_b1b95.out
 tkdiff $exec/4n_b97-3.out  4n_b97-3.out

--- a/QA/tests/nwxc_ad_nwdft_bnzp/run
+++ b/QA/tests/nwxc_ad_nwdft_bnzp/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec=/home/d3y133/nwchem-dev/nwchem-trunk/bin/LINUX64/nwchem
 $exec 4n_b1b95.nw 2>&1 | tee 4n_b1b95.out
 $exec 4n_b97-3.nw 2>&1 | tee 4n_b97-3.out

--- a/QA/tests/nwxc_mx_nwdft_bnzp/check
+++ b/QA/tests/nwxc_mx_nwdft_bnzp/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec=/home/d3y133/nwchem-dev/nwchem-ref/QA/tests/nwxc_nwdft_4n
 tkdiff $exec/4n_b1b95.out  4n_b1b95.out
 tkdiff $exec/4n_b97-3.out  4n_b97-3.out

--- a/QA/tests/nwxc_mx_nwdft_bnzp/run
+++ b/QA/tests/nwxc_mx_nwdft_bnzp/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec=/home/d3y133/nwchem-dev/nwchem-trunk/bin/LINUX64/nwchem
 $exec 4n_b1b95.nw 2>&1 | tee 4n_b1b95.out
 $exec 4n_b97-3.nw 2>&1 | tee 4n_b97-3.out

--- a/QA/tests/nwxc_nwdft_bnzp/check
+++ b/QA/tests/nwxc_nwdft_bnzp/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec=/home/d3y133/nwchem-dev/nwchem-ref/QA/tests/nwxc_nwdft_4n
 tkdiff $exec/4n_b1b95.out  4n_b1b95.out
 tkdiff $exec/4n_b97-3.out  4n_b97-3.out

--- a/QA/tests/nwxc_nwdft_bnzp/run
+++ b/QA/tests/nwxc_nwdft_bnzp/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec=/home/d3y133/nwchem-dev/nwchem-trunk/bin/LINUX64/nwchem
 $exec 4n_b1b95.nw 2>&1 | tee 4n_b1b95.out
 $exec 4n_b97-3.nw 2>&1 | tee 4n_b97-3.out

--- a/contrib/add_Id
+++ b/contrib/add_Id
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # add_Id
 # ------

--- a/contrib/add_Id_C
+++ b/contrib/add_Id_C
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Add the $Id: $ construct to a C file. For simplicity it is simply appended.
 #

--- a/contrib/add_Id_Fortran
+++ b/contrib/add_Id_Fortran
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Add the $Id: $ construct to a Fortran file. For simplicity it is simply appended.
 #

--- a/contrib/add_Id_Makefile
+++ b/contrib/add_Id_Makefile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Add the $Id: $ construct to a Makefile. For simplicity it is simply appended.
 # This is used to avoid adding the C-style construct in Makefile include files.

--- a/contrib/contributors/contributors
+++ b/contrib/contributors/contributors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function usage()
 {
     cat <<EOF

--- a/contrib/distro-tools/build_nwchem
+++ b/contrib/distro-tools/build_nwchem
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #export RELEASE=6.5
 function usage()
 {

--- a/contrib/distro-tools/build_nwchem_bin_distro
+++ b/contrib/distro-tools/build_nwchem_bin_distro
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ $# != 3 ] ; then
   echo "Usage: $0 source-directory linux-version gcc-version"
   echo ""

--- a/contrib/distro-tools/build_nwchem_modules
+++ b/contrib/distro-tools/build_nwchem_modules
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script tests various builds to ensure that routines are stubbed 
 # properly when not needed. 

--- a/contrib/distro-tools/build_nwchem_src_distro
+++ b/contrib/distro-tools/build_nwchem_src_distro
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source=`pwd`/$1
 date=`date +%Y-%m-%d`
 revision=`svn info ${source} | grep Revision:`

--- a/contrib/doxygen/run_doxygen
+++ b/contrib/doxygen/run_doxygen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Doxygen run script for NWChem
 #

--- a/contrib/fde/freeze_thaw_example/clear_up.sh
+++ b/contrib/fde/freeze_thaw_example/clear_up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf *.movecs *.gridpts.* *.db *.out.rhf
 

--- a/contrib/fde/freeze_thaw_example/freeze_thaw.sh
+++ b/contrib/fde/freeze_thaw_example/freeze_thaw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f h2o1.movecs ] || [ ! -f h2o2.movecs ]; then 
   mpirun -np 4 ~/Programs/nwchem-dev-new-build/bin/LINUX64/./nwchem dimer.nw > dimer.out.rhf;

--- a/contrib/getmem.nwchem
+++ b/contrib/getmem.nwchem
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 # this script tries to figure out no. of processors and RAM

--- a/contrib/git.nwchem/dotar68_git.sh
+++ b/contrib/git.nwchem/dotar68_git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 rm -rf temp.`date +%Y%m%d`
 mkdir -p temp.`date +%Y%m%d`
 cd temp.`date +%Y%m%d`

--- a/contrib/git.nwchem/dotar_release.sh
+++ b/contrib/git.nwchem/dotar_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 Vx=7
 Vy=0
 Vz=0

--- a/contrib/git.nwchem/download_count_releases.sh
+++ b/contrib/git.nwchem/download_count_releases.sh
@@ -1,3 +1,3 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
  curl -s https://api.github.com/repos/nwchemgit/nwchem/releases|egrep dow|sed 's/\"browser\_download\_url\":\ \"https:\/\/github.com\/nwchemgit\/nwchem\/releases\/download\///g' | sed 's/\"//g'
 # curl -s https://api.github.com/repos/nwchemgit/nwchem/releases|egrep dow|sed 's/\"browser\_download\_url\":\ \"https:\/\/github.com\/nwchemgit\/nwchem\/releases\/download\//g'

--- a/contrib/git.nwchem/generate_changelog.sh
+++ b/contrib/git.nwchem/generate_changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -f
+#!/usr/bin/env bash -f
 #git log v6.8...v6.8-release --oneline --reverse
 #args are tag1 and tag2
 git log $1...$2 --oneline --reverse

--- a/contrib/mapointer_test/fix_include_files
+++ b/contrib/mapointer_test/fix_include_files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/contrib/mkdocs/build_website.sh
+++ b/contrib/mkdocs/build_website.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 MYPWD=`pwd`
 if [[ -z "${NWCHEM_TOP}" ]]; then
     DIRMKDOCS=`dirname "$0"`

--- a/contrib/mkdocs/preload.sh
+++ b/contrib/mkdocs/preload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
   rm -rf nwchemgit.github.io_temp
   git clone --depth 1 git@github.com:nwchemgit/nwchemgit.github.io.git nwchemgit.github.io_temp
 cd nwchemgit.github.io_temp

--- a/contrib/mkdocs/remove_svg.sh
+++ b/contrib/mkdocs/remove_svg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 sed \
    -e  's/<img alt=\"\$\$/\$\$/' \
    -e  's/<img alt=\"\\(/\\(/' \

--- a/contrib/mov2asc/test/run_test
+++ b/contrib/mov2asc/test/run_test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ ${#NWCHEM_EXECUTABLE} -eq 0 ] ; then
   export NWCHEM_EXECUTABLE=`find ../../../bin -name nwchem`
 fi

--- a/contrib/quasar/yaml_driver
+++ b/contrib/quasar/yaml_driver
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 inputFile=$(basename -- "$1")
 inputFile="${inputFile%.*}"

--- a/contrib/robodoc/run_robodoc
+++ b/contrib/robodoc/run_robodoc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Designed to use Robodoc 4.99.38
 #

--- a/contrib/svn_expand_Id
+++ b/contrib/svn_expand_Id
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $Id$
 #

--- a/contrib/validate/get_tests.bash
+++ b/contrib/validate/get_tests.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # get_tests.bash
 # --------------

--- a/contrib/validate/validate
+++ b/contrib/validate/validate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Validate
 # ========

--- a/contrib/xeonphi/build4xeonphi.sh
+++ b/contrib/xeonphi/build4xeonphi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -f
+#!/usr/bin/env bash -f
 cd nwchem-6.5
 export NWCHEM_TOP=`pwd`
 export NWCHEM_TARGET=LINUX64

--- a/src/NWints/simint/libsimint_source/build_simint.sh
+++ b/src/NWints/simint/libsimint_source/build_simint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # script to download simint-generator, create the simint library, compile it
 # and link it in NWChem
 # FC=compilername can be used to set compiler, e.g.

--- a/src/config/has_blas
+++ b/src/config/has_blas
@@ -1,4 +1,4 @@
-#!/bin/bash -f
+#!/usr/bin/env bash -f
 #
 # $Id$
 #

--- a/src/config/has_dblas
+++ b/src/config/has_dblas
@@ -1,4 +1,4 @@
-#!/bin/bash -f
+#!/usr/bin/env bash -f
 #
 # $Id$
 #

--- a/src/nwxc/maxima/bin/autoxc
+++ b/src/nwxc/maxima/bin/autoxc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function usage ()
 {
    cat<<EOF

--- a/src/nwxc/maxima/bin/autoxc-Ds
+++ b/src/nwxc/maxima/bin/autoxc-Ds
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function usage ()
 {
    cat<<EOF

--- a/src/rdmft/recycling/wfn1/compile.bash
+++ b/src/rdmft/recycling/wfn1/compile.bash
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 gfortran wfn1_test_para.F wfn1_f0df0f1.F wfn1_f1f2f3.F -o testpara

--- a/src/tools/mingw64_patch.sh
+++ b/src/tools/mingw64_patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm -f win64_ma_nxtval.patch
 cat > win64_ma_nxtval.patch <<EOF
 --- $1/ma/ma.c.org	2020-02-28 11:39:16.000000000 -0800

--- a/src/tools/msmpi_patch.sh
+++ b/src/tools/msmpi_patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm -f comex_configure.patch
 cat > comex_configure.patch <<EOF
 --- $1/comex/configure.orig	2020-06-04 11:16:29.506196033 -0700

--- a/src/tools/nxtval.sh
+++ b/src/tools/nxtval.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 sed -e 's/NXTVAL_/NXTVAL_OFF_/' $1/tcgmsg/tcgmsg-mpi/sndrcv.h > $1/tcgmsg/tcgmsg-mpi/sndrcv.h.mod
 mv $1/tcgmsg/tcgmsg-mpi/sndrcv.h.mod  $1/tcgmsg/tcgmsg-mpi/sndrcv.h
 sed -e 's/NXTVAL_/NXTVAL_OFF_/' $1/tcgmsg/tcgmsg-mpi/srftoc.h > $1/tcgmsg/tcgmsg-mpi/srftoc.h.mod

--- a/src/util/shortsrc
+++ b/src/util/shortsrc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 mv util_version.F bigv.F
 cat > util_version.F<<EOF 
       subroutine util_version()

--- a/travis/build_env.sh
+++ b/travis/build_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 os=`uname`
 dist="ubuntu"
 arch=`uname -m`

--- a/travis/check_failures.sh
+++ b/travis/check_failures.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ -z "$TRAVIS_BUILD_DIR" ]] ; then
     TRAVIS_BUILD_DIR=$(pwd)
 fi

--- a/travis/compile_nwchem.sh
+++ b/travis/compile_nwchem.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "start compile"
 set -e
 # source env. variables

--- a/travis/config_nwchem.sh
+++ b/travis/config_nwchem.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # source env. variables
 if [[ -z "$TRAVIS_BUILD_DIR" ]] ; then
     TRAVIS_BUILD_DIR=$(pwd)

--- a/travis/run_qas.sh
+++ b/travis/run_qas.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 # Exit on error
 set -e
 # source env. variables

--- a/travis/sleep_loop.sh
+++ b/travis/sleep_loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm -f make.log
 echo "starting sleep_loop.sh for command: " ${@}
 "${@}" >& make.log &


### PR DESCRIPTION
This is needed on FreeBSD and other systems where bash isn't located in /bin/bash.