### PR TITLE
convert all instances of sqrt(dot_product(*,*)) to norm(*), which is mathematically equivalent

### DIFF
--- a/src/nwpw/gw/Transfer/Utilities/spherical.f90
+++ b/src/nwpw/gw/Transfer/Utilities/spherical.f90
@@ -83,7 +83,7 @@
       do im=ll-mmm+1,ll+mmm
         fact=fact*im
       enddo
-      costheta=rr(3)/sqrt(dot_product(rr,rr))
+      costheta=rr(3)/norm2(rr)
       rmag=sqrt(dot_product(rr(1:2),rr(1:2)))
       if (rmag.le.0.d0) then
         if (mmm.eq.0) then

--- a/src/nwpw/gw/Transfer/mk2cse.f90
+++ b/src/nwpw/gw/Transfer/mk2cse.f90
@@ -136,7 +136,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 
@@ -466,7 +466,7 @@ do ibp=nbcore+1,ncband
           do jj=1,3
             bgrad=bgrad+(evtx(jj+1)-evtx(1))*rg(:,jj)
           enddo
-          xmult=4.d0*pi/sqrt(dot_product(bgrad,bgrad))
+          xmult=4.d0*pi/norm2(bgrad)
           if (lc) then
             do iw=1,nwpt
               vpyr(:)=vpyr0(:,iw)/vqvtx0
@@ -757,7 +757,7 @@ external xfn1,xfn2,xfn3,grater
 !write(6,'(3f10.6)') xkvtx
 !write(6,'(3f10.6)') xkv0
   call cross(xq1,xq2,xnorm)
-  area=sqrt(dot_product(xnorm,xnorm))
+  area=norm2(xnorm)
 !write(6,*)
 !write(6,'(a,es15.5)') 'area  ',area
   aa=dot_product(xq1,xq1)
@@ -975,7 +975,7 @@ external xfn4,xfn5,xfn6,grater
 !write(6,'(3f10.6)') xkvtx
 !write(6,'(3f10.6)') xkv0
   call cross(xq1,xq2,xnorm)
-  area=sqrt(dot_product(xnorm,xnorm))
+  area=norm2(xnorm)
 !write(6,*)
 !write(6,'(a,es15.5)') 'area  ',area
   aa=dot_product(xq1,xq1)

--- a/src/nwpw/gw/Transfer/mk3cse.f90
+++ b/src/nwpw/gw/Transfer/mk3cse.f90
@@ -152,7 +152,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 
@@ -607,7 +607,7 @@ do ibp=test_bands_se(1),test_bands_se(2)
             do jj=1,3
               bgrad=bgrad+(evtx(jj+1)-evtx(1))*rg(:,jj)
             enddo
-            xmult=4.d0*pi/sqrt(dot_product(bgrad,bgrad))
+            xmult=4.d0*pi/norm2(bgrad)
             if (lc) then
               do iw=1,nwpt
                 aa0(iw)=xmat2(ictr(1),ictr(2),ictr(3))*max(dimag(lossfn(iw,iqctr,1)),0.d0)
@@ -676,7 +676,7 @@ do ibp=test_bands_se(1),test_bands_se(2)
             do jj=1,3
               bgrad=bgrad+(evtx(jj+1)-evtx(1))*rg(:,jj)
             enddo
-            xmult=4.d0*pi/sqrt(dot_product(bgrad,bgrad))
+            xmult=4.d0*pi/norm2(bgrad)
             if (lc) then
               do iw=1,nwpt
                 vpyr(:)=vpyr0(:,iw)/vqvtx0
@@ -1139,7 +1139,7 @@ external xfn1,xfn2,xfn3,grater
   xq2=xkp(:,2)-xkp(:,3)
   xkv0=xkp(:,3)+xkvtx
   call cross(xq1,xq2,xnorm)
-  area=sqrt(dot_product(xnorm,xnorm))
+  area=norm2(xnorm)
   aa=dot_product(xq1,xq1)
   bb=2*dot_product(xq1,xkv0)
   cc=2*dot_product(xq1,xq2)
@@ -1349,7 +1349,7 @@ external xfn4,xfn5,xfn6,grater
   xq2=xkp(:,2)-xkp(:,3)
   xkv0=xkp(:,3)+xkvtx
   call cross(xq1,xq2,xnorm)
-  area=sqrt(dot_product(xnorm,xnorm))
+  area=norm2(xnorm)
   aa=dot_product(xq1,xq1)
   bb=2*dot_product(xq1,xkv0)
   cc=2*dot_product(xq1,xq2)

--- a/src/nwpw/gw/Transfer/mkcse.f90
+++ b/src/nwpw/gw/Transfer/mkcse.f90
@@ -114,7 +114,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 

