### PR TITLE
new details input keyword to read spherical option from basis library

### DIFF
--- a/src/basis/bas_input.F
+++ b/src/basis/bas_input.F
@@ -367,7 +367,6 @@ c
       logical oIs_rel
       logical oshell_is_rel
       logical oIs_star
-      logical read_sphere       !< [Input] flag for reading spherical from library
       integer spvalues(nsptypes)
       integer num_elec
       integer l_value, ind, icount
@@ -382,7 +381,7 @@ cc AJL/End
 c
 #include "ecpso_sfnP.fh"
 c
-      read_sphere=.false.
+      star_details=.false.
       oIs_ecp = Is_ECP_in(basis)
       oIs_so  = Is_SO_in(basis)
 c
@@ -560,7 +559,7 @@ c
 c
 c     details, ie read spherical from library
 c
- 101           read_sphere = .true.
+ 101           star_details = .true.
                goto 22
 c
 c...  nelec  ...  =>  number of electrons for ecp
@@ -603,7 +602,7 @@ c
 c
       if (standard .ne. ' ') then
          call bas_tag_lib(basis, osegment, tag, tag_in_lib, standard,
-     $        filename, oshell_is_rel, read_sphere)
+     $        filename, oshell_is_rel, star_details)
          goto 10
       endif
 c
@@ -1553,3 +1552,5 @@ c    .     close(unit=unitrc,status='keep') ! close file after library name foun
 10002 format(1x,f5.0,31(2x,1pe15.6))
 10003 format(31(2x,1pe15.6))
       end
+
+      

--- a/src/basis/bas_input.F
+++ b/src/basis/bas_input.F
@@ -12,7 +12,7 @@ c $Id$
 c
 c   basis [<name>] [library [<standard set>] [file <filename>] \
 c         [spherical|cartesian] [segment||nosegment] [print|noprint]\
-c         [ecpset ecp_name] [soset so_name] [rel]
+c         [ecpset ecp_name] [soset so_name] [rel] [bse]
 c
 c     tag library [tag in library] <standard set> [file <filename>]
 c     tag <shell type>
@@ -53,10 +53,11 @@ c::passed
       integer rtdb              ! [input] handle to database
 c::local
       integer nopt
-      parameter (nopt = 12)
+      parameter (nopt = 13)
       character*10 opts(nopt)
       character*255 test, name, filename, standard
       character*255 ecpname, soname
+      character*256 mydir
       character*1000 errmsg
       logical status, ospherical, osegment, oprint
       logical o_add_ecpname, o_add_soname
@@ -68,10 +69,11 @@ c::local
       data opts /
      &    'spherical', 'cartesian', 'segment', 'nosegment', 'library',
      &    'file',      'print',     'noprint', 'ecpset',    'soset',
-     &    'version', 'rel'/
+     &    'version', 'rel','bse'/
 c
       ecpname = '                                                '
       soname = '                                                '
+      mydir = ' '
 c
 c     Check is a basis/ecp directive and read in name of the basis
 c
@@ -120,7 +122,7 @@ c
          endif
 c
          goto (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
-     &         1100,1200) ind
+     &         1100,1200,1300) ind
          goto 10000
 c
 c     spherical
@@ -205,12 +207,18 @@ c
          endif
          goto 10
 c
+c use libraries.bse
+c
+01300    continue
+         mydir='libraries.bse'
+         goto 10
+c
       endif
 c
 c initialize the default library name based on rules in bas_library_file
 c the file parameter can overide this setting for a given standard basis set
 c 
-      call bas_set_library_name()
+      call bas_set_library_name(mydir)
 c
       
 c
@@ -305,7 +313,7 @@ c
      $    '      [file <filename>] [segment]\\',
      $    '      [spherical|cartesian]\\',
      &    '      [print|noprint] [rel] [ecpset name_of_ecp]',
-     &    ' [soset name_of_so_potential]')
+     &    ' [soset name_of_so_potential] [bse]')
       call errquit('bas_input: invalid format for basis directive', 0,
      &       INPUT_ERR)
 c
@@ -382,6 +390,15 @@ c
 #include "ecpso_sfnP.fh"
 c
       star_details=.false.
+c
+c     if user_library_name ends in /libraries.bse/ star_details=t
+c
+      if(user_library_name(
+     /     (inp_strlen(user_library_name)-14):
+     /     inp_strlen(user_library_name)).eq.
+     /     '/libraries.bse/') then
+         star_details=.true.
+      endif
       oIs_ecp = Is_ECP_in(basis)
       oIs_so  = Is_SO_in(basis)
 c
