### PR TITLE
Bugfix in DFT-D3 gradients

### DIFF
--- a/src/nwdft/xc/xc_vdw_main.F
+++ b/src/nwdft/xc/xc_vdw_main.F
@@ -31,6 +31,12 @@ c
       double precision tmp6,tmp6a,tmp8,tmp8a
       double precision xc_fdmpbj, xc_fdmpbj_d1
       external         xc_fdmpbj, xc_fdmpbj_d1
+      double precision dEdrij
+      double precision dc6(n),cns(n),dc6i,dc6j
+      double precision dEdc6,rAj2,dcn,rij(3)
+      double precision dcndrij
+      external dcndrij
+
 c
 c     Derivatives of Grimme dispersion term
 c
@@ -71,316 +77,173 @@ c DFT-D3
 c
       else if (ivdw.eq.3) then
 c
-c        Precompute coordinate derivatives C6 dependency
-c
-         if (.not.ma_push_get(mt_dbl,3*n,'xcvdw cnij',l_cnij,k_cnij))
-     &      call errquit('xcvdw cnij: cannot allocate cnij',0, MA_ERR)
-         if (.not.ma_push_get(mt_dbl,3*n*n,'vdw cnijk',l_cnijk,k_cnijk))
-     &      call errquit('vdw cnijk: cannot allocate cnijk',0, MA_ERR)
-c
-         call crd_nr_der(n,x,z,dbl_mb(k_cnij),dbl_mb(k_cnijk))
+c Precompute coordination numbers
 c
          do A=1,n
