### PR TITLE
Read libxc RTDB vars

### DIFF
--- a/src/nwdft/xc/xc_util.F
+++ b/src/nwdft/xc/xc_util.F
@@ -337,6 +337,7 @@ c
       logical function xc_getxcfac(rtdb)
       implicit none
       integer rtdb
+      logical dolibxc
 c     load cfac and xfac into cdft.fh
 #include "cdft.fh"
 #include "rtdb.fh"
@@ -364,6 +365,13 @@ c
       xc_getxcfac=xc_getxcfac.and.
      A     rtdb_get(rtdb, 'dft:cfac', mt_dbl, numfunc,
      &     cfac)
+
+      xc_getxcfac=xc_getxcfac.and.
+     &      rtdb_get(rtdb, 'dft:libxcon', mt_log, 1, dolibxc)
+      if (dolibxc) then
+        call nwchem_libxc_rdinput(rtdb,'dft')
+      endif
+
       return
       end
 c


### PR DESCRIPTION
Corrects a bug where `task dft freq` hangs due to information mismatch among the MPI tasks when using a `libxc` functional and no previous `task dft` is present.

A small reproducer is 
```
title libxc_test

scratch_dir /scratch
permanent_dir /scratch

geometry
  N  0.0 0.0 0.0
  N  0.0 0.0 1.1
end

basis "ao basis" spherical
 * library cc-pvdz
end

dft
  xc mgga_x_r2scan mgga_c_r2scan
end

task dft freq
```