@@ -621,7 +638,7 @@ c
 c
 10000 write(LuOut,1)
  1    format(' basis directive body format is:',/,
-     $       '       tag library <standard set> [file <filename>]',/,
+     $'       tag library [details] <standard set> [file <filename>]',/,
      $       '                   [except <exceptions list>] [rel]',/,
      $       '       tag <contraction type> [rel]',/,
      $       '           <exponent> <contraction coefficients>',/,
@@ -1277,8 +1294,13 @@ c
 c
 c     add here basis/libraries bit
 c
+      if(libname.ne.' ') then
+      compiled_name=compiled_name(1:inp_strlen(compiled_name))
+     $     //"/basis/"//libname(1:inp_strlen(libname))//"/"
+      else
       compiled_name=compiled_name(1:inp_strlen(compiled_name))
      $     //"/basis/libraries/"
+      endif
 *
 * order of precedence for choosing name
 * 1) value of NWCHEM_BASIS_LIBRARY environment variable
@@ -1380,9 +1402,12 @@ c
 c     if (nwrcopen)
 c    .     close(unit=unitrc,status='keep') ! close file after library name found
       end
-      subroutine bas_set_library_name()
+      subroutine bas_set_library_name(mydir)
       implicit none
+      character*(*) mydir
 #include "baslibraryP.fh"
+#include "inp.fh"
+      user_library_name=mydir
       call bas_library_file(user_library_name)
       end
 *.....................................................................

--- a/src/basis/bas_starP.fh
+++ b/src/basis/bas_starP.fh
@@ -9,7 +9,7 @@ c
       character*16 star_tag, star_in_lib, star_excpt
       character*255 star_bas_typ, star_file
       integer star_nr_tags, star_nr_excpt, star_tot_excpt
-      logical star_rel, star_segment
+      logical star_rel, star_segment, star_details
 
       common /startagsc/
      &       star_tag(max_star_tag), star_in_lib(max_star_tag),
@@ -18,4 +18,5 @@ c
 
       common /startags/
      &       star_nr_tags, star_nr_excpt(max_star_tag), 
-     &       star_tot_excpt, star_rel(max_star_tag), star_segment
+     &       star_tot_excpt, star_rel(max_star_tag), star_segment,
+     &       star_details

--- a/src/basis/basis.F
+++ b/src/basis/basis.F
@@ -1191,7 +1191,7 @@ c
         tmp(lentmp:) = ' '
         tmp(lentmp:) = ':star nr except'
         rtdb_status = rtdb_status .and. rtdb_get(
-     &         rtdb,tmp,mt_int,star_nr_tags,star_nr_excpt)
+     &         rtdb,tmp,mt_int,star_nr_tags,star_nr_excpt(1))
         tmp(lentmp:) = ' '
         tmp(lentmp:) = ':star rel'
         rtdb_status = rtdb_status .and. rtdb_get(
@@ -1200,6 +1200,10 @@ c
         tmp(lentmp:) = ':star segment'
         rtdb_status = rtdb_status .and. rtdb_get(
      &         rtdb,tmp,mt_log,1,star_segment)
+        tmp(lentmp:) = ' ' 
+        tmp(lentmp:) = ':star details'
+        rtdb_status = rtdb_status .and. rtdb_get(
+     &         rtdb,tmp,mt_log,1,star_details)
 c
 c get a list of tags from the current geometry
 c
@@ -1280,7 +1284,7 @@ c
      &              tag_in_lib = tag_to_add
                  call bas_tag_lib(basisin,star_segment,tag_to_add, 
      &                tag_in_lib, star_bas_typ(istar), star_file(istar), 
-     &                star_rel(istar),.false.)
+     &                star_rel(istar),star_details)
               endif
 00011         continue
            enddo
@@ -1962,7 +1966,7 @@ c
      &    channels,  ! AJL/SPIN-POLARISED ECPs
      &    star_nr_tags, star_tag, star_in_lib, star_bas_typ,
      &    star_file, star_nr_excpt, star_excpt, star_tot_excpt,
-     &    star_rel, star_segment)
+     &    star_rel, star_segment, star_details)
 c
       end
 C> @}