-           force(1,A)=0.0d0
-           force(2,A)=0.0d0
-           force(3,A)=0.0d0
-           if (Z(A).ne.0) then
-             do j=1,n
-               if(A.ne.j) then      
-                  dxAj=x(1,A)-x(1,j)
-                  dyAj=x(2,A)-x(2,j)
-                  dzAj=x(3,A)-x(3,j)
-                  rAj=dxAj**2+dyAj**2+dzAj**2
-c
-c                 Two center derivatives. Grimme uses screening to reduce 
-c                 computational work
-c
-c                 Screening r^2 distance vs threshold of 20000.0
-c
-                  if (rAj.gt.20000.d0) goto 901
-c
-c                 Factors
-c
-                  r0aj=r0AB(z(A),z(j))
-                  Qfac=Qatom(z(A))*Qatom(z(j))
-                  fac6=(dsqrt(rAj)/(sr6*r0aj))**(-alpha)
-                  fac8=(dsqrt(rAj)/(sr8*r0aj))**(-(alpha+2.0d0))
-                  fdmp6=1.0d0/(1.0d0+6.0d0*fac6)
-                  fdmp8=1.0d0/(1.0d0+6.0d0*fac8)
-c
-c                 Coordination dependent C6_AB value
-c
-                  cnA=crd_nr(A,n,x,z)
-                  cnj=crd_nr(j,n,x,z)
-                  c6Aj=c6cn(z(A),z(j),cnA,cnj)
-c
-c                 Get gradient for coordination number dependent C6
-c
-                  call c6_grad(grad_c6,A,j,A,x,z,n,
-     &                         dbl_mb(k_cnij),dbl_mb(k_cnijk))
-c
-                  tmp6=6.0d0*fdmp6*s6*c6Aj/(rAj**4.0d0)
-                  tmp8=6.0d0*fdmp8*s8*c6Aj*Qfac/(rAj**5.0d0)
-c
-c                 dx contribution to A
-c
-                  tmp6a=tmp6*dxAj
-                  tmp8a=tmp8*dxAj
-                  force(1,A)=force(1,A)
-     $              +(1.0d0-fdmp6*fac6*alpha)*tmp6a
-     $              -fdmp6*s6*grad_c6(1)/(rAj**3.0d0)
-     $              +(4.0d0-3.0d0*fdmp8*fac8*(alpha+2.0d0))*tmp8a
-     $              -3.0d0*fdmp8*s8*grad_c6(1)*Qfac/(rAj**4.0d0)
-c
-c                 dy contribution to A
-c
-                  tmp6a=tmp6*dyAj
-                  tmp8a=tmp8*dyAj
-                  force(2,A)=force(2,A)
-     $              +(1.0d0-fdmp6*fac6*alpha)*tmp6a
-     $              -fdmp6*s6*grad_c6(2)/(rAj**3.0d0)
-     $              +(4.0d0-3.0d0*fdmp8*fac8*(alpha+2.0d0))*tmp8a
-     $              -3.0d0*fdmp8*s8*grad_c6(2)*Qfac/(rAj**4.0d0)
-c
-c                 dz contribution to A
-c
-                  tmp6a=tmp6*dzAj
-                  tmp8a=tmp8*dzAj
-                  force(3,A)=force(3,A)
-     $              +(1.0d0-fdmp6*fac6*alpha)*tmp6a
-     $              -fdmp6*s6*grad_c6(3)/(rAj**3.0d0)
-     $              +(4.0d0-3.0d0*fdmp8*fac8*(alpha+2.0d0))*tmp8a
-     $              -3.0d0*fdmp8*s8*grad_c6(3)*Qfac/(rAj**4.0d0)
- 901              continue
-               endif
-             enddo
-c
-cDMR: Three-center terms are not included in xc_vdw_e
-c
-c            Three center derivatives. Grimme uses aggressive screening
-c            to get this N^3 contribution back to N^2
-c
-c             do j=2,n
-c               if(A.ne.j) then      
-c                  rAj=sqrt(
-c     +                 (x(1,A)-x(1,j))**2 +
-c     +                 (x(2,A)-x(2,j))**2 +
-c     +                 (x(3,A)-x(3,j))**2)
-c                  r0aj=r0AB(z(A),z(j))
-c
-c                 Screening per Grimme
-c
-c                  if (rAj.gt.1600d0*r0aj/r0AB(1,1)) goto 910
-c
-c                 Third center involved
-c
-c                  do k=1,j-1
-c                     if(A.ne.k) then      
-c                       dxAk=x(1,A)-x(1,k)
-c                       dyAk=x(2,A)-x(2,k)
-c                       dzAk=x(3,A)-x(3,k)
-c                       rAk=dxAk**2+dyAk**2+dzAk**2
-c                       r0ak=r0AB(z(A),z(k))
-c                       dxjk=x(1,j)-x(1,k)
-c                       dyjk=x(2,j)-x(2,k)
-c                       dzjk=x(3,j)-x(3,k)
-c                       rjk=dxjk**2+dyjk**2+dzjk**2
-c                       r0jk=r0AB(z(j),z(k))
-c
-c                      Screening r^2 distance vs threshold of 1600.0*(radii Ak)
-c
-c                       if ((rAk.gt.1600.0d0*r0ak/r0AB(1,1)).or.
-c     $                     (rjk.gt.1600.0d0*r0jk/r0AB(1,1))) goto 911
-c
-c                      Get gradient for coordination number dependent C6 for three centers
-c
-c                       call c6_grad(grad_c6,j,k,A,x,z,n,
-c     &                              dbl_mb(k_cnij),dbl_mb(k_cnijk))
-c                       fac6=(sr6*r0jk/dsqrt(rjk))**(alpha)
-c                       fac8=(sr8*r0jk/dsqrt(rjk))**(alpha+2.0d0)
-c                       fdmp6=1.0d0/(1.0d0+6.0d0*fac6)
-c                       fdmp8=1.0d0/(1.0d0+6.0d0*fac8)
-c
-c                      dx, dy, and dz contribution to A
-c
-c                       Qfac=Qatom(z(j))*Qatom(z(k))
-c                       force(1,A)=force(1,A)
-c     $                      -fdmp6*s6*grad_c6(1)/(rjk**3.0d0)
-c     $                      -3.0d0*fdmp8*s8*grad_c6(1)*Qfac/(rjk**4.0d0)
-c                       force(2,A)=force(2,A)
-c     $                      -fdmp6*s6*grad_c6(2)/(rjk**3.0d0)
-c     $                      -3.0d0*fdmp8*s8*grad_c6(2)*Qfac/(rjk**4.0d0)
-c                       force(3,A)=force(3,A)
-c     $                      -fdmp6*s6*grad_c6(3)/(rjk**3.0d0)
-c     $                      -3.0d0*fdmp8*s8*grad_c6(3)*Qfac/(rjk**4.0d0)
-c                     endif
-c 911              continue
-c                  enddo
-c 910           continue
-c               endif
-c             enddo
-           endif
+           if (Z(A).eq.0) cycle
+           cns(A) = crd_nr(A,n,x,z)
          enddo
