### PR TITLE
Print only once custom COSMO parameters

### DIFF
--- a/src/solvation/cosmo_charges.F
+++ b/src/solvation/cosmo_charges.F
@@ -115,7 +115,7 @@ c
      &                 mt_int,nefc,int_mb(k_efciat)))
      &   call errquit('cosmo_charges: rtdb get failed for efciat',914,
      &       RTDB_ERR)
-      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad))
+      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad),.false.)
       status = rtdb_get(rtdb,'cosmo:radius',mt_dbl, nat,dbl_mb(k_rad))
       do i = 0, nat-1
         dbl_mb(k_rad+i) = dbl_mb(k_rad+i)/cau2ang
@@ -324,7 +324,7 @@ c
      &                 mt_int,nefc,int_mb(k_efciat)))
      &   call errquit('cosmo_charges: rtdb get failed for efciat',914,
      &       RTDB_ERR)
-      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad))
+      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad),.false.)
       status = rtdb_get(rtdb,'cosmo:radius',mt_dbl, nat,dbl_mb(k_rad))
       do i = 0, nat-1
         dbl_mb(k_rad+i) = dbl_mb(k_rad+i)/cau2ang

--- a/src/solvation/cosmo_def_radii.F
+++ b/src/solvation/cosmo_def_radii.F
@@ -38,7 +38,7 @@ C>     and physics, 91st Edition, 2010-2011; W.M. Haynes, Ed.;
 C>     CRC Press, Boca Raton, FL, 2010; pp. 9-49 -- 9-50,
 C>     ISBN-13: 978-1439820773.
 C>
-      subroutine cosmo_def_radii(rtdb,geom,nat,radius)
+      subroutine cosmo_def_radii(rtdb,geom,nat,radius,oprint)
       implicit none
 #include "errquit.fh"
 #include "mafdecls.fh"
@@ -52,6 +52,7 @@ c
       integer nat  !< [Input] The number of atoms
 c
       double precision radius(nat) !< [Output] The atom radii
+      logical oprint
 c
       logical ostatus
       integer mxelm
@@ -313,7 +314,7 @@ c
      &                     aname,
      &                     ctag(i))) then
               radius(iat) = crad(i)
-              if(ga_nodeid().eq.0) 
+              if(ga_nodeid().eq.0 .and. oprint) 
      &            write(*,9977) ctag(i),crad(i)
               cycle atomloop
              
@@ -363,7 +364,7 @@ c bq with zero charge. extract element
      &                     symb,
      &                     ctag(i))) then
               radius(iat) = crad(i)
-              if(ga_nodeid().eq.0) 
+              if(ga_nodeid().eq.0 .and. oprint) 
      &            write(*,9978) ctag(i),symb, crad(i)
               cycle atomloop
              

--- a/src/solvation/cosmo_initialize.F
+++ b/src/solvation/cosmo_initialize.F
@@ -216,7 +216,7 @@ c
       if(.not.ma_push_get(mt_dbl,nat,'cosmo rads',l_rad,k_rad))
      & call errquit('cosmo_init malloc k_rad failed',911,MA_ERR)
 c
-      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad))
+      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad),.true.)
 c
       if(.not.ma_push_get(mt_dbl,nat*3,'coord',l_coscoor,k_coscoor))
      & call errquit('cosmo_init malloc k_coscoor failed',911,MA_ERR)
@@ -426,7 +426,7 @@ c     set cosmo radii to smd radii if do_cosmo_smd is true; if the radii
 c     are provided by the user then we will use those
 c
       if (do_cosmo_smd) then
-       call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad))
+       call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad),.true.)
       endif
 c
       if (.not.

--- a/src/solvation/grad_hnd_cos.F
+++ b/src/solvation/grad_hnd_cos.F
@@ -183,7 +183,7 @@ c
 c
       if (.not.ma_push_get(MT_DBL,nat,"rad",l_rad,k_rad))
      $  call errquit("grad_hnd_cos: could not allocate rad",nat,MA_ERR)
-      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad))
+      call cosmo_def_radii(rtdb,geom,nat,dbl_mb(k_rad),.false.)
       status = rtdb_get(rtdb,'cosmo:radius',mt_dbl,nat,
      $                  dbl_mb(k_rad))
       do iat1=0,nat-1


### PR DESCRIPTION
Avoids printing custom radii read from a file during each SCF cycle