@@ -1972,7 +1976,7 @@ C> @}
      &       nucontin, nexcf, stdnamein, ecp_name, ecp_channels,
      &       star_nr_tags, star_tag, star_in_lib, star_bas_typ,
      &       star_file, star_nr_excpt, star_excpt, star_tot_excpt,
-     &       star_rel, star_segment)
+     &       star_rel, star_segment, star_details)
       implicit none
 c
 c stores from argument data structures the basis set information to
@@ -2021,6 +2025,7 @@ c. . . . . . . . . . . . . . . . . . .         contractions coeffs.
       character*255 star_file(star_nr_tags) ! [input] star filename data
       logical star_rel(star_nr_tags) ! [input] star relativistic data
       logical star_segment ! [input] star segment or not ?
+      logical star_details ! [input] star read details from library file
       integer star_tot_excpt ! [input] star total number of except tags
       integer star_nr_excpt(star_nr_tags) ! [input] number of except per tag
       character*16 star_excpt(star_nr_tags) ! [input] except tag list
@@ -2073,23 +2078,23 @@ c
       if (nexcf .gt. 0) then
          tmp(lentmp:) = ' ' 
          tmp(lentmp:) = ':exps and coeffs'
-         status = status .and. rtdb_put(rtdb,tmp,mt_dbl,nexcf,excfin)
+         status = status .and. rtdb_put(rtdb,tmp,mt_dbl,nexcf,excfin(1))
       endif
 
       tmp(lentmp:) = ' ' 
       tmp(lentmp:) = ':header'
       status = status .and.
-     &       rtdb_put(rtdb,tmp,mt_int,ndbs_head,head_array)
+     &       rtdb_put(rtdb,tmp,mt_int,ndbs_head,head_array(1))
 
       tmp(lentmp:) = ' ' 
       tmp(lentmp:) = ':tags info'
       status = status .and. rtdb_put(
-     &       rtdb,tmp,mt_int,(ndbs_tags*ntags_bsmx), tags_array)
+     &       rtdb,tmp,mt_int,(ndbs_tags*ntags_bsmx), tags_array(1,1))
 
       tmp(lentmp:) = ' ' 
       tmp(lentmp:) = ':contraction info'
       status = status .and. rtdb_put(
-     &       rtdb,tmp,mt_int,(ndbs_ucont*nucont_bsmx),ucont_array)
+     &       rtdb,tmp,mt_int,(ndbs_ucont*nucont_bsmx),ucont_array(1,1))
       tmp(lentmp:) = ' ' 
       tmp(lentmp:) = ':star nr tags'
       status = status .and. rtdb_put(
@@ -2128,7 +2133,7 @@ c
         tmp(lentmp:) = ' ' 
         tmp(lentmp:) = ':star nr except'
         status = status .and. rtdb_put(
-     &         rtdb,tmp,mt_int,star_nr_tags,star_nr_excpt)
+     &         rtdb,tmp,mt_int,star_nr_tags,star_nr_excpt(1))
         tmp(lentmp:) = ' ' 
         tmp(lentmp:) = ':star rel'
         status = status .and. rtdb_put(
@@ -2137,6 +2142,9 @@ c
         tmp(lentmp:) = ':star segment'
         status = status .and. rtdb_put(
      &         rtdb,tmp,mt_log,1,star_segment)
+        tmp(lentmp:) = ':star details'
+        status = status .and. rtdb_put(
+     &         rtdb,tmp,mt_log,1,star_details)
       endif
 c
 c reset the stag tag data array for reuse
@@ -2660,7 +2668,7 @@ c
                write(key,'(''basis:'',a,'':header'')')
      $              bs_names_rtdb(basis)(1:len_bs_rtdb(basis))
                if (.not. rtdb_get(rtdb, key, mt_int, 
-     $              ndbs_head, head_array)) then
+     $              ndbs_head, head_array(1))) then
                   write(LuOut,*) ' Warning: basis set ', basis, 
      $                 ' may be corrupt'
                   natom = -1


### PR DESCRIPTION
* New input option `details` to fetch cartesian/spherical information from library file
```
basis
 * details aug-cc-pvdz
end
```` 
```
NWCHEM_BASIS_LIBRARY=$NWCHEM_TOP/src/basis/libraries.bse/ nwchem
```

* New input option `bse` to use $NWCHEM_TOP/src/basis/libraries.bse/ as basis library and use spherical or cartesian functions as indicated in the library file
```
basis bse
 *  aug-cc-pvdz
end
```` 