-         if (.not.ma_pop_stack(l_cnijk))
-     $      call errquit('xcvdw cnijk: cannot pop cnijk',4, MA_ERR)
-         if (.not.ma_pop_stack(l_cnij))
-     $      call errquit('xcvdw cnij: cannot pop cnij',4, MA_ERR)
+c
+c Get derivatives with respect to CNs
+c
+         dc6(:) = 0d0
+         do A=2,n
+           if (Z(A).eq.0) cycle
+           do j=1,A-1
+             if (Z(j).eq.0) cycle
+             rAj = sum((x(:,j) - x(:,A))**2)
+             if (rAj.gt.9000.0d0) cycle
+             rAj = dsqrt(rAj)
+c
+c            Factors
+c
+             r0aj=r0AB(z(A),z(j))
+             Qfac=Qatom(z(A))*Qatom(z(j))
+             fac6=(rAj/(sr6*r0aj))**(-alpha)
+             fac8=(rAj/(sr8*r0aj))**(-(alpha+2.0d0))
+             fdmp6=1.0d0/(1.0d0+6.0d0*fac6)
+             fdmp8=1.0d0/(1.0d0+6.0d0*fac8)
+
+             ! Derivative of the C6 coeff with respect to CNs
+             call c6_grad(A,j,x,z,n,dc6i,dc6j,cns(A),cns(j))
+
+             ! Derivative of Edisp with respect to C6
+             dEdc6 = fdmp6*s6/rAj**6 + 3d0*s8*Qfac*fdmp8/rAj**8
+
+             ! Derivative of Edisp with respect to CNs
+             dc6(A) = dc6(A) + dEdc6*dc6i
+             dc6(j) = dc6(j) + dEdc6*dc6j
+           enddo
+         enddo
+c
+c Get the gradients
+c
+         force(:,:) = 0d0
+         do A=2,n
+           if (Z(A).eq.0) cycle
+           do j=1,A-1
+             if (Z(j).eq.0) cycle
+             rij(:) = x(:,j) - x(:,A)
+
+             rAj2 = sum(rij**2)
+             rAj = dsqrt(rAj2)
+
+             ! Derivative of the CNs with respect to rij
+             if (rAj2.gt.1600.d0) then
+               dcn = 0d0
+             else
+               dcn = dcndrij(A,j,rAj,z)
+             endif
+
+             ! Intermediate factors
+             cnA = cns(A)
+             cnj = cns(j)
+             r0aj=r0AB(z(A),z(j))
+             Qfac=Qatom(z(A))*Qatom(z(j))
+             c6Aj=c6cn(z(A),z(j),cnA,cnj)
+             c8=3.0d0*c6Aj*Qfac
+             fac6=(rAj/(sr6*r0aj))**(-alpha)
+             fac8=(rAj/(sr8*r0aj))**(-(alpha+2.0d0))
+             fdmp6=1.0d0/(1.0d0+6.0d0*fac6)
+             fdmp8=1.0d0/(1.0d0+6.0d0*fac8)
+             tmp6=6.0d0*alpha*fac6*fdmp6**2/(rAj)
+             tmp8=6.0d0*(alpha+2d0)*fac8*fdmp8**2/(rAj)
+
+             ! Derivative of Edisp with respect to rij
+             dEdrij = -6d0*s6*c6Aj*fdmp6/rAj**7 + s6*c6Aj*tmp6/rAj**6 -
+     $                 24d0*s8*c6Aj*Qfac*fdmp8/rAj**9 + 
+     $                 3d0*s8*c6Aj*Qfac*tmp8/rAj**8 +
+     $                 dcn*(dc6(A) + dc6(j))
+
+             ! Nuclear gradients
+             force(:,A) = force(:,A) + dEdrij*rij/rAj
+             force(:,j) = force(:,j) - dEdrij*rij/rAj
+           enddo
+         enddo
 c
 c DFT-D3BJ
 c
       else if (ivdw.eq.4) then
 c
