### PR TITLE
Elpa testing

### DIFF
--- a/src/tools/GNUmakefile
+++ b/src/tools/GNUmakefile
@@ -557,6 +557,12 @@ endif
 #detect clang
 GOTCLANG= $(shell $(CC) -dM -E - </dev/null 2> /dev/null |grep __clang__|head -1|cut -c19)
 GOTFREEBSD= $(shell uname -o 2>&1|awk ' /FreeBSD/ {print "1";exit}')
+ifeq ($(_FC),ifort)
+  USE_FPICF=1
+endif
+ifeq ($(_FC),ifx)
+  USE_FPICF=1
+endif
 ifdef USE_FPICF
   FFLAGS_FORGA += "-fPIC"
 endif

--- a/travis/run_qas.sh
+++ b/travis/run_qas.sh
@@ -54,6 +54,9 @@ env|egrep MP
  case "$ARMCI_NETWORK" in
     MPI-PR)
 	nprocs=$(( nprocs + 1 ))
+	if [[ "$BUILD_MPICH" == 1 && $nprocs > 2 ]]; then
+	    nprocs=2
+	fi
 	case "$MPI_IMPL" in
 	    openmpi)
 		export MPIRUN_NPOPT="-mca mpi_yield_when_idle 0 --oversubscribe -np "


### PR DESCRIPTION
* enable USE_FPICF=1 by default for FC=ifort/ifx for tools compilation
* speed QA tests by setting np=2 when BUILD_MPICH&MPI-PR