### PR TITLE
OpenACC memory updates

### DIFF
--- a/src/ccsd/GNUmakefile
+++ b/src/ccsd/GNUmakefile
@@ -112,7 +112,7 @@ endif
 ifdef USE_OPENACC_TRPDRV
   OBJ_OPTIMIZE += ccsd_trpdrv_openacc.o
   USES_BLAS    += ccsd_trpdrv_openacc.F
-  FOPTIONS += -acc -gpu=managed -cuda -cudalib=cublas -DUSE_OPENACC_TRPDRV
+  FOPTIONS += -acc -cuda -cudalib=cublas -DUSE_OPENACC_TRPDRV
 endif
 
 

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -96,6 +96,7 @@
       integer n_progr,pct_progr
       parameter(n_progr=20)
       logical i_progr(n_progr+1)
+      logical got_ak
       ! timers
       double precision :: tt0, tt1, tc0, tc1
       integer(INT32) :: shi
@@ -256,6 +257,9 @@
                      call ga_nbget(g_objv,1+2*lnoov+(klo-1)*lnov,
      &                    2*lnoov+khi*lnov,av,av,Xka,(khi-klo+1)*lnov,
      &                    nbh_objv3)
+                     got_ak=.true.
+                  else
+                     got_ak=.false.
                   endif
 
                   do i=1,nocc
@@ -279,7 +283,9 @@
 
 !                     call dcopy(nvir,t1((i-1)*nvir+1),1,t1v2,1)
                      t1v2(:) = t1((i-1)*nvir+1:i*nvir)
-                     call ga_nbwait(nbh_objv1) ! Dja
+                     if(i.eq.1) then
+                        call ga_nbwait(nbh_objv1) ! Dja
+                     endif
 !                     call dcopy(nvir,Dja(1+(i-1)*nvir),1,dintc1,1)
                      dintc1(:) = Dja(1+(i-1)*nvir:i*nvir)
                      call ga_nbwait(nbh_objv5) ! Djia
@@ -292,7 +298,9 @@
                         t1v1(:) = t1((k-1)*nvir+1:k*nvir)
                         !call dcopy(nvir,Dja(1+(k-1)*nvir),1,dintc2,1)
                         dintc2(:) = Dja(1+(k-1)*nvir:k*nvir)
-                        call ga_nbwait(nbh_objv4(k)) ! Djka
+                        if(i.eq.1) then
+                           call ga_nbwait(nbh_objv4(k)) ! Djka
+                        endif
                         !call dcopy(nvir,Djka(1+(k-klo)*nvir),1,dintx2,1)
                         dintx2(:) = Djka(1+(k-klo)*nvir:(k-klo+1)*nvir)
                         emp4i = 0.0d0
@@ -310,9 +318,13 @@
 !  All of these are independent of k, so we wait on them only
 !  at the first trip of the loop.
 !
-                        if (k.eq.klo) then
-                            call ga_nbwait(nbh_objv2)
-                            call ga_nbwait(nbh_objv3)
+                        if (i.eq.1.and.k.eq.klo) then
+                           if(got_ak) then
+                              call ga_nbwait(nbh_exch1)
+                              call ga_nbwait(nbh_coul1)
+                              call ga_nbwait(nbh_objv2)
+                              call ga_nbwait(nbh_objv3)
+                           endif
                             call ga_nbwait(nbh_objv6)
                             call ga_nbwait(nbh_objv7)
                             call ga_nbwait(nbh_objo1)
@@ -321,9 +333,7 @@
                             call ga_nbwait(nbh_objo4)
                             call ga_nbwait(nbh_objo5)
                             call ga_nbwait(nbh_objo6)
-                            call ga_nbwait(nbh_exch1)
                             call ga_nbwait(nbh_exch2)
-                            call ga_nbwait(nbh_coul1)
                             call ga_nbwait(nbh_coul2)
                         endif
 

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -43,9 +43,9 @@
 ! it is correct that dint[cx]1 are paired with t1v2 and vice versa
 ! in the inlined tengy loops.  see ccsd_tengy in ccsd_trpdrv.F for
 ! verification of the i-k and k-i pairing of these.