-c        Precompute coordinate derivatives C6 dependency
-c
-         if (.not.ma_push_get(mt_dbl,3*n,'xcvdw cnij',l_cnij,k_cnij))
-     &      call errquit('xcvdw cnij: cannot allocate cnij',0, MA_ERR)
-         if (.not.ma_push_get(mt_dbl,3*n*n,'vdw cnijk',l_cnijk,k_cnijk))
-     &      call errquit('vdw cnijk: cannot allocate cnijk',0, MA_ERR)
-c
-         call crd_nr_der(n,x,z,dbl_mb(k_cnij),dbl_mb(k_cnijk))
+c Precompute coordination numbers
 c
          do A=1,n
-           force(1,A)=0.0d0
-           force(2,A)=0.0d0
-           force(3,A)=0.0d0
-           if (Z(A).ne.0) then
-             do j=1,n
-               if(A.ne.j.and.Z(j).ne.0) then      
-                  dxAj=x(1,A)-x(1,j)
-                  dyAj=x(2,A)-x(2,j)
-                  dzAj=x(3,A)-x(3,j)
-                  rAj=dxAj**2+dyAj**2+dzAj**2
-c
-c                 Two center derivatives. Grimme uses screening to reduce 
-c                 computational work
-c
-c                 Screening r^2 distance vs threshold of 20000.0
-c
-                  if (rAj.gt.20000.d0) goto 941
-c
-c                 Factors
-c
-                  rAj = dsqrt(rAj)
-                  Qfac=Qatom(z(A))*Qatom(z(j))
-c
-c                 Coordination dependent C6_AB value
-c
-                  cnA=crd_nr(A,n,x,z)
-                  cnj=crd_nr(j,n,x,z)
-                  c6Aj=c6cn(z(A),z(j),cnA,cnj)
-                  c8=3.0d0*c6Aj*Qfac
-                  r0Aj=dsqrt(3.0d0*Qfac)
-c
-c                 Get gradient for coordination number dependent C6
-c
-                  call c6_grad(grad_c6,A,j,A,x,z,n,
-     &                         dbl_mb(k_cnij),dbl_mb(k_cnijk))
-c
-c                 dx contribution to A
-c
-                  force(1,A)=force(1,A)
-     $              -s6*c6Aj*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,6)
-     $               *dxAj/rAj
-     $              -s8*c8*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,8)
-     $               *dxAj/rAj
-     $              -s6*grad_c6(1)*xc_fdmpbj(rAj,r0Aj,a1,a2,6)
-     $              -s8*3.0d0*grad_c6(1)*Qfac*xc_fdmpbj(rAj,r0Aj,
-     $                a1,a2,8)
-c
-c                 dy contribution to A
-c
-                  force(2,A)=force(2,A)
-     $              -s6*c6Aj*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,6)
-     $               *dyAj/rAj
-     $              -s8*c8*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,8)
-     $               *dyAj/rAj
-     $              -s6*grad_c6(2)*xc_fdmpbj(rAj,r0Aj,a1,a2,6)
-     $              -s8*3.0d0*grad_c6(2)*Qfac*xc_fdmpbj(rAj,r0Aj,
-     $                a1,a2,8)
-c
-c                 dz contribution to A
-c
-                  force(3,A)=force(3,A)
-     $              -s6*c6Aj*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,6)
-     $               *dzAj/rAj
-     $              -s8*c8*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,8)
-     $               *dzAj/rAj
-     $              -s6*grad_c6(3)*xc_fdmpbj(rAj,r0Aj,a1,a2,6)
-     $              -s8*3.0d0*grad_c6(3)*Qfac*xc_fdmpbj(rAj,r0Aj,
-     $                a1,a2,8)
- 941              continue
-               endif
-             enddo
-c
-cDMR: Three center terms are not included in xc_vdw_e
-c
-c            Three center derivatives. Grimme uses aggressive screening
-c            to get this N^3 contribution back to N^2
-c
-c             do j=1,n
-c               if(A.ne.j.and.z(j).ne.0) then      
-c                  rAj=sqrt(
-c     +                 (x(1,A)-x(1,j))**2 +
-c     +                 (x(2,A)-x(2,j))**2 +
-c     +                 (x(3,A)-x(3,j))**2)
-c                  r0aj=r0AB(z(A),z(j))
-c
-c                 Screening per Grimme
-c
-c                  if (rAj.gt.1600d0*r0aj/r0AB(1,1)) goto 950
-c
-c                 Third center involved
-c
-c                  do k=1,n
-c                     if(A.ne.k.and.k.ne.j.and.z(k).ne.0) then      
-c                       dxAk=x(1,A)-x(1,k)
-c                       dyAk=x(2,A)-x(2,k)
-c                       dzAk=x(3,A)-x(3,k)
-c                       rAk=dxAk**2+dyAk**2+dzAk**2
-c                       r0ak=r0AB(z(A),z(k))
-c                       dxjk=x(1,j)-x(1,k)
-c                       dyjk=x(2,j)-x(2,k)
-c                       dzjk=x(3,j)-x(3,k)
-c                       rjk=dxjk**2+dyjk**2+dzjk**2
-c                       r0jk=r0AB(z(j),z(k))
-c
-c                      Screening r^2 distance vs threshold of 1600.0*(radii Ak)
-c
-c                       if ((rAk.gt.1600.0d0*r0ak/r0AB(1,1)).or.
-c     $                     (rjk.gt.1600.0d0*r0jk/r0AB(1,1))) goto 951
-c
-c                      Get gradient for coordination number dependent C6 for three centers
-c
-c                       call c6_grad(grad_c6,j,k,A,x,z,n,
-c     &                              dbl_mb(k_cnij),dbl_mb(k_cnijk))
-c                       rjk=dsqrt(rjk)
-c
-c                      dx, dy, and dz contribution to A
-c
-c                       Qfac=Qatom(z(j))*Qatom(z(k))
-c                       fdmp6=xc_fdmpbj(rjk,dsqrt(3.0d0*Qfac),a1,a2,6)
-c                       fdmp8=xc_fdmpbj(rjk,dsqrt(3.0d0*Qfac),a1,a2,8)
-c                       force(1,A)=force(1,A)
-c     $                           -fdmp6*s6*grad_c6(1)
-c     $                           -3.0d0*fdmp8*s8*grad_c6(1)*Qfac
-c                       force(2,A)=force(2,A)
-c     $                           -fdmp6*s6*grad_c6(2)
-c     $                           -3.0d0*fdmp8*s8*grad_c6(2)*Qfac
-c                       force(3,A)=force(3,A)
-c     $                           -fdmp6*s6*grad_c6(3)
-c     $                           -3.0d0*fdmp8*s8*grad_c6(3)*Qfac
-c                     endif
-c 951              continue
-c                  enddo
-c 950           continue
-c               endif
-c             enddo
-           endif
+           if (Z(A).eq.0) cycle
+           cns(A) = crd_nr(A,n,x,z)
          enddo
