### PR TITLE
fix the typo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ variables:
     - export NWCHEM_TOP=$CI_PROJECT_DIR
     - source /opt/intel/oneapi/setvars.sh
     - export NWCHEM_EXECUTABLE=${NWCHEM_TOP}/../binaries/nwchem_ifx
-    - export PYTHONVERSON=3.8
+    - export PYTHONVERSION=3.8
     - export FC=ifx
 
 .flang_template: &flang_sourcing


### PR DESCRIPTION
PYTHONVERSON should by PYTHONVERSION

Signed-off-by: Jeff Hammond <jeff.science@gmail.com>