-      double precision, allocatable, managed :: dintc1(:),dintc2(:)
-      double precision, allocatable, managed :: dintx1(:),dintx2(:)
-      double precision, allocatable, managed :: t1v1(:),t1v2(:)
+      double precision, allocatable, device :: dintc1(:),dintc2(:)
+      double precision, allocatable, device :: dintx1(:),dintx2(:)
+      double precision, allocatable, device :: t1v1(:),t1v2(:)
       integer :: alloc_error, err
 !
       double precision :: emp4i,emp5i,emp4k,emp5k
@@ -133,22 +133,12 @@
 ! device-only temp arrays
 ! produced by DGEMM, consumed by TENGY
 !
-      allocate( f1n(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f1n',1,MA_ERR)
-      allocate( f2n(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f2n',2,MA_ERR)
-      allocate( f3n(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f3n',3,MA_ERR)
-      allocate( f4n(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f4n',4,MA_ERR)
-      allocate( f1t(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f1t',5,MA_ERR)
-      allocate( f2t(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f2t',6,MA_ERR)
-      allocate( f3t(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f3t',7,MA_ERR)
-      allocate( f4t(1:nvir,1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f4t',8,MA_ERR)
+      allocate( f1n(1:nvir,1:nvir), f1t(1:nvir,1:nvir),
+     &          f2n(1:nvir,1:nvir), f2t(1:nvir,1:nvir),
+     &          f3n(1:nvir,1:nvir), f3t(1:nvir,1:nvir),
+     &          f4n(1:nvir,1:nvir), f4t(1:nvir,1:nvir),
+     &          stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('f[1234][tn]',8,MA_ERR)
 !
 ! device-only copy of input eorb
 !
@@ -159,55 +149,23 @@
 !
 ! for TENGY
 !
-      allocate( dintc1(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintc1',11,MA_ERR)
-      allocate( dintx1(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintx1',12,MA_ERR)
-      allocate( t1v1(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('t1v1',13,MA_ERR)
-      allocate( dintc2(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintc2',14,MA_ERR)
-      allocate( dintx2(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintx2',15,MA_ERR)
-      allocate( t1v2(1:nvir), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('t1v2',16,MA_ERR)
+      allocate( dintc1(1:nvir), dintc2(1:nvir),
+     &          dintx1(1:nvir), dintx2(1:nvir),
+     &          t1v1(1:nvir), t1v2(1:nvir), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('CXT1 temps',6,MA_ERR)
 !
 ! UM arrays, produced by GA Get, consumed by DGEMM
 !
-      allocate( Tij(1:lnvv), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tij',100,MA_ERR)
-      allocate( Tkj(1:kchunk*lnvv), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tkj',101,MA_ERR)
-      allocate( Tia(1:lnov*nocc), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tia',102,MA_ERR)
-      allocate( Tka(1:kchunk*lnov), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tka',103,MA_ERR)
-      allocate( Xia(1:lnov*nocc), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Xia',104,MA_ERR)
-      allocate( Xka(1:kchunk*lnov), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Xka',105,MA_ERR)
-      allocate( Jia(1:lnvv), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jia',106,MA_ERR)
-      allocate( Jka(1:kchunk*lnvv), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jka',107,MA_ERR)
-      allocate( Kia(1:lnvv), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kia',108,MA_ERR)
-      allocate( Kka(1:kchunk*lnvv), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kka',109,MA_ERR)
-      allocate( Jij(1:lnov*nocc), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jij',110,MA_ERR)
-      allocate( Jkj(1:kchunk*lnov), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jkj',111,MA_ERR)
-      allocate( Kij(1:lnov*nocc), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kij',112,MA_ERR)
-      allocate( Kkj(1:kchunk*lnov), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kkj',113,MA_ERR)
-      allocate( Dja(1:lnov), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Dja',114,MA_ERR)
-      allocate( Djka(1:nvir*kchunk), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Djka',115,MA_ERR)
-      allocate( Djia(1:nvir*nocc), stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Djia',116,MA_ERR)
+      allocate( Tij(1:lnvv), Tkj(1:kchunk*lnvv),
+     &          Tia(1:lnov*nocc), Tka(1:kchunk*lnov),
+     &          Xia(1:lnov*nocc), Xka(1:kchunk*lnov),
+     &          Jia(1:lnvv), Jka(1:kchunk*lnvv),
+     &          Kia(1:lnvv), Kka(1:kchunk*lnvv),
+     &          Jij(1:lnov*nocc), Jkj(1:kchunk*lnov),
+     &          Kij(1:lnov*nocc), Kkj(1:kchunk*lnov),
+     &          Dja(1:lnov), Djka(1:nvir*kchunk),
+     &          Djia(1:nvir*nocc), stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('TKJKD alloc',1,MA_ERR)
 !
 !      call ga_sync() ! ga_sync called just before trpdrv in aoccsd2
 !
@@ -358,7 +316,7 @@
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
-                       
+
                         err = cublasDgemm_v2(handle(2),
      &                        cu_op_n,cu_op_t,
      &                        nv4,nv4,nv4,1.0d0,
@@ -375,7 +333,7 @@
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
-                       
+
                         err = cublasDgemm_v2(handle(3),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
@@ -392,7 +350,7 @@
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
-                       
+
                         err = cublasDgemm_v2(handle(4),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
@@ -409,7 +367,7 @@
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
-                       
+
                         err = cublasDgemm_v2(handle(5),
      &                        cu_op_n,cu_op_t,
      &                        nv4,nv4,nv4,1.0d0,
@@ -426,7 +384,7 @@
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
-                       
+
                         err = cublasDgemm_v2(handle(6),
      &                        cu_op_n,cu_op_t,
      &                        nv4,nv4,nv4,1.0d0,
@@ -443,7 +401,7 @@
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
-                       
+
                         err = cublasDgemm_v2(handle(7),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
@@ -460,7 +418,7 @@
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
                         endif
-                       
+
                         err = cublasDgemm_v2(handle(8),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
@@ -507,7 +465,7 @@
      &                       2*27 )
 #endif
 
-!$acc parallel loop collapse(2) private(denom) 
+!$acc parallel loop collapse(2) private(denom)
 !$acc&         reduction(+:emp4i,emp4k,emp5i,emp5k)
            do b=1,nvir
              do c=1,nvir
@@ -611,72 +569,17 @@
          call qexit('trpdrv',0)
       endif
 !
-      deallocate( f1n, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f1n',1,MA_ERR)
-      deallocate( f2n, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f2n',2,MA_ERR)
-      deallocate( f3n, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f3n',3,MA_ERR)
-      deallocate( f4n, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f4n',4,MA_ERR)
-      deallocate( f1t, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f1t',5,MA_ERR)
-      deallocate( f2t, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f2t',6,MA_ERR)
-      deallocate( f3t, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f3t',7,MA_ERR)
-      deallocate( f4t, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('f4t',8,MA_ERR)
+      deallocate( f1n, f1t, f2n, f2t, f3n, f3t, f4n, f4t,
+     &            stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('free f[1234][tn]',8,MA_ERR)
 
-      deallocate( eorb, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('eorb',10,MA_ERR)
-      deallocate( dintc1, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintc1',11,MA_ERR)
-      deallocate( dintx1, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintx1',12,MA_ERR)
-      deallocate( t1v1, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('t1v1',13,MA_ERR)
-      deallocate( dintc2, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintc2',14,MA_ERR)
-      deallocate( dintx2, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('dintx2',15,MA_ERR)
-      deallocate( t1v2, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('t1v2',16,MA_ERR)
+      deallocate( eorb, dintc1, dintx1, t1v1, dintc2, dintx2, t1v2,
+     &            stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('free CXT1 temps',6,MA_ERR)
 
-      deallocate( Tij, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tij',100,MA_ERR)
-      deallocate( Tkj, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tkj',101,MA_ERR)
-      deallocate( Tia, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tia',102,MA_ERR)
-      deallocate( Tka, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Tka',103,MA_ERR)
-      deallocate( Xia, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Xia',104,MA_ERR)
-      deallocate( Xka, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Xka',105,MA_ERR)
-      deallocate( Jia, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jia',106,MA_ERR)
-      deallocate( Jka, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jka',107,MA_ERR)
-      deallocate( Kia, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kia',108,MA_ERR)
-      deallocate( Kka, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kka',109,MA_ERR)
-      deallocate( Jij, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jij',110,MA_ERR)
-      deallocate( Jkj, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Jkj',111,MA_ERR)
-      deallocate( Kij, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kij',112,MA_ERR)
-      deallocate( Kkj, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Kkj',113,MA_ERR)
-      deallocate( Dja, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Dja',114,MA_ERR)
-      deallocate( Djka, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Djka',115,MA_ERR)
-      deallocate( Djia, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('Djia',116,MA_ERR)
+      deallocate( Tij, Tkj, Tia, Tka, Xia, Xka, Jia, Jka, Kia, Kka,
+     &            Jij, Jkj, Kij, Kkj, Dja, Djka, Djia, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('free TKJKD alloc',1,MA_ERR)
 !
 ! CUDA stuff
 !

--- a/src/ccsd/ccsd_trpdrv_openacc.F
+++ b/src/ccsd/ccsd_trpdrv_openacc.F
@@ -31,14 +31,21 @@
       double precision, allocatable, device :: f2t(:,:)
       double precision, allocatable, device :: f3t(:,:)
       double precision, allocatable, device :: f4t(:,:)
-      double precision, allocatable, managed :: Tij(:), Tkj(:)
-      double precision, allocatable, managed :: Tia(:), Tka(:)
-      double precision, allocatable, managed :: Xia(:), Xka(:)
-      double precision, allocatable, managed :: Jia(:), Jka(:)
-      double precision, allocatable, managed :: Jij(:), Jkj(:)
-      double precision, allocatable, managed :: Kia(:), Kka(:)
-      double precision, allocatable, managed :: Kij(:), Kkj(:)
-      double precision, allocatable, managed :: Dja(:), Djka(:), Djia(:)
+      double precision, allocatable, pinned :: Tij(:), Tkj(:)
+      double precision, allocatable, pinned :: Tia(:), Tka(:)
+      double precision, allocatable, pinned :: Xia(:), Xka(:)
+      double precision, allocatable, pinned :: Jia(:), Jka(:)
+      double precision, allocatable, pinned :: Jij(:), Jkj(:)
+      double precision, allocatable, pinned :: Kia(:), Kka(:)
+      double precision, allocatable, pinned :: Kij(:), Kkj(:)
+      double precision, allocatable, pinned :: Dja(:), Djka(:), Djia(:)
+      double precision, allocatable, device :: xTij(:), xTkj(:)
+      double precision, allocatable, device :: xTia(:), xTka(:)
+      double precision, allocatable, device :: xXia(:), xXka(:)
+      double precision, allocatable, device :: xJia(:), xJka(:)
+      double precision, allocatable, device :: xJij(:), xJkj(:)
+      double precision, allocatable, device :: xKia(:), xKka(:)
+      double precision, allocatable, device :: xKij(:), xKkj(:)
 ! used to make inline threaded tengy correct - for now
 ! it is correct that dint[cx]1 are paired with t1v2 and vice versa
 ! in the inlined tengy loops.  see ccsd_tengy in ccsd_trpdrv.F for
@@ -156,16 +163,25 @@
 !
 ! UM arrays, produced by GA Get, consumed by DGEMM
 !
-      allocate( Tij(1:lnvv), Tkj(1:kchunk*lnvv),
+      allocate( Tij(1:lnvv),      Tkj(1:kchunk*lnvv),
      &          Tia(1:lnov*nocc), Tka(1:kchunk*lnov),
      &          Xia(1:lnov*nocc), Xka(1:kchunk*lnov),
-     &          Jia(1:lnvv), Jka(1:kchunk*lnvv),
-     &          Kia(1:lnvv), Kka(1:kchunk*lnvv),
+     &          Jia(1:lnvv),      Jka(1:kchunk*lnvv),
+     &          Kia(1:lnvv),      Kka(1:kchunk*lnvv),
      &          Jij(1:lnov*nocc), Jkj(1:kchunk*lnov),
      &          Kij(1:lnov*nocc), Kkj(1:kchunk*lnov),
-     &          Dja(1:lnov), Djka(1:nvir*kchunk),
+     &          Dja(1:lnov),      Djka(1:nvir*kchunk),
      &          Djia(1:nvir*nocc), stat=alloc_error)
       if (alloc_error.ne.0) call errquit('TKJKD alloc',1,MA_ERR)
+      allocate( xTij(1:lnvv),      xTkj(1:kchunk*lnvv),
+     &          xTia(1:lnov*nocc), xTka(1:kchunk*lnov),
+     &          xXia(1:lnov*nocc), xXka(1:kchunk*lnov),
+     &          xJia(1:lnvv),      xJka(1:kchunk*lnvv),
+     &          xKia(1:lnvv),      xKka(1:kchunk*lnvv),
+     &          xJij(1:lnov*nocc), xJkj(1:kchunk*lnov),
+     &          xKij(1:lnov*nocc), xKkj(1:kchunk*lnov),
+     &          stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('TKJKD GPU alloc',1,MA_ERR)
 !
 !      call ga_sync() ! ga_sync called just before trpdrv in aoccsd2
 !
@@ -295,6 +311,22 @@
                             call ga_nbwait(nbh_coul2)
                         endif
 
+                        ! these should be moved up
+                            xTij  = Tij
+                            xTia  = Tia
+                            xXia  = Xia
+                            xJia  = Jia
+                            xJij  = Jij
+                            xKia  = Kia
+                            xKij  = Kij
+                            xTkj  = Tkj
+                            xTka  = Tka
+                            xXka  = Xka
+                            xJka  = Jka
+                            xJkj  = Jkj
+                            xKka  = Kka
+                            xKkj  = Kkj
+
                         tc0 = util_wallsec()
 
                         nv4 = nvir ! no possibility of overflow
@@ -303,7 +335,7 @@
                         err = cublasDgemm_v2(handle(1),
      &                        cu_op_n,cu_op_t,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Jia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        xJia,nv4,xTkj(1+(k-klo)*lnvv),nv4,0.0d0,
      &                        f1n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -311,7 +343,7 @@
                         err = cublasDgemm_v2(handle(1),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Tia,nv4,Kkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        xTia,nv4,xKkj(1+(k-klo)*lnov),no4,1.0d0,
      &                        f1n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -320,7 +352,7 @@
                         err = cublasDgemm_v2(handle(2),
      &                        cu_op_n,cu_op_t,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Kia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        xKia,nv4,xTkj(1+(k-klo)*lnvv),nv4,0.0d0,
      &                        f2n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -328,7 +360,7 @@
                         err = cublasDgemm_v2(handle(2),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Xia,nv4,Kkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        xXia,nv4,xKkj(1+(k-klo)*lnov),no4,1.0d0,
      &                        f2n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -337,7 +369,7 @@
                         err = cublasDgemm_v2(handle(3),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Jia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        xJia,nv4,xTkj(1+(k-klo)*lnvv),nv4,0.0d0,
      &                        f3n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -345,7 +377,7 @@
                         err = cublasDgemm_v2(handle(3),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Tia,nv4,Jkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        xTia,nv4,xJkj(1+(k-klo)*lnov),no4,1.0d0,
      &                        f3n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -354,7 +386,7 @@
                         err = cublasDgemm_v2(handle(4),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Kia,nv4,Tkj(1+(k-klo)*lnvv),nv4,0.0d0,
+     &                        xKia,nv4,xTkj(1+(k-klo)*lnvv),nv4,0.0d0,
      &                        f4n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -362,7 +394,7 @@
                         err = cublasDgemm_v2(handle(4),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Xia,nv4,Jkj(1+(k-klo)*lnov),no4,1.0d0,
+     &                        xXia,nv4,xJkj(1+(k-klo)*lnov),no4,1.0d0,
      &                        f4n,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -371,7 +403,7 @@
                         err = cublasDgemm_v2(handle(5),
      &                        cu_op_n,cu_op_t,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Jka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        xJka(1+(k-klo)*lnvv),nv4,xTij,nv4,0.0d0,
      &                        f1t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -379,7 +411,7 @@
                         err = cublasDgemm_v2(handle(5),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Tka(1+(k-klo)*lnov),nv4,Kij,no4,1.0d0,
+     &                        xTka(1+(k-klo)*lnov),nv4,xKij,no4,1.0d0,
      &                        f1t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -388,7 +420,7 @@
                         err = cublasDgemm_v2(handle(6),
      &                        cu_op_n,cu_op_t,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Kka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        xKka(1+(k-klo)*lnvv),nv4,xTij,nv4,0.0d0,
      &                        f2t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -396,7 +428,7 @@
                         err = cublasDgemm_v2(handle(6),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Xka(1+(k-klo)*lnov),nv4,Kij,no4,1.0d0,
+     &                        xXka(1+(k-klo)*lnov),nv4,xKij,no4,1.0d0,
      &                        f2t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -405,7 +437,7 @@
                         err = cublasDgemm_v2(handle(7),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Jka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        xJka(1+(k-klo)*lnvv),nv4,xTij,nv4,0.0d0,
      &                        f3t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -413,7 +445,7 @@
                         err = cublasDgemm_v2(handle(7),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Tka(1+(k-klo)*lnov),nv4,Jij,no4,1.0d0,
+     &                        xTka(1+(k-klo)*lnov),nv4,xJij,no4,1.0d0,
      &                        f3t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -422,7 +454,7 @@
                         err = cublasDgemm_v2(handle(8),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,nv4,1.0d0,
-     &                        Kka(1+(k-klo)*lnvv),nv4,Tij,nv4,0.0d0,
+     &                        xKka(1+(k-klo)*lnvv),nv4,xTij,nv4,0.0d0,
      &                        f4t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -430,7 +462,7 @@
                         err = cublasDgemm_v2(handle(8),
      &                        cu_op_n,cu_op_n,
      &                        nv4,nv4,no4,-1.0d0,
-     &                        Xka(1+(k-klo)*lnov),nv4,Jij,no4,1.0d0,
+     &                        xXka(1+(k-klo)*lnov),nv4,xJij,no4,1.0d0,
      &                        f4t,nv4)
                         if (err.ne.0) then
                           call errquit('cublasDgemm_v2',err,UNKNOWN_ERR)
@@ -577,9 +609,14 @@
      &            stat=alloc_error)
       if (alloc_error.ne.0) call errquit('free CXT1 temps',6,MA_ERR)
 
-      deallocate( Tij, Tkj, Tia, Tka, Xia, Xka, Jia, Jka, Kia, Kka,
-     &            Jij, Jkj, Kij, Kkj, Dja, Djka, Djia, stat=alloc_error)
-      if (alloc_error.ne.0) call errquit('free TKJKD alloc',1,MA_ERR)
+      deallocate( Tij, Tkj, Tia, Tka, Xia, Xka,
+     &            Jia, Jka, Kia, Kka, Jij, Jkj, Kij, Kkj,
+     &            Dja, Djka, Djia, stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('free TKJKD',1,MA_ERR)
+      deallocate( xTij, xTkj, xTia, xTka, xXia, xXka,
+     &            xJia, xJka, xKia, xKka, xJij, xJkj, xKij, xKkj,
+     &            stat=alloc_error)
+      if (alloc_error.ne.0) call errquit('free TKJKD GPU',1,MA_ERR)
 !
 ! CUDA stuff
 !

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3405,7 +3405,7 @@ else
 endif
 
 ifdef NWCHEM_LINK_CUDA
-    CORE_LIBS += -acc -gpu=managed -cuda -cudalib=cublas
+    CORE_LIBS += -acc -cuda -cudalib=cublas
 endif
 
 

--- a/src/tools/GNUmakefile
+++ b/src/tools/GNUmakefile
@@ -650,11 +650,12 @@ ifndef ARMCI_NETWORK
     ARMCI_NETWORK=MPI-TS
     MAYBE_ARMCI = --with-mpi-ts
 endif
-# CUDA UM support
-ifdef NWCHEM_LINK_CUDA
-    MAYBE_ARMCI +=  --enable-cuda-mem
-endif
-#
+
+# CUDA UM support - disabled now that trpdrv_openacc does not need it
+#ifdef NWCHEM_LINK_CUDA
+#    MAYBE_ARMCI +=  --enable-cuda-mem
+#endif
+
 # Apparently weak bindings do not work with CYGWIN64 at the moment. There seems
 # to be an issue with the COFF object format that gets in the way (with ELF
 # this is apparently not a problem). Some details can be found at


### PR DESCRIPTION
UM thrashes because of GA/MPI.  Just use pinned+device instead to keep it simple.