-         if (.not.ma_pop_stack(l_cnijk))
-     $      call errquit('xcvdw cnijk: cannot pop cnijk',4, MA_ERR)
-         if (.not.ma_pop_stack(l_cnij))
-     $      call errquit('xcvdw cnij: cannot pop cnij',4, MA_ERR)
+c
+c Get derivatives with respect to CNs
+c
+         dc6(:) = 0d0
+         do A=2,n
+           if (Z(A).eq.0) cycle
+           do j=1,A-1
+             if (Z(j).eq.0) cycle
+             rAj = sum((x(:,j) - x(:,A))**2)
+             if (rAj.gt.9000.0d0) cycle
+             rAj = dsqrt(rAj)
+             Qfac=Qatom(z(A))*Qatom(z(j))
+             r0Aj=dsqrt(3.0d0*Qfac)
+
+             ! Derivative of the C6 coeff with respect to CNs
+             call c6_grad(A,j,x,z,n,dc6i,dc6j,cns(A),cns(j))
+
+             ! Derivative of Edisp with respect to C6
+             dEdc6 = s6*xc_fdmpbj(rAj,r0Aj,a1,a2,6) +
+     $               s8*3d0*Qfac*xc_fdmpbj(rAj,r0Aj,a1,a2,8)
+
+             ! Derivative of Edisp with respect to CNs
+             dc6(A) = dc6(A) + dEdc6*dc6i
+             dc6(j) = dc6(j) + dEdc6*dc6j
+           enddo
+         enddo
+c
+c Get the gradients
+c
+         force(:,:) = 0d0
+         do A=2,n
+           if (Z(A).eq.0) cycle
+           do j=1,A-1
+             if (Z(j).eq.0) cycle
+             rij(:) = x(:,j) - x(:,A)
+
+             rAj2 = sum(rij**2)
+             rAj = dsqrt(rAj2)
+
+             ! Derivative of the CNs with respect to rij
+             if (rAj2.gt.1600.d0) then
+               dcn = 0d0
+             else
+               dcn = dcndrij(A,j,rAj,z)
+             endif
+
+             ! Intermediate factors
+             cnA = cns(A)
+             cnj = cns(j)
+             Qfac=Qatom(z(A))*Qatom(z(j))
+             c6Aj=c6cn(z(A),z(j),cnA,cnj)
+             c8=3.0d0*c6Aj*Qfac
+             r0Aj=dsqrt(3.0d0*Qfac)
+
+             ! Derivative of Edisp with respect to rij
+             dEdrij =
+     $       s6*c6Aj*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,6) +
+     $       s8*c8*xc_fdmpbj_d1(rAj,r0Aj,a1,a2,8) +
+     $       dcn*(dc6(A) + dc6(j))
+
+             ! Nuclear gradients
+             force(:,A) = force(:,A) + dEdrij*rij/rAj
+             force(:,j) = force(:,j) - dEdrij*rij/rAj
+           enddo
+         enddo
+c
+      endif
+
+      if (ga_nodeid().eq.0) then
+      do A=1,n
+        write(*,'(3F16.8)') force(1:3,A)
+      enddo
+      write(*,*) sqrt(sum(force**2))
       endif
 c
 #ifdef DEBUG

