### PR TITLE
fix portability issues in gwmol cpu detection

### DIFF
--- a/src/gwmol/mycpu.c
+++ b/src/gwmol/mycpu.c
@@ -1,5 +1,7 @@
-#if defined(__x86_64__) && ( defined (MACX) || defined (MACX64) )
+#if defined (MACX) || defined (MACX64)
+  #if defined(__x86_64__)
     #include <cpuid.h>
+  #endif
 #else
     // sched_getcpu is non-standard and may only be found in glibc,
     // so this code is not portable to Alpine Linux, BSD,
@@ -12,15 +14,17 @@ int findmycpu_ ()
 {
   int cpu = -1;
 
-#if defined(__x86_64__) && ( defined (MACX) || defined (MACX64) )
-  int cpuinfo[4];
-  __cpuid_count(1, 0, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
-  if ( (cpuinfo[3] & (1 << 9)) == 0 ) {
-    cpu = -1;
-  }
-  else {
-    cpu = (unsigned) cpuinfo[1] >> 24;
-  }
+#if defined (MACX) || defined (MACX64)
+  #if defined(__x86_64__)
+    int cpuinfo[4];
+    __cpuid_count(1, 0, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
+    if ( (cpuinfo[3] & (1 << 9)) == 0 ) {
+      cpu = -1;
+    }
+    else {
+      cpu = (unsigned) cpuinfo[1] >> 24;
+    }
+  #endif
 #else
   cpu = sched_getcpu();
 #endif

--- a/src/gwmol/mycpu.c
+++ b/src/gwmol/mycpu.c
@@ -1,16 +1,18 @@
-#if defined (MACX) || defined (MACX64)
-#include <cpuid.h>
-#include <stdint.h>
+#if defined(__x86_64__) && ( defined (MACX) || defined (MACX64) )
+    #include <cpuid.h>
 #else
-#include <utmpx.h>
-int sched_getcpu();
+    // sched_getcpu is non-standard and may only be found in glibc,
+    // so this code is not portable to Alpine Linux, BSD,
+    // or anything else that uses something else, e.g. MUSL
+    #include <sched.h>
+    int sched_getcpu(void);
 #endif
-
 
 int findmycpu_ ()
 {
-  int cpu;
-#if defined (MACX) || defined (MACX64)
+  int cpu = -1;
+
+#if defined(__x86_64__) && ( defined (MACX) || defined (MACX64) )
   int cpuinfo[4];
   __cpuid_count(1, 0, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
   if ( (cpuinfo[3] & (1 << 9)) == 0 ) {


### PR DESCRIPTION
CPUID is an x86 instruction, so the GCC compiler intrinsic that wraps it does not work on MacOS with an ARM CPU.

the other preprocess branch is not completely portable either, but i am ignoring that for now.  we will likely get a bug report when someone tries to use something other than glibc on a non-MacOS system.

i do not see a particularly good reason to have this code at all, since printing out the processor ID doesn't seem essential, and you can mostly avoid it by making sure that `omp_get_num_threads` returns a value less than or equal to `omp_get_num_procs`.

Signed-off-by: Jeff Hammond <jeff.science@gmail.com>