### PR TITLE
add NO_MPIF support to gwmol

### DIFF
--- a/src/gwmol/GNUmakefile
+++ b/src/gwmol/GNUmakefile
@@ -31,6 +31,10 @@ LIB_INCLUDES = -I./
 
 include ../config/makefile.h
 
+ifdef NO_MPIF
+  LIB_DEFINES += -DNO_MPIF
+endif
+
 ifeq ($(_USE_SCALAPACK),Y)
 _USE_ELPA = $(shell ${GA_PATH}/bin/ga-config  --use_elpa| awk ' /1/ {print "Y"}')
 

--- a/src/gwmol/GNUmakefile
+++ b/src/gwmol/GNUmakefile
@@ -31,9 +31,6 @@ LIB_INCLUDES = -I./
 
 include ../config/makefile.h
 
-ifdef NO_MPIF
-  LIB_DEFINES += -DNO_MPIF
-endif
 
 ifeq ($(_USE_SCALAPACK),Y)
 _USE_ELPA = $(shell ${GA_PATH}/bin/ga-config  --use_elpa| awk ' /1/ {print "Y"}')

--- a/src/gwmol/gw_init.F
+++ b/src/gwmol/gw_init.F
@@ -73,7 +73,11 @@ c
 
 #ifdef USE_OPENMP
       pars%iMaxThreads = omp_get_max_threads()
+#ifdef NO_MPIF
+      names = 'Not Available (NO_MPIF)'
+#else
       call mpi_get_processor_name(names,resultlen,ierr)
+#endif
       do iproc=0,pars%nprocs-1
         if (iproc.eq.pars%me) then
 !$omp     parallel private(tid,cpu)

--- a/src/gwmol/gw_init.F
+++ b/src/gwmol/gw_init.F
@@ -73,31 +73,6 @@ c
 
 #ifdef USE_OPENMP
       pars%iMaxThreads = omp_get_max_threads()
-#ifdef NO_MPIF
-      names = 'Not Available (NO_MPIF)'
-#else
-      call mpi_get_processor_name(names,resultlen,ierr)
-#endif
-      do iproc=0,pars%nprocs-1
-        if (iproc.eq.pars%me) then
-!$omp     parallel private(tid,cpu)
-            tid = omp_get_thread_num()
-!$omp       do ordered schedule (static,1)
-            do itid=0,omp_get_num_threads()-1
-!$omp         ordered
-              write(luout,1234) pars%me,tid,names(1:resultlen)
-!$omp         end ordered
-            enddo
-!$omp       end do
-!$omp     end parallel
-          call util_flush(luout)
-        endif
-        t0 = util_wallsec()
-        call ga_sync()
-        do while (util_wallsec()-t0 .lt. 0.1d0)
-        end do
-      enddo
- 1234 format(' rank',I5,' thread ',I5,' hostname ',A20)
 #else
       pars%iMaxThreads = 1
 #endif


### PR DESCRIPTION
gwmol calls MPI Fortran (Get_processor_name), which needs to be excepted for NO_MPIF.

Signed-off-by: Jeff Hammond