--- a/src/nwdft/xc/xc_vdw_main.F
+++ b/src/nwdft/xc/xc_vdw_main.F
@@ -238,13 +238,6 @@ c
          enddo
 c
       endif
-
-      if (ga_nodeid().eq.0) then
-      do A=1,n
-        write(*,'(3F16.8)') force(1:3,A)
-      enddo
-      write(*,*) sqrt(sum(force**2))
-      endif
 c
 #ifdef DEBUG
       write(6,*) ' gradient vdw called'

--- a/src/nwdft/xc/xc_vdw_util.F
+++ b/src/nwdft/xc/xc_vdw_util.F
@@ -60,7 +60,7 @@ c
          enddo
       enddo
 c
-      if (bottom.gt.0.0d0) then
+      if (bottom.gt.1.0d-99) then
          c6cn=top/bottom
       else
          c6cn=0.0d0
@@ -125,7 +125,7 @@ C>
       double precision t1,t2,dt1x,dt1y,dt1z,dt2x,dt2y,dt2z
       double precision tmp1,tmp2,tmp3,tmp4,fac1,fac2
       double precision eps
-      parameter (eps=1d-19)
+      parameter (eps=1d-99)
       integer i,j
 c
       cni=crd_nr(iat,n,x,z)

--- a/src/nwdft/xc/xc_vdw_util.F
+++ b/src/nwdft/xc/xc_vdw_util.F
@@ -70,32 +70,11 @@ c
 c
 c     Analytical gradient of coordination number dependent C6
 c