--- a/src/nwpw/gw/Transfer/mkexch.f90
+++ b/src/nwpw/gw/Transfer/mkexch.f90
@@ -63,7 +63,7 @@ parameter (pi=3.1415926535897932384626433832795, &
     pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
     pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
     pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-    dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+    dist(ii)=dot_product(gamma,pln)/norm2(pln)
   enddo
   falloff=minval(dist)
 

--- a/src/nwpw/gw/Transfer/mkploss.f90
+++ b/src/nwpw/gw/Transfer/mkploss.f90
@@ -190,7 +190,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 
@@ -809,7 +809,7 @@ do ibp=test_bands_se(1),test_bands_se(2)
             do jj=1,3
               bgrad=bgrad+(evtx(jj+1)-evtx(1))*rgc(:,jj)
             enddo
-            xmult=1.d0/sqrt(dot_product(bgrad,bgrad))
+            xmult=1.d0/norm2(bgrad)
 ! DEBUG
 !cdum = 0.d0
 ! DEBUG

--- a/src/nwpw/gw/Transfer/mkppse.f90
+++ b/src/nwpw/gw/Transfer/mkppse.f90
@@ -105,7 +105,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 

--- a/src/nwpw/gw/Transfer/mkppse2.f90
+++ b/src/nwpw/gw/Transfer/mkppse2.f90
@@ -103,7 +103,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 
@@ -541,7 +541,7 @@ do ibp=nbcore+1,ncband
           do jj=1,3
             bgrad=bgrad+(evtx(jj+1)-evtx(1))*rg(:,jj)
           enddo
-          xmult=4.d0*pi/sqrt(dot_product(bgrad,bgrad))
+          xmult=4.d0*pi/norm2(bgrad)
           do iw=1,nwpt
             vpyr(:)=vpyr0(:,iw)/vqvtx0
             aa0(iw)=vpyr(indxe(1))

--- a/src/nwpw/gw/Transfer/mkpwse.f90
+++ b/src/nwpw/gw/Transfer/mkpwse.f90
@@ -216,7 +216,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 
@@ -558,7 +558,7 @@ gfo=minval(dist)
             do jj=1,3
               bgrad=bgrad+(evtx(jj+1)-evtx(1))*rgc(:,jj)
             enddo
-            xmult=1.d0/sqrt(dot_product(bgrad,bgrad))
+            xmult=1.d0/norm2(bgrad)
             if (lc) then
               do iww=iwwlim(1)-1,iwwlim(4)+1
                 wwwlo=dw*(iww-0.5d0)
@@ -987,7 +987,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 

--- a/src/nwpw/gw/Transfer/mkse.f90
+++ b/src/nwpw/gw/Transfer/mkse.f90
@@ -204,7 +204,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 
@@ -838,7 +838,7 @@ do ibp=test_bands_se(1),test_bands_se(2)
             do jj=1,3
               bgrad=bgrad+(evtx(jj+1)-evtx(1))*rgc(:,jj)
             enddo
-            xmult=1.d0/sqrt(dot_product(bgrad,bgrad))
+            xmult=1.d0/norm2(bgrad)
             if (lc) then
 ! DEBUG
 !cdum = 0.d0
@@ -1267,7 +1267,7 @@ double complex :: cdummy1,cdummy2
   vt1=xkv0+xq2
   vt2=xq1-xq2
   call crossreduced(xq1,xq2,xnorm)
-  area=sqrt(dot_product(xnorm,xnorm))
+  area=norm2(xnorm)
   aa0=xkv0(iv)*xkv0(jv)
   aa1=xq1(iv)*xkv0(jv)+xq1(jv)*xkv0(iv)
   aa2=xq1(iv)*xq1(jv)

--- a/src/nwpw/gw/Transfer/mksekss.f90
+++ b/src/nwpw/gw/Transfer/mksekss.f90
@@ -102,7 +102,7 @@ do ii=1,3
   pln(1)=blat(jj,2)*blat(kk,3)-blat(jj,3)*blat(kk,2)
   pln(2)=-blat(jj,1)*blat(kk,3)+blat(jj,3)*blat(kk,1)
   pln(3)=blat(jj,1)*blat(kk,2)-blat(jj,2)*blat(kk,1)
-  dist(ii)=dot_product(gamma,pln)/sqrt(dot_product(pln,pln))
+  dist(ii)=dot_product(gamma,pln)/norm2(pln)
 enddo
 gfo=minval(dist)
 

--- a/src/nwpw/gw/Transfer/mkxclda.f90
+++ b/src/nwpw/gw/Transfer/mkxclda.f90
@@ -75,7 +75,7 @@ external linterp,spharm
     rrel(ii)=rrel(ii)+rprimd(ii,jj)*(rr(jj)-xred(jj,iatom))
   enddo
   enddo
-  rrmag=sqrt(dot_product(rrel,rrel))
+  rrmag=norm2(rrel)
   wfval=0.d0
   if (rrmag.gt.rphigrid(itpaw,gridsize(itpaw,iphigrid(itpaw)))) return
   do iorb=1,nlmn(itpaw)
@@ -111,7 +111,7 @@ external linterp,spharm
     rrel(ii)=rrel(ii)+rprimd(ii,jj)*(rr(jj)-xred(jj,iatom))
   enddo
   enddo
-  rrmag=sqrt(dot_product(rrel,rrel))
+  rrmag=norm2(rrel)
   wfval=0.d0
   if (rrmag.gt.rphigrid(itpaw,gridsize(itpaw,iphigrid(itpaw)))) return
   do iorb=1,nlmn(itpaw)
@@ -146,7 +146,7 @@ external linterp,spharm
     rrel(ii)=rrel(ii)+rprimd(ii,jj)*(rr(jj)-xred(jj,iatom))
   enddo
   enddo
-  rrmag=sqrt(dot_product(rrel,rrel))
+  rrmag=norm2(rrel)
   wfval=0.d0
   if (rrmag.gt.rphigrid(itpaw,gridsize(itpaw,iphigrid(itpaw)))) return
   do iorb=1,nlmn(itpaw)

--- a/src/nwpw/gw/Transfer/pspwmatel.f90
+++ b/src/nwpw/gw/Transfer/pspwmatel.f90
@@ -20,7 +20,7 @@ do ii=1,3
     qqgg(jj)=qqgg(jj)+blat(ii,jj)*(-qq(ii)-dble(igg(ii)))
   enddo
 enddo
-qqggmag=sqrt(dot_product(qqgg,qqgg))
+qqggmag=norm2(qqgg)
 !write(6,*) qqgg
 !write(6,*) qqggmag
 !write(6,*) rphigrid(itpaw,gridsize(itpaw,iphigrid(itpaw)))

--- a/src/nwpw/gw/Transfer/setetint.f90
+++ b/src/nwpw/gw/Transfer/setetint.f90
@@ -166,7 +166,7 @@ double precision :: www
         do jj=1,3
           bgrad=bgrad+(evtx(jj+1)-evtx(1))*rg(:,jj)
         enddo
-        xmult=4.d0*pi/sqrt(dot_product(bgrad,bgrad))
+        xmult=4.d0*pi/norm2(bgrad)
         do iw=1,nwpt
           vpyr(:)=vpyr0(:,iw)/vqvtx0
           aa0(iw)=vpyr(indxe(1))

--- a/src/nwpw/gw/Transfer/testint.f90
+++ b/src/nwpw/gw/Transfer/testint.f90
@@ -62,7 +62,7 @@ write(6,*) xint(9)
 f0=enval(1)
 !!grad=(/1.d0,1.d0,1.d0/)
 grad=xgrad(:,1)
-agrad=sqrt(dot_product(grad,grad))
+agrad=norm2(grad)
 enval=(/(dot_product(grad,vtx(:,ii))+f0,ii=1,8)/)
 !
 !!enval=(/(0.5d0*(-1)**((ii-1)/1),ii=1,8)/)

--- a/src/nwpw/gw/Transfer/tprojwf.f90
+++ b/src/nwpw/gw/Transfer/tprojwf.f90
@@ -71,7 +71,7 @@ do iz=1,ngkpt(3)
       kkgg(jj)=kkgg(jj)+blat(ii,jj)*(kk(ii)+dble(igg(ii)))
     enddo
     enddo
-    kkggmag=sqrt(dot_product(kkgg,kkgg))
+    kkggmag=norm2(kkgg)
     nnold=-1
     do ll=0,llmax(itpaw)
       do mm=-ll,ll
@@ -124,7 +124,7 @@ do iz=1,ngkpt(3)
         kkgg(jj)=kkgg(jj)+blat(ii,jj)*(kk(ii)+dble(igg(ii)))
       enddo
       enddo
-      kkggmag=sqrt(dot_product(kkgg,kkgg))
+      kkggmag=norm2(kkgg)
       nnold=-1
       do ll=0,llmax(itpaw)
         do mm=-ll,ll


### PR DESCRIPTION
```sh
for v in rrel qqgg bgrad grad avec kkgg pln xnorm rr qq ; do 
   sed -i "s/sqrt(dot_product($v,$v))/norm2($v)/g" Transfer/*.f90 Transfer/Utilities/spherical.f90
done
```

Signed-off-by: Jeff Hammond <jeff.science@gmail.com>