-C> \brief Gradient of \f$C_6\f$
-C>
-C> Calculate the gradient of the geometry dependent \f$C_6\f$ 
-C> coefficients. The \f$C_6\f$ coefficients
-C> are calculated according to Eq.(16) of [1]:
-C> \f{eqnarray*}{
-C>   C_6^{AB}\left(\mathrm{CN}^A(R),\mathrm{CN}^B(R)\right)
-C>   &=& \frac{\sum_i^{N_A}\sum_j^{N_B}C_{6,\mathrm{ref}}^{AB}\left(\mathrm{CN}_i^A,\mathrm{CN}_j^B\right)L_{ij}^{AB}(R)}{\sum_i^{N_A}\sum_j^{N_B}L_{ij}^{AB}(R)} \\\\
-C>   L_{ij}^{AB}(R) &=& e^{-k_3[(\mathrm{CN}^A(R)-\mathrm{CN}^A_i)^2
-C>                             +(\mathrm{CN}^B(R)-\mathrm{CN}^B_j)^2]}
-C> \f}
-C> where \f$\mathrm{CN}^A(R)\f$ and \f$\mathrm{CN}^B(R)\f$ are geometry
-C> dependent coordination numbers for atoms \f$A\f$ and \f$B\f$.
-C> The quantities \f$\mathrm{CN}^A_i\f$ and \f$\mathrm{CN}^B_j\f$
-C> are coordination numbers of atoms of the same type as \f$A\f$ and
-C> \f$B\f$ in reference molecules \f$i\f$ and \f$j\f$. These latter 
-C> quantities as well as \f$C_{6,\mathrm{ref}}^{AB}\f$ are precomputed
-C> constants, independent of the current geometry.
-C>
-C> Here we calculate 
-C> \f{eqnarray*}{
-C>   \frac{\partial C_6^{AB}\left(\mathrm{CN}^A(R),\mathrm{CN}^B(R)\right)}
-C>        {\partial \left(R_C\right)_i}
-C> \f}
-C> where atom \f$C\f$ maybe equal to \f$A\f$, \f$B\f$ or some other
-C> atom entirely, \f$i\f$ is either \f$x, y,\f$ or \f$z\f$.
+c  Comput derivatives of the C6 coefficients with respect to
+c  the coordination numbers.
+c
+c  The nuclear gradient will be assembled on a later stage
+c
 C> 
 C> ### References ###
 C>
@@ -107,91 +86,59 @@ C>     J. Chem. Phys. (2010) <b>132</b>, 154104, DOI:
 C>     <a href="https://doi.org/10.1063/1.3382344"> 
 C>     10.1063/1.3382344</a>.
 C>
-      subroutine c6_grad(grad,iat,jat,kat,x,z,n,cnij,cnijk)
+      subroutine c6_grad(iat,jat,x,z,n,dc6i,dc6j,cni,cnj)
       implicit none
 #include "xc_vdw.fh"
       integer n   !< [Input] The number of atoms
       integer iat !< [Input] Atom \f$A\f$
       integer jat !< [Input] Atom \f$B\f$
-      integer kat !< [Input] Atom \f$C\f$
       integer z(n) !< [Input] The atomic numbers of the atoms
-      double precision cnij(3,n) !< [Input] \f$\mathrm{cnij}(i,A)=\frac{\partial\mathrm{CN}^A(R)}{\partial \left(\vec{R}_A\right)_i}\f$
-      double precision cnijk(3,n,n) !< [Input] \f$\mathrm{cnijk}(i,B,A)=\frac{\partial\mathrm{CN}^A(R)}{\partial \left(\vec{R}_B\right)_i}\f$
-      double precision grad(3) !< [Output] The gradient
-      double precision cni,cnj
-      double precision crd_nr,cnik(3),cnjk(3)
       double precision x(3,n)
+      double precision dc6i, dc6j
+      double precision cni,cnj
+      double precision crd_nr
+      double precision c6ref
       external crd_nr
-      double precision t1,t2,dt1x,dt1y,dt1z,dt2x,dt2y,dt2z
+      double precision t1,t2,nomi,nomj,denomi,denomj
       double precision tmp1,tmp2,tmp3,tmp4,fac1,fac2
       double precision eps
       parameter (eps=1d-99)
       integer i,j
 c
-      cni=crd_nr(iat,n,x,z)
-      cnj=crd_nr(jat,n,x,z)
-      if (iat.eq.kat) then
-         cnik(1)=cnij(1,kat)
-         cnik(2)=cnij(2,kat)
-         cnik(3)=cnij(3,kat)
-         cnjk(1)=cnijk(1,kat,jat)
-         cnjk(2)=cnijk(2,kat,jat)
-         cnjk(3)=cnijk(3,kat,jat)
-      else if (jat.eq.kat) then
-         cnik(1)=cnijk(1,kat,iat)
-         cnik(2)=cnijk(2,kat,iat)
-         cnik(3)=cnijk(3,kat,iat)
-         cnjk(1)=cnij(1,kat)
-         cnjk(2)=cnij(2,kat)
-         cnjk(3)=cnij(3,kat)
-      else
-         cnik(1)=cnijk(1,kat,iat)
-         cnik(2)=cnijk(2,kat,iat)
-         cnik(3)=cnijk(3,kat,iat)
-         cnjk(1)=cnijk(1,kat,jat)
-         cnjk(2)=cnijk(2,kat,jat)
-         cnjk(3)=cnijk(3,kat,jat)
-      endif
       t1=0.0d0
       t2=0.0d0
-      dt1x=0.0d0
-      dt1y=0.0d0
-      dt1z=0.0d0
-      dt2x=0.0d0
-      dt2y=0.0d0
-      dt2z=0.0d0
+      nomi = 0d0
+      nomj = 0d0
+      denomi = 0d0
+      denomj = 0d0
+
       do i=1,maxcn(z(iat))
         do j=1,maxcn(z(jat))
-          tmp1=c6AB(z(iat),z(jat),i,j,3)-cnj
-          tmp2=c6AB(z(iat),z(jat),i,j,2)-cni
-          tmp3=dexp(k3*(tmp1*tmp1+tmp2*tmp2))
-          t1=t1+c6AB(z(iat),z(jat),i,j,1)*tmp3
-          t2=t2+tmp3
-          fac1=tmp3*k3*2.0d0
-          fac2=fac1*c6AB(z(iat),z(jat),i,j,1)
-          tmp4=(tmp2*cnik(1)+tmp1*cnjk(1))
-          dt1x=dt1x+fac2*tmp4
-          dt2x=dt2x+fac1*tmp4
-          tmp4=(tmp2*cnik(2)+tmp1*cnjk(2))
-          dt1y=dt1y+fac2*tmp4
-          dt2y=dt2y+fac1*tmp4
-          tmp4=(tmp2*cnik(3)+tmp1*cnjk(3))
-          dt1z=dt1z+fac2*tmp4
-          dt2z=dt2z+fac1*tmp4
+          c6ref = c6AB(z(iat),z(jat),i,j,1)
+          if (c6ref.gt.0d0) then
+            tmp1=c6AB(z(iat),z(jat),i,j,3)-cnj
+            tmp2=c6AB(z(iat),z(jat),i,j,2)-cni
+            tmp3=dexp(k3*(tmp1*tmp1+tmp2*tmp2))
+            t1=t1+c6AB(z(iat),z(jat),i,j,1)*tmp3
+            t2=t2+tmp3
+            fac1=tmp3*k3*2.0d0
+            fac2=fac1*c6ref
+            nomi = nomi - fac2*tmp2
+            denomi = denomi - fac1*tmp2
+            nomj = nomj - fac2*tmp1
+            denomj = denomj -  fac1*tmp1
+          endif
         enddo
       enddo
-c
-c     Numerical test to avoid division by zero (following Grimme)
-c
-      if (abs(t2).gt.eps) then
-        grad(1)=(dt1x*t2-dt2x*t1)/(t2**2)
-        grad(2)=(dt1y*t2-dt2y*t1)/(t2**2)
-        grad(3)=(dt1z*t2-dt2z*t1)/(t2**2)
+
+      if (t2.gt.1d-99) then
+        dc6i = ((nomi*t2 - denomi*t1))/(t2*t2)
+        dc6j = ((nomj*t2 - denomj*t1))/(t2*t2)
       else
-        grad(1)=0.0d0
-        grad(2)=0.0d0
-        grad(3)=0.0d0
+        dc6i = 0d0
+        dc6j = 0d0
       endif
+
       end
 c
       double precision function c6ij_sk(i,j,z)
@@ -320,6 +267,20 @@ c
          endif
       enddo
       return
+      end
+
+      double precision function dcndrij(iat,jat,r,iz)
+      implicit none
+#include "xc_vdw.fh"
+      integer iat,jat
+      double precision r
+      double precision rcov,expterm
+      integer iz(*)
+
+      rcov = cov_table(iz(iat))+cov_table(iz(jat))
+      expterm = exp(-k1*(rcov/r-1d0))
+      dcndrij = -k1*rcov*expterm/(r*(expterm+1d0))**2
+
       end
 c
 c     Coordination numbers based on inverse damping function 


### PR DESCRIPTION
Both DFT-D3 and DFT-D3(BJ) gradients (`disp vdw 3` and `vdw disp 4`) were not accurate