### PR TITLE
COSMO is initialized/finalized in nwdft.F

### DIFF
--- a/QA/doqmtests.mpi
+++ b/QA/doqmtests.mpi
@@ -72,6 +72,8 @@ let "myexit+=$?"
 let "myexit+=$?"
 ./runtests.mpi.unix procs $np h2o_diag_to_cg_ub3lyp h2o_cg_to_diag_ub3lyp
 let "myexit+=$?"
+./runtests.mpi.unix procs $np h2o_cg_opt_cosmo
+let "myexit+=$?"
 #
 #---   small tests that should fail!
 echo ' '

--- a/QA/tests/h2o_cg_opt_cosmo/h2o_cg_opt_cosmo.nw
+++ b/QA/tests/h2o_cg_opt_cosmo/h2o_cg_opt_cosmo.nw
@@ -1,0 +1,25 @@
+echo
+start h2o_cg_opt_cosmo
+
+geometry units au
+ O 0       0        0
+ H 0       1.430   -1.107
+ H 0      -1.430   -1.107
+end
+
+
+basis
+  O library 6-31g*
+  H library 6-31g*
+end
+
+dft
+  cgmin
+  print "force components"
+  convergence nr 0.0
+end
+
+cosmo
+end
+
+task dft optimize

--- a/QA/tests/h2o_cg_opt_cosmo/h2o_cg_opt_cosmo.out
+++ b/QA/tests/h2o_cg_opt_cosmo/h2o_cg_opt_cosmo.out
@@ -1,0 +1,3141 @@
+ argument  1 = h2o_cg_opt_cosmo.nw
+  NWChem w/ OpenMP: maximum threads =    1
+
+
+
+============================== echo of input deck ==============================
+echo
+start h2o_cg_opt_dat
+
+geometry units au
+ O 0       0        0
+ H 0       1.430   -1.107
+ H 0      -1.430   -1.107
+end
+
+
+basis
+  O library 6-31g*
+  H library 6-31g*
+end
+
+dft
+  cgmin
+  print "force components"
+  convergence nr 0.0
+end
+
+cosmo
+end
+
+task dft optimize
+================================================================================
+
+
+                                         
+                                         
+
+
+             Northwest Computational Chemistry Package (NWChem) 7.0.1
+             --------------------------------------------------------
+
+
+                    Environmental Molecular Sciences Laboratory
+                       Pacific Northwest National Laboratory
+                                Richland, WA 99352
+
+                              Copyright (c) 1994-2022
+                       Pacific Northwest National Laboratory
+                            Battelle Memorial Institute
+
+             NWChem is an open-source computational chemistry package
+                        distributed under the terms of the
+                      Educational Community License (ECL) 2.0
+             A copy of the license is included with this distribution
+                              in the LICENSE.TXT file
+
+                                  ACKNOWLEDGMENT
+                                  --------------
+
+            This software and its documentation were developed at the
+            EMSL at Pacific Northwest National Laboratory, a multiprogram
+            national laboratory, operated for the U.S. Department of Energy
+            by Battelle under Contract Number DE-AC05-76RL01830. Support
+            for this work was provided by the Department of Energy Office
+            of Biological and Environmental Research, Office of Basic
+            Energy Sciences, and the Office of Advanced Scientific Computing.
+
+
+           Job information
+           ---------------
+
+    hostname        = WE41275u
+    program         = nwchem
+    date            = Mon Oct 24 14:48:22 2022
+
+    compiled        = Mon_Oct_24_14:29:25_2022
+    source          = /home/meji656/Sources/nwchem.master
+    nwchem branch   = 7.0.0
+    nwchem revision = nwchem_on_git-4063-g862a16112c
+    ga revision     = 5.8.1
+    use scalapack   = T
+    input           = h2o_cg_opt_cosmo.nw
+    prefix          = h2o_cg_opt_dat.
+    data base       = ./h2o_cg_opt_dat.db
+    status          = startup
+    nproc           =        2
+    time left       =     -1s
+
+
+
+           Memory information
+           ------------------
+
+    heap     =   26214396 doubles =    200.0 Mbytes
+    stack    =   26214401 doubles =    200.0 Mbytes
+    global   =   52428800 doubles =    400.0 Mbytes (distinct from heap & stack)
+    total    =  104857597 doubles =    800.0 Mbytes
+    verify   = yes
+    hardfail = no 
+
+
+           Directory information
+           ---------------------
+
+  0 permanent = .
+  0 scratch   = .
+
+
+
+
+                                NWChem Input Module
+                                -------------------
+
+
+ C2V symmetry detected
+
+          ------
+          auto-z
+          ------
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+
+                             Geometry "geometry" -> ""
+                             -------------------------
+
+ Output coordinates in a.u. (scale by  1.000000000 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 O                    8.0000     0.00000000     0.00000000     0.22140000
+    2 H                    1.0000    -1.43000000     0.00000000    -0.88560000
+    3 H                    1.0000     1.43000000     0.00000000    -0.88560000
+
+      Atomic Mass 
+      ----------- 
+
+      O                 15.994910
+      H                  1.007825
+
+
+ Effective nuclear repulsion energy (a.u.)       9.1971984402
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.0000000000
+
+      Symmetry information
+      --------------------
+
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     2
+
+      Symmetry unique atoms
+
+     1    2
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value
+      ----------- --------  ----- ----- ----- ----- ----- ----------
+    1 Stretch                  1     2                       0.95697
+    2 Stretch                  1     3                       0.95697
+    3 Bend                     2     1     3               104.51124
+
+
+            XYZ format geometry
+            -------------------
+     3
+ geometry
+ O                     0.00000000     0.00000000     0.11715984
+ H                    -0.75672347     0.00000000    -0.46863937
+ H                     0.75672347     0.00000000    -0.46863937
+
+ ==============================================================================
+                                internuclear distances
+ ------------------------------------------------------------------------------
+       center one      |      center two      | atomic units |       a.u.
+ ------------------------------------------------------------------------------
+    2 H                |   1 O                |     1.80841  |     1.80841
+    3 H                |   1 O                |     1.80841  |     1.80841
+ ------------------------------------------------------------------------------
+                         number of included internuclear distances:          2
+ ==============================================================================
+
+
+
+ ==============================================================================
+                                 internuclear angles
+ ------------------------------------------------------------------------------
+        center 1       |       center 2       |       center 3       |  degrees
+ ------------------------------------------------------------------------------
+    2 H                |   1 O                |   3 H                |   104.51
+ ------------------------------------------------------------------------------
+                            number of included internuclear angles:          1
+ ==============================================================================
+
+
+
+  library name resolved from: environment
+  library file name is: </home/meji656/Sources/nwchem.master/src/basis/libraries.bse/>
+  
+                      Basis "ao basis" -> "" (cartesian)
+                      -----
+  O (Oxygen)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  5.48467166E+03  0.001831
+  1 S  8.25234946E+02  0.013950
+  1 S  1.88046958E+02  0.068445
+  1 S  5.29645000E+01  0.232714
+  1 S  1.68975704E+01  0.470193
+  1 S  5.79963534E+00  0.358521
+
+  2 S  1.55396163E+01 -0.110778
+  2 S  3.59993359E+00 -0.148026
+  2 S  1.01376175E+00  1.130767
+
+  3 P  1.55396163E+01  0.070874
+  3 P  3.59993359E+00  0.339753
+  3 P  1.01376175E+00  0.727159
+
+  4 S  2.70005823E-01  1.000000
+
+  5 P  2.70005823E-01  1.000000
+
+  6 D  8.00000000E-01  1.000000
+
+  H (Hydrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  1.87311370E+01  0.033495
+  1 S  2.82539437E+00  0.234727
+  1 S  6.40121692E-01  0.813757
+
+  2 S  1.61277759E-01  1.000000
+
+
+
+ Summary of "ao basis" -> "" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+
+
+                           NWChem Geometry Optimization
+                           ----------------------------
+
+
+  no constraints, skipping    0.0000000000000000     
+ maximum gradient threshold         (gmax) =   0.000450
+ rms gradient threshold             (grms) =   0.000300
+ maximum cartesian step threshold   (xmax) =   0.001800
+ rms cartesian step threshold       (xrms) =   0.001200
+ fixed trust radius                (trust) =   0.300000
+ maximum step size to saddle      (sadstp) =   0.100000
+ energy precision                  (eprec) =   5.0D-06
+ maximum number of steps          (nptopt) =   40
+ initial hessian option           (inhess) =    0
+ line search option               (linopt) =    1
+ hessian update option            (modupd) =    1
+ saddle point option              (modsad) =    0
+ initial eigen-mode to follow     (moddir) =    0
+ initial variable to follow       (vardir) =    0
+ follow first negative mode     (firstneg) =    T
+ apply conjugacy                    (opcg) =    F
+ source of zmatrix                         =   autoz   
+
+
+          -------------------
+          Energy Minimization
+          -------------------
+
+
+ Names of Z-matrix variables 
+    1              2              3         
+
+ Variables with the same non-blank name are constrained to be equal
+
+
+ Using old Hessian from previous optimization
+
+          --------
+          Step   0
+          --------
+
+
+                         Geometry "geometry" -> "geometry"
+                         ---------------------------------
+
+ Output coordinates in a.u. (scale by  1.000000000 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 O                    8.0000     0.00000000     0.00000000     0.22140000
+    2 H                    1.0000    -1.43000000     0.00000000    -0.88560000
+    3 H                    1.0000     1.43000000     0.00000000    -0.88560000
+
+      Atomic Mass 
+      ----------- 
+
+      O                 15.994910
+      H                  1.007825
+
+
+ Effective nuclear repulsion energy (a.u.)       9.1971984402
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.0000000000
+
+      Symmetry information
+      --------------------
+
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     2
+
+      Symmetry unique atoms
+
+     1    2
+
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1         10
+        a2          1
+        b1          5
+        b2          3
+
+
+ solvent parameters
+ solvname_short: h2o     
+ solvname_long:  water                              
+ dielec:       78.4000
+ dielecinf:     1.7769
+
+          ---------------
+          -cosmo- solvent
+          ---------------
+ Cosmo: York-Karplus, doi: 10.1021/jp992097l
+ dielectric constant -eps-     =  78.40
+ screen = (eps-1)/(eps    )    =   0.98724
+ surface charge correction     = lagrangian
+
+ solvent accessible surface
+ --------------------------
+
+ ---------- ATOMIC COORDINATES (A.U.) ------------ VDWR(ANG.) --
+     1    0.00000000    0.00000000    0.22140000     1.720
+     2   -1.43000000    0.00000000   -0.88560000     1.300
+     3    1.43000000    0.00000000   -0.88560000     1.300
+ number of segments per atom =         32
+ number of   points per atom =         32
+ atom (   nspa,  nppa )
+ ----------------------
+    1 (     20,     0 )       0
+    2 (     20,     0 )       0
+    3 (     20,     0 )       0
+ number of -cosmo- surface points =       60
+ molecular surface =     40.637 angstrom**2
+ molecular volume  =     20.850 angstrom**3
+ G(cav/disp)       =      1.063 kcal/mol
+ -lineq- algorithm             =   0
+ -bem- low  level              =   2
+ -bem- from -octahedral-
+ gaussian surface charge width =   4.50000
+ degree of switching           =   1.00000
+ switching function tolerance  =   0.00010
+ atomic radii = 
+ --------------
+    1  8.000  1.720
+    2  1.000  1.300
+    3  1.000  1.300
+ ...... end of -cosmo- initialization ......
+
+
+  Caching 1-el integrals 
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+      Superposition of Atomic Density Guess
+      -------------------------------------
+
+ Sum of atomic energies:         -75.75081731
+
+      Non-variational initial energy
+      ------------------------------
+
+ Total energy =     -75.919952
+ 1-e energy   =    -121.737767
+ 2-e energy   =      36.620616
+ HOMO         =      -0.470482
+ LUMO         =       0.114886
+
+
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+
+  Numbering of irreducible representations: 
+
+     1 a1          2 a2          3 b1          4 b2      
+
+  Orbital symmetries:
+
+     1 a1          2 a1          3 b1          4 a1          5 b2      
+     6 a1          7 b1          8 b1          9 a1         10 b2      
+    11 a1         12 b1         13 a1         14 a1         15 a2      
+
+
+
+ ----------------------------------------------
+         Quadratically convergent ROKS
+
+ Convergence threshold     :          5.000E-04
+ Maximum no. of iterations :           50
+ Final Fock-matrix accuracy:          1.000E-08
+
+ PCG initial level shift   :              5.000
+ PCG change shift at maxg  :              0.500
+ PCG final level shift     :              0.000
+ NR  initial level shift   :              0.000
+ NR  change shift at maxg  :              0.000
+ NR  final level shift     :              0.000
+ NR  enabled at maxg       :              0.000
+ ----------------------------------------------
+
+     COSMO gas phase
+
+ Grid_pts file          = ./h2o_cg_opt_dat.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =      9        Max. recs in file   = 506625431
+
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8064261906  1.07D+00  6.05D-01      0.2
+                 2      -75.8405593872  2.41D-01  1.14D-01      0.2
+                 3      -75.8440118640  1.13D-01  7.58D-02      0.2
+                 4      -75.8443200943  1.87D-02  1.30D-02      0.3
+                 5      -75.8443287559  8.00D-03  5.62D-03      0.3
+                 6      -75.8443301832  6.09D-04  3.19D-04      0.4
+                 7      -75.8443301934  1.03D-04  4.89D-05      0.4
+     COSMO solvation phase
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8553687004  1.02D-01  4.99D-02      0.4
+                 2      -75.8564874716  5.66D-02  3.11D-02      0.5
+                 3      -75.8566462130  9.56D-03  4.75D-03      0.5
+                 4      -75.8566518820  1.55D-03  6.13D-04      0.6
+                 5      -75.8566519873  3.73D-04  1.45D-04      0.6
+
+
+         Total DFT energy =      -75.856651987252
+      One electron energy =     -123.227772222417
+           Coulomb energy =       46.877378269909
+    Exchange-Corr. energy =       -8.775977234737
+ Nuclear repulsion energy =        9.197198440198
+
+             COSMO energy =        0.072520759795
+
+ Numeric. integr. density =       10.000001251258
+
+     Total iterative time =      0.5s
+
+
+                                   COSMO solvation results
+                                   -----------------------
+
+                 gas phase energy =       -75.844330193405
+                 sol phase energy =       -75.856651987252
+ (electrostatic) solvation energy =         0.012321793848 (    7.73 kcal/mol)
+
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+
+ Vector    1  Occ=2.000000D+00  E=-1.859832D+01  Symmetry=a1
+              MO Center=  3.7D-19,  1.4D-19,  1.2D-01, r^2= 1.5D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.990629  1 O  s          
+
+ Vector    2  Occ=2.000000D+00  E=-9.004889D-01  Symmetry=a1
+              MO Center=  3.2D-18,  4.1D-19, -9.3D-02, r^2= 5.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.458322  1 O  s                  6      0.446227  1 O  s          
+     1     -0.210682  1 O  s          
+
+ Vector    3  Occ=2.000000D+00  E=-4.629853D-01  Symmetry=b1
+              MO Center=  5.2D-17, -5.5D-18, -9.3D-02, r^2= 7.6D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.528176  1 O  px                 7      0.285018  1 O  px         
+    16     -0.226664  2 H  s                 18      0.226664  3 H  s          
+
+ Vector    4  Occ=2.000000D+00  E=-3.169045D-01  Symmetry=a1
+              MO Center=  1.9D-17, -1.5D-17,  2.2D-01, r^2= 6.7D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.556593  1 O  pz                 6      0.393736  1 O  s          
+     9      0.394046  1 O  pz                 2      0.163601  1 O  s          
+
+ Vector    5  Occ=2.000000D+00  E=-2.373197D-01  Symmetry=b2
+              MO Center= -6.9D-17,  3.9D-17,  9.8D-02, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.634983  1 O  py                 8      0.516461  1 O  py         
+
+ Vector    6  Occ=0.000000D+00  E= 6.552742D-02  Symmetry=a1
+              MO Center=  5.7D-17,  5.2D-18, -6.1D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.176321  1 O  s                 17     -0.946925  2 H  s          
+    19     -0.946925  3 H  s                  9     -0.444732  1 O  pz         
+     5     -0.270922  1 O  pz                 2      0.174690  1 O  s          
+
+ Vector    7  Occ=0.000000D+00  E= 1.506226D-01  Symmetry=b1
+              MO Center=  2.4D-17,  5.7D-34, -5.5D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.251935  2 H  s                 19     -1.251935  3 H  s          
+     7      0.721214  1 O  px                 3      0.438006  1 O  px         
+
+ Vector    8  Occ=0.000000D+00  E= 7.483727D-01  Symmetry=b1
+              MO Center=  6.4D-17, -6.0D-33, -1.0D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.831419  2 H  s                 18     -0.831419  3 H  s          
+    17     -0.603565  2 H  s                 19      0.603565  3 H  s          
+     7      0.528812  1 O  px                12      0.360877  1 O  dxz        
+
+ Vector    9  Occ=0.000000D+00  E= 7.993974D-01  Symmetry=a1
+              MO Center= -1.9D-17, -5.8D-18,  4.5D-01, r^2= 1.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.908978  1 O  pz                 9     -0.832046  1 O  pz         
+     6     -0.734539  1 O  s                  2      0.403321  1 O  s          
+    16      0.250700  2 H  s                 18      0.250700  3 H  s          
+    10      0.220735  1 O  dxx               17     -0.199779  2 H  s          
+    19     -0.199779  3 H  s                 15      0.173382  1 O  dzz        
+
+ Vector   10  Occ=0.000000D+00  E= 8.180467D-01  Symmetry=b2
+              MO Center= -1.8D-17, -2.8D-17,  1.1D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8     -1.033639  1 O  py                 4      0.965793  1 O  py         
+
+ Vector   11  Occ=0.000000D+00  E= 8.593734D-01  Symmetry=a1
+              MO Center=  2.2D-17, -4.6D-17, -3.6D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.048339  1 O  s                 16      0.819576  2 H  s          
+    18      0.819576  3 H  s                  2     -0.682465  1 O  s          
+    17     -0.622550  2 H  s                 19     -0.622550  3 H  s          
+     9      0.431945  1 O  pz                13     -0.323918  1 O  dyy        
+    15     -0.190559  1 O  dzz        
+
+ Vector   12  Occ=0.000000D+00  E= 9.996814D-01  Symmetry=b1
+              MO Center= -6.2D-17, -2.6D-31,  3.5D-02, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      1.638323  1 O  px                17      1.029192  2 H  s          
+    19     -1.029192  3 H  s                  3     -0.985358  1 O  px         
+
+ Vector   13  Occ=0.000000D+00  E= 1.143111D+00  Symmetry=a1
+              MO Center=  5.9D-16,  4.9D-17, -3.7D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.681156  1 O  s                  2     -1.493859  1 O  s          
+     9     -1.080037  1 O  pz                17     -0.831293  2 H  s          
+    19     -0.831293  3 H  s                 10     -0.656974  1 O  dxx        
+    15     -0.389847  1 O  dzz                5      0.381870  1 O  pz         
+    16     -0.313776  2 H  s                 18     -0.313776  3 H  s          
+
+ Vector   14  Occ=0.000000D+00  E= 1.653058D+00  Symmetry=a1
+              MO Center= -3.3D-17,  3.1D-17,  1.7D-01, r^2= 6.2D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      1.010154  1 O  dzz               10     -0.582462  1 O  dxx        
+    13     -0.357522  1 O  dyy                6     -0.268445  1 O  s          
+
+ Vector   15  Occ=0.000000D+00  E= 1.668325D+00  Symmetry=a2
+              MO Center= -1.0D-16,  9.9D-17,  1.2D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.732051  1 O  dxy        
+
+ Vector   16  Occ=0.000000D+00  E= 1.704236D+00  Symmetry=b2
+              MO Center=  1.9D-16, -3.3D-17,  1.4D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      1.730945  1 O  dyz        
+
+ Vector   17  Occ=0.000000D+00  E= 2.222824D+00  Symmetry=a1
+              MO Center=  2.5D-16,  1.1D-18, -3.9D-03, r^2= 8.4D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.593813  1 O  s                 13     -1.128925  1 O  dyy        
+    16     -0.842336  2 H  s                 18     -0.842336  3 H  s          
+     9     -0.755986  1 O  pz                10      0.751569  1 O  dxx        
+     2     -0.520394  1 O  s                 17     -0.151539  2 H  s          
+    19     -0.151539  3 H  s          
+
+ Vector   18  Occ=0.000000D+00  E= 2.523453D+00  Symmetry=b1
+              MO Center= -5.8D-17, -9.3D-17,  6.2D-02, r^2= 8.7D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      2.223689  1 O  dxz               16     -0.956064  2 H  s          
+    18      0.956064  3 H  s                  7     -0.881098  1 O  px         
+
+ Vector   19  Occ=0.000000D+00  E= 3.473514D+00  Symmetry=a1
+              MO Center= -3.4D-16,  1.3D-18,  1.1D-01, r^2= 1.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.752717  1 O  s                 13     -1.584277  1 O  dyy        
+    15     -1.559371  1 O  dzz               10     -1.537362  1 O  dxx        
+    17     -0.576101  2 H  s                 19     -0.576101  3 H  s          
+     1     -0.473739  1 O  s                  9     -0.339141  1 O  pz         
+     2      0.268453  1 O  s          
+
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+
+                            NWChem DFT Gradient Module
+                            --------------------------
+
+
+
+  charge          =   0.00
+  wavefunction    = closed shell
+
+XC gradient
+    -0.677813    -0.456413     0.323929
+     0.118634     0.020805     0.039254
+     0.559179     0.435608    -0.363183
+
+CD gradient
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+
+   1  -0.677813  -0.456413   0.323929
+   2   0.118634   0.020805   0.039254
+   3   0.559179   0.435608  -0.363183
+  Using symmetry
+
+
+                         DFT ENERGY GRADIENTS
+
+    atom               coordinates                        gradient
+                 x          y          z           x          y          z
+   1 O       0.000000   0.000000   0.221400    0.000000   0.000000  -0.026959
+   2 H      -1.430000   0.000000  -0.885600    0.015149   0.000000   0.013479
+   3 H       1.430000   0.000000  -0.885600   -0.015149   0.000000   0.013479
+
+                 ----------------------------------------
+                 |  Time  |  1-e(secs)   |  2-e(secs)   |
+                 ----------------------------------------
+                 |  CPU   |       0.00   |       0.02   |
+                 ----------------------------------------
+                 |  WALL  |       0.00   |       0.02   |
+                 ----------------------------------------
+  no constraints, skipping    0.0000000000000000     
+
+@ Step       Energy      Delta E   Gmax     Grms     Xrms     Xmax   Walltime
+@ ---- ---------------- -------- -------- -------- -------- -------- --------
+@    0     -75.85665199  0.0D+00  0.02023  0.01654  0.00000  0.00000      0.7
+                                                                    
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value     Gradient
+      ----------- --------  ----- ----- ----- ----- ----- ---------- ----------
+    1 Stretch                  1     2                       0.95697   -0.02023
+    2 Stretch                  1     3                       0.95697   -0.02023
+    3 Bend                     2     1     3               104.51124    0.00133
+
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1         10
+        a2          1
+        b1          5
+        b2          3
+
+
+ solvent parameters
+ solvname_short: h2o     
+ solvname_long:  water                              
+ dielec:       78.4000
+ dielecinf:     1.7769
+
+          ---------------
+          -cosmo- solvent
+          ---------------
+ Cosmo: York-Karplus, doi: 10.1021/jp992097l
+ dielectric constant -eps-     =  78.40
+ screen = (eps-1)/(eps    )    =   0.98724
+ surface charge correction     = lagrangian
+
+ solvent accessible surface
+ --------------------------
+
+ ---------- ATOMIC COORDINATES (A.U.) ------------ VDWR(ANG.) --
+     1    0.00000000    0.00000000    0.25122265     1.720
+     2   -1.46593989    0.00000000   -0.90051133     1.300
+     3    1.46593989    0.00000000   -0.90051133     1.300
+ number of segments per atom =         32
+ number of   points per atom =         32
+ atom (   nspa,  nppa )
+ ----------------------
+    1 (     20,     0 )       0
+    2 (     20,     0 )       0
+    3 (     20,     0 )       0
+ number of -cosmo- surface points =       60
+ molecular surface =     41.194 angstrom**2
+ molecular volume  =     21.096 angstrom**3
+ G(cav/disp)       =      1.066 kcal/mol
+ -lineq- algorithm             =   0
+ -bem- low  level              =   2
+ -bem- from -octahedral-
+ gaussian surface charge width =   4.50000
+ degree of switching           =   1.00000
+ switching function tolerance  =   0.00010
+ atomic radii = 
+ --------------
+    1  8.000  1.720
+    2  1.000  1.300
+    3  1.000  1.300
+ ...... end of -cosmo- initialization ......
+
+
+  Caching 1-el integrals 
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+ Loading old vectors from job with title :
+
+
+
+
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+
+  Numbering of irreducible representations: 
+
+     1 a1          2 a2          3 b1          4 b2      
+
+  Orbital symmetries:
+
+     1 a1          2 a1          3 b1          4 a1          5 b2      
+     6 a1          7 b1          8 b1          9 a1         10 b2      
+    11 a1         12 b1         13 a1         14 a1         15 a2      
+
+
+
+ ----------------------------------------------
+         Quadratically convergent ROKS
+
+ Convergence threshold     :          5.000E-04
+ Maximum no. of iterations :           50
+ Final Fock-matrix accuracy:          1.000E-08
+
+ PCG initial level shift   :              5.000
+ PCG change shift at maxg  :              0.500
+ PCG final level shift     :              0.000
+ NR  initial level shift   :              0.000
+ NR  change shift at maxg  :              0.000
+ NR  final level shift     :              0.000
+ NR  enabled at maxg       :              0.000
+ ----------------------------------------------
+
+     COSMO gas phase
+
+ Grid_pts file          = ./h2o_cg_opt_dat.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =      9        Max. recs in file   = 506625431
+
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8421870620  1.45D-01  8.40D-02      0.8
+                 2      -75.8443424502  8.40D-02  4.64D-02      0.8
+                 3      -75.8447946382  1.15D-02  5.17D-03      0.9
+                 4      -75.8448017852  3.13D-03  1.17D-03      0.9
+                 5      -75.8448023078  1.17D-03  4.82D-04      1.0
+                 6      -75.8448023698  2.10D-04  1.10D-04      1.0
+     COSMO solvation phase
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8559486043  1.03D-01  5.28D-02      1.0
+                 2      -75.8571303454  6.20D-02  3.29D-02      1.1
+                 3      -75.8573235993  1.01D-02  5.08D-03      1.1
+                 4      -75.8573299059  1.67D-03  6.31D-04      1.2
+                 5      -75.8573300350  3.47D-04  1.65D-04      1.2
+
+
+         Total DFT energy =      -75.857330035009
+      One electron energy =     -122.755026343392
+           Coulomb energy =       46.644353138989
+    Exchange-Corr. energy =       -8.749594096062
+ Nuclear repulsion energy =        8.923565105208
+
+             COSMO energy =        0.079372160248
+
+ Numeric. integr. density =       10.000000962292
+
+     Total iterative time =      0.5s
+
+
+                                   COSMO solvation results
+                                   -----------------------
+
+                 gas phase energy =       -75.844802369795
+                 sol phase energy =       -75.857330035009
+ (electrostatic) solvation energy =         0.012527665214 (    7.86 kcal/mol)
+
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+
+ Vector    1  Occ=2.000000D+00  E=-1.860291D+01  Symmetry=a1
+              MO Center=  2.2D-21,  2.3D-21,  1.3D-01, r^2= 1.5D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.990673  1 O  s          
+
+ Vector    2  Occ=2.000000D+00  E=-8.890872D-01  Symmetry=a1
+              MO Center=  3.3D-18, -9.4D-19, -7.4D-02, r^2= 5.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.458814  1 O  s                  6      0.459531  1 O  s          
+     1     -0.211494  1 O  s          
+
+ Vector    3  Occ=2.000000D+00  E=-4.516446D-01  Symmetry=b1
+              MO Center= -5.0D-18, -1.4D-19, -8.5D-02, r^2= 7.9D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.524505  1 O  px                 7      0.290566  1 O  px         
+    16     -0.223764  2 H  s                 18      0.223764  3 H  s          
+
+ Vector    4  Occ=2.000000D+00  E=-3.166252D-01  Symmetry=a1
+              MO Center=  4.8D-17, -1.4D-17,  2.2D-01, r^2= 6.9D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.552836  1 O  pz                 6      0.392404  1 O  s          
+     9      0.391083  1 O  pz                 2      0.163316  1 O  s          
+
+ Vector    5  Occ=2.000000D+00  E=-2.350034D-01  Symmetry=b2
+              MO Center= -6.3D-17,  3.9D-17,  1.1D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.635185  1 O  py                 8      0.516294  1 O  py         
+
+ Vector    6  Occ=0.000000D+00  E= 5.586308D-02  Symmetry=a1
+              MO Center=  1.1D-16,  5.1D-18, -6.0D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.113958  1 O  s                 17     -0.916841  2 H  s          
+    19     -0.916841  3 H  s                  9     -0.450344  1 O  pz         
+     5     -0.286498  1 O  pz                 2      0.175535  1 O  s          
+
+ Vector    7  Occ=0.000000D+00  E= 1.379717D-01  Symmetry=b1
+              MO Center= -1.1D-16,  3.1D-19, -5.3D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.188703  2 H  s                 19     -1.188703  3 H  s          
+     7      0.704081  1 O  px                 3      0.446157  1 O  px         
+
+ Vector    8  Occ=0.000000D+00  E= 7.359920D-01  Symmetry=b1
+              MO Center= -1.2D-16, -4.2D-33, -1.6D-01, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.828982  2 H  s                 18     -0.828982  3 H  s          
+    17     -0.699609  2 H  s                 19      0.699609  3 H  s          
+     7      0.403926  1 O  px                12      0.360835  1 O  dxz        
+
+ Vector    9  Occ=0.000000D+00  E= 7.892495D-01  Symmetry=a1
+              MO Center=  8.3D-18, -1.0D-16,  2.6D-01, r^2= 1.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.866925  1 O  pz                 9     -0.703837  1 O  pz         
+     6     -0.474123  1 O  s                 16      0.443642  2 H  s          
+    18      0.443642  3 H  s                 17     -0.357912  2 H  s          
+    19     -0.357912  3 H  s                  2      0.253260  1 O  s          
+    10      0.213028  1 O  dxx        
+
+ Vector   10  Occ=0.000000D+00  E= 8.180714D-01  Symmetry=b2
+              MO Center= -1.8D-17, -3.0D-17,  1.3D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8     -1.033733  1 O  py                 4      0.965669  1 O  py         
+
+ Vector   11  Occ=0.000000D+00  E= 8.432327D-01  Symmetry=a1
+              MO Center=  6.7D-17,  7.3D-17, -1.5D-01, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.329393  1 O  s                  2     -0.791696  1 O  s          
+    16      0.718049  2 H  s                 18      0.718049  3 H  s          
+    17     -0.598284  2 H  s                 19     -0.598284  3 H  s          
+     9      0.568035  1 O  pz                13     -0.342728  1 O  dyy        
+     5     -0.230653  1 O  pz                15     -0.229490  1 O  dzz        
+
+ Vector   12  Occ=0.000000D+00  E= 9.907443D-01  Symmetry=b1
+              MO Center= -3.2D-16,  1.4D-18,  8.7D-02, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      1.626566  1 O  px                 3     -0.976669  1 O  px         
+    17      0.952921  2 H  s                 19     -0.952921  3 H  s          
+
+ Vector   13  Occ=0.000000D+00  E= 1.139770D+00  Symmetry=a1
+              MO Center=  4.6D-16,  3.1D-17, -3.6D-01, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.540347  1 O  s                  2     -1.453715  1 O  s          
+     9     -1.095202  1 O  pz                17     -0.771793  2 H  s          
+    19     -0.771793  3 H  s                 10     -0.654064  1 O  dxx        
+     5      0.403573  1 O  pz                15     -0.391542  1 O  dzz        
+    16     -0.338231  2 H  s                 18     -0.338231  3 H  s          
+
+ Vector   14  Occ=0.000000D+00  E= 1.657390D+00  Symmetry=a1
+              MO Center= -2.3D-17,  3.1D-17,  1.8D-01, r^2= 6.2D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      1.006915  1 O  dzz               10     -0.599483  1 O  dxx        
+    13     -0.339763  1 O  dyy                6     -0.246228  1 O  s          
+
+ Vector   15  Occ=0.000000D+00  E= 1.675668D+00  Symmetry=a2
+              MO Center= -1.0D-16,  9.2D-17,  1.3D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.732051  1 O  dxy        
+
+ Vector   16  Occ=0.000000D+00  E= 1.708029D+00  Symmetry=b2
+              MO Center=  1.8D-16, -3.2D-17,  1.5D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      1.731012  1 O  dyz        
+
+ Vector   17  Occ=0.000000D+00  E= 2.187730D+00  Symmetry=a1
+              MO Center=  8.2D-17,  1.8D-20,  1.0D-02, r^2= 8.3D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.483455  1 O  s                 13     -1.121011  1 O  dyy        
+    16     -0.788008  2 H  s                 18     -0.788008  3 H  s          
+    10      0.725421  1 O  dxx                9     -0.719521  1 O  pz         
+     2     -0.520837  1 O  s          
+
+ Vector   18  Occ=0.000000D+00  E= 2.471924D+00  Symmetry=b1
+              MO Center=  2.5D-17, -9.4D-17,  6.5D-02, r^2= 8.7D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      2.165149  1 O  dxz               16     -0.896799  2 H  s          
+    18      0.896799  3 H  s                  7     -0.812424  1 O  px         
+
+ Vector   19  Occ=0.000000D+00  E= 3.457278D+00  Symmetry=a1
+              MO Center= -2.5D-17,  1.6D-18,  1.3D-01, r^2= 1.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.677990  1 O  s                 13     -1.581316  1 O  dyy        
+    15     -1.544730  1 O  dzz               10     -1.517026  1 O  dxx        
+    17     -0.549495  2 H  s                 19     -0.549495  3 H  s          
+     1     -0.470708  1 O  s                  9     -0.339796  1 O  pz         
+     2      0.286766  1 O  s          
+
+ Line search: 
+     step= 1.00 grad=-2.3D-03 hess= 1.6D-03 energy=    -75.857330 mode=downhill
+ new step= 0.71                   predicted energy=    -75.857466
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+          --------
+          Step   1
+          --------
+
+
+                         Geometry "geometry" -> "geometry"
+                         ---------------------------------
+
+ Output coordinates in a.u. (scale by  1.000000000 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 O                    8.0000     0.00000000     0.00000000     0.24252193
+    2 H                    1.0000    -1.45556043     0.00000000    -0.89616096
+    3 H                    1.0000     1.45556043     0.00000000    -0.89616096
+
+      Atomic Mass 
+      ----------- 
+
+      O                 15.994910
+      H                  1.007825
+
+
+ Effective nuclear repulsion energy (a.u.)       9.0013277179
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.1478534800
+
+      Symmetry information
+      --------------------
+
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     2
+
+      Symmetry unique atoms
+
+     1    2
+
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1         10
+        a2          1
+        b1          5
+        b2          3
+
+
+ solvent parameters
+ solvname_short: h2o     
+ solvname_long:  water                              
+ dielec:       78.4000
+ dielecinf:     1.7769
+
+          ---------------
+          -cosmo- solvent
+          ---------------
+ Cosmo: York-Karplus, doi: 10.1021/jp992097l
+ dielectric constant -eps-     =  78.40
+ screen = (eps-1)/(eps    )    =   0.98724
+ surface charge correction     = lagrangian
+
+ solvent accessible surface
+ --------------------------
+
+ ---------- ATOMIC COORDINATES (A.U.) ------------ VDWR(ANG.) --
+     1    0.00000000    0.00000000    0.24252193     1.720
+     2   -1.45556043    0.00000000   -0.89616096     1.300
+     3    1.45556043    0.00000000   -0.89616096     1.300
+ number of segments per atom =         32
+ number of   points per atom =         32
+ atom (   nspa,  nppa )
+ ----------------------
+    1 (     20,     0 )       0
+    2 (     20,     0 )       0
+    3 (     20,     0 )       0
+ number of -cosmo- surface points =       60
+ molecular surface =     41.033 angstrom**2
+ molecular volume  =     21.025 angstrom**3
+ G(cav/disp)       =      1.065 kcal/mol
+ -lineq- algorithm             =   0
+ -bem- low  level              =   2
+ -bem- from -octahedral-
+ gaussian surface charge width =   4.50000
+ degree of switching           =   1.00000
+ switching function tolerance  =   0.00010
+ atomic radii = 
+ --------------
+    1  8.000  1.720
+    2  1.000  1.300
+    3  1.000  1.300
+ ...... end of -cosmo- initialization ......
+
+
+  Caching 1-el integrals 
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+ Loading old vectors from job with title :
+
+
+
+
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+
+  Numbering of irreducible representations: 
+
+     1 a1          2 a2          3 b1          4 b2      
+
+  Orbital symmetries:
+
+     1 a1          2 a1          3 b1          4 a1          5 b2      
+     6 a1          7 b1          8 b1          9 a1         10 b2      
+    11 a1         12 b1         13 a1         14 a1         15 a2      
+
+
+
+ ----------------------------------------------
+         Quadratically convergent ROKS
+
+ Convergence threshold     :          5.000E-04
+ Maximum no. of iterations :           50
+ Final Fock-matrix accuracy:          1.000E-08
+
+ PCG initial level shift   :              5.000
+ PCG change shift at maxg  :              0.500
+ PCG final level shift     :              0.000
+ NR  initial level shift   :              0.000
+ NR  change shift at maxg  :              0.000
+ NR  final level shift     :              0.000
+ NR  enabled at maxg       :              0.000
+ ----------------------------------------------
+
+     COSMO gas phase
+
+ Grid_pts file          = ./h2o_cg_opt_dat.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =      9        Max. recs in file   = 506625431
+
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8435957094  1.18D-01  5.47D-02      1.3
+                 2      -75.8448463185  5.17D-02  2.69D-02      1.3
+                 3      -75.8449714054  9.63D-03  3.69D-03      1.4
+                 4      -75.8449776191  1.55D-03  6.98D-04      1.4
+                 5      -75.8449777352  3.37D-04  1.50D-04      1.5
+     COSMO solvation phase
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8560991351  1.03D-01  5.20D-02      1.5
+                 2      -75.8572627378  6.02D-02  3.20D-02      1.6
+                 3      -75.8574442434  9.93D-03  4.98D-03      1.6
+                 4      -75.8574503565  1.63D-03  6.24D-04      1.7
+                 5      -75.8574504794  2.95D-04  1.42D-04      1.7
+
+
+         Total DFT energy =      -75.857450479356
+      One electron energy =     -122.889985540987
+           Coulomb energy =       46.710905880027
+    Exchange-Corr. energy =       -8.757099103119
+ Nuclear repulsion energy =        9.001327717931
+
+             COSMO energy =        0.077400566791
+
+ Numeric. integr. density =       10.000001191674
+
+     Total iterative time =      0.5s
+
+
+                                   COSMO solvation results
+                                   -----------------------
+
+                 gas phase energy =       -75.844977735163
+                 sol phase energy =       -75.857450479356
+ (electrostatic) solvation energy =         0.012472744193 (    7.83 kcal/mol)
+
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+
+ Vector    1  Occ=2.000000D+00  E=-1.860160D+01  Symmetry=a1
+              MO Center=  1.5D-21,  2.1D-21,  1.3D-01, r^2= 1.5D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.990660  1 O  s          
+
+ Vector    2  Occ=2.000000D+00  E=-8.923186D-01  Symmetry=a1
+              MO Center= -2.8D-18,  1.2D-18, -7.9D-02, r^2= 5.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.458647  1 O  s                  6      0.455757  1 O  s          
+     1     -0.211244  1 O  s          
+
+ Vector    3  Occ=2.000000D+00  E=-4.548772D-01  Symmetry=b1
+              MO Center=  1.6D-17, -2.1D-20, -8.7D-02, r^2= 7.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.525532  1 O  px                 7      0.289012  1 O  px         
+    16     -0.224600  2 H  s                 18      0.224600  3 H  s          
+
+ Vector    4  Occ=2.000000D+00  E=-3.166915D-01  Symmetry=a1
+              MO Center= -3.6D-18, -1.7D-19,  2.2D-01, r^2= 6.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.553924  1 O  pz                 6      0.392911  1 O  s          
+     9      0.391961  1 O  pz                 2      0.163408  1 O  s          
+
+ Vector    5  Occ=2.000000D+00  E=-2.356585D-01  Symmetry=b2
+              MO Center= -6.5D-17,  1.6D-17,  1.1D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.635105  1 O  py                 8      0.516366  1 O  py         
+
+ Vector    6  Occ=0.000000D+00  E= 5.869943D-02  Symmetry=a1
+              MO Center=  1.0D-16,  3.1D-18, -6.0D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.131955  1 O  s                 17     -0.925565  2 H  s          
+    19     -0.925565  3 H  s                  9     -0.448869  1 O  pz         
+     5     -0.282018  1 O  pz                 2      0.175351  1 O  s          
+
+ Vector    7  Occ=0.000000D+00  E= 1.416904D-01  Symmetry=b1
+              MO Center= -6.4D-17, -7.2D-20, -5.4D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.206754  2 H  s                 19     -1.206754  3 H  s          
+     7      0.709166  1 O  px                 3      0.443895  1 O  px         
+
+ Vector    8  Occ=0.000000D+00  E= 7.394454D-01  Symmetry=b1
+              MO Center=  4.7D-17, -6.6D-21, -1.5D-01, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.829800  2 H  s                 18     -0.829800  3 H  s          
+    17     -0.673483  2 H  s                 19      0.673483  3 H  s          
+     7      0.438694  1 O  px                12      0.360965  1 O  dxz        
+
+ Vector    9  Occ=0.000000D+00  E= 7.928105D-01  Symmetry=a1
+              MO Center= -6.3D-17,  1.4D-16,  3.3D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.884982  1 O  pz                 9     -0.744083  1 O  pz         
+     6     -0.561417  1 O  s                 16      0.389474  2 H  s          
+    18      0.389474  3 H  s                 17     -0.310790  2 H  s          
+    19     -0.310790  3 H  s                  2      0.301302  1 O  s          
+    10      0.217539  1 O  dxx        
+
+ Vector   10  Occ=0.000000D+00  E= 8.180601D-01  Symmetry=b2
+              MO Center= -1.8D-17, -2.2D-16,  1.3D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8     -1.033693  1 O  py                 4      0.965719  1 O  py         
+
+ Vector   11  Occ=0.000000D+00  E= 8.470771D-01  Symmetry=a1
+              MO Center=  1.9D-16,  2.8D-17, -2.2D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.254846  1 O  s                  2     -0.763001  1 O  s          
+    16      0.752995  2 H  s                 18      0.752995  3 H  s          
+    17     -0.610715  2 H  s                 19     -0.610715  3 H  s          
+     9      0.530480  1 O  pz                13     -0.338561  1 O  dyy        
+    15     -0.218754  1 O  dzz                5     -0.167653  1 O  pz         
+
+ Vector   12  Occ=0.000000D+00  E= 9.931619D-01  Symmetry=b1
+              MO Center= -1.2D-16, -3.3D-20,  7.2D-02, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      1.630808  1 O  px                 3     -0.979148  1 O  px         
+    17      0.974983  2 H  s                 19     -0.974983  3 H  s          
+
+ Vector   13  Occ=0.000000D+00  E= 1.140662D+00  Symmetry=a1
+              MO Center= -4.2D-16,  2.7D-17, -3.6D-01, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.581103  1 O  s                  2     -1.465255  1 O  s          
+     9     -1.091124  1 O  pz                17     -0.788815  2 H  s          
+    19     -0.788815  3 H  s                 10     -0.655224  1 O  dxx        
+     5      0.397122  1 O  pz                15     -0.391010  1 O  dzz        
+    16     -0.331547  2 H  s                 18     -0.331547  3 H  s          
+
+ Vector   14  Occ=0.000000D+00  E= 1.656131D+00  Symmetry=a1
+              MO Center= -1.3D-17,  3.1D-17,  1.8D-01, r^2= 6.2D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      1.007940  1 O  dzz               10     -0.594495  1 O  dxx        
+    13     -0.344946  1 O  dyy                6     -0.252697  1 O  s          
+
+ Vector   15  Occ=0.000000D+00  E= 1.673568D+00  Symmetry=a2
+              MO Center= -1.0D-16,  9.4D-17,  1.3D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.732051  1 O  dxy        
+
+ Vector   16  Occ=0.000000D+00  E= 1.706941D+00  Symmetry=b2
+              MO Center=  1.8D-16, -2.4D-17,  1.5D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      1.730992  1 O  dyz        
+
+ Vector   17  Occ=0.000000D+00  E= 2.197783D+00  Symmetry=a1
+              MO Center=  2.0D-17,  7.3D-19,  5.9D-03, r^2= 8.4D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.515429  1 O  s                 13     -1.123456  1 O  dyy        
+    16     -0.803326  2 H  s                 18     -0.803326  3 H  s          
+     9     -0.730171  1 O  pz                10      0.732675  1 O  dxx        
+     2     -0.521339  1 O  s          
+
+ Vector   18  Occ=0.000000D+00  E= 2.486818D+00  Symmetry=b1
+              MO Center=  7.5D-17, -9.4D-17,  6.4D-02, r^2= 8.7D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      2.181715  1 O  dxz               16     -0.913479  2 H  s          
+    18      0.913479  3 H  s                  7     -0.831804  1 O  px         
+
+ Vector   19  Occ=0.000000D+00  E= 3.461915D+00  Symmetry=a1
+              MO Center= -1.4D-16,  1.3D-18,  1.2D-01, r^2= 1.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.699264  1 O  s                 13     -1.582138  1 O  dyy        
+    15     -1.548894  1 O  dzz               10     -1.522705  1 O  dxx        
+    17     -0.557126  2 H  s                 19     -0.557126  3 H  s          
+     1     -0.471564  1 O  s                  9     -0.339680  1 O  pz         
+     2      0.281652  1 O  s          
+
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+
+                            NWChem DFT Gradient Module
+                            --------------------------
+
+
+
+  charge          =   0.00
+  wavefunction    = closed shell
+
+XC gradient
+    -0.655704    -0.438780     0.315530
+     0.115389     0.020855     0.040375
+     0.540315     0.417925    -0.355905
+
+CD gradient
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+
+   1  -0.655704  -0.438780   0.315530
+   2   0.115389   0.020855   0.040375
+   3   0.540315   0.417925  -0.355905
+  Using symmetry
+
+
+                         DFT ENERGY GRADIENTS
+
+    atom               coordinates                        gradient
+                 x          y          z           x          y          z
+   1 O       0.000000   0.000000   0.242522    0.000000   0.000000  -0.002239
+   2 H      -1.455560   0.000000  -0.896161   -0.001277   0.000000   0.001120
+   3 H       1.455560   0.000000  -0.896161    0.001277   0.000000   0.001120
+
+                 ----------------------------------------
+                 |  Time  |  1-e(secs)   |  2-e(secs)   |
+                 ----------------------------------------
+                 |  CPU   |       0.00   |       0.02   |
+                 ----------------------------------------
+                 |  WALL  |       0.00   |       0.02   |
+                 ----------------------------------------
+  no constraints, skipping    0.0000000000000000     
+
+  Step       Energy      Delta E   Gmax     Grms     Xrms     Xmax   Walltime
+  ---- ---------------- -------- -------- -------- -------- -------- --------
+@    1     -75.85745048 -8.0D-04  0.00163  0.00098  0.01476  0.02530      1.8
+                                                                    
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value     Gradient
+      ----------- --------  ----- ----- ----- ----- ----- ---------- ----------
+    1 Stretch                  1     2                       0.97794    0.00032
+    2 Stretch                  1     3                       0.97794    0.00032
+    3 Bend                     2     1     3               103.92796    0.00163
+
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1         10
+        a2          1
+        b1          5
+        b2          3
+
+
+ solvent parameters
+ solvname_short: h2o     
+ solvname_long:  water                              
+ dielec:       78.4000
+ dielecinf:     1.7769
+
+          ---------------
+          -cosmo- solvent
+          ---------------
+ Cosmo: York-Karplus, doi: 10.1021/jp992097l
+ dielectric constant -eps-     =  78.40
+ screen = (eps-1)/(eps    )    =   0.98724
+ surface charge correction     = lagrangian
+
+ solvent accessible surface
+ --------------------------
+
+ ---------- ATOMIC COORDINATES (A.U.) ------------ VDWR(ANG.) --
+     1    0.00000000    0.00000000    0.25142265     1.720
+     2   -1.44553950    0.00000000   -0.90061132     1.300
+     3    1.44553950    0.00000000   -0.90061132     1.300
+ number of segments per atom =         32
+ number of   points per atom =         32
+ atom (   nspa,  nppa )
+ ----------------------
+    1 (     20,     0 )       0
+    2 (     20,     0 )       0
+    3 (     20,     0 )       0
+ number of -cosmo- surface points =       60
+ molecular surface =     41.009 angstrom**2
+ molecular volume  =     21.019 angstrom**3
+ G(cav/disp)       =      1.065 kcal/mol
+ -lineq- algorithm             =   0
+ -bem- low  level              =   2
+ -bem- from -octahedral-
+ gaussian surface charge width =   4.50000
+ degree of switching           =   1.00000
+ switching function tolerance  =   0.00010
+ atomic radii = 
+ --------------
+    1  8.000  1.720
+    2  1.000  1.300
+    3  1.000  1.300
+ ...... end of -cosmo- initialization ......
+
+
+  Caching 1-el integrals 
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+ Loading old vectors from job with title :
+
+
+
+
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+
+  Numbering of irreducible representations: 
+
+     1 a1          2 a2          3 b1          4 b2      
+
+  Orbital symmetries:
+
+     1 a1          2 a1          3 b1          4 a1          5 b2      
+     6 a1          7 b1          8 b1          9 a1         10 b2      
+    11 a1         12 b1         13 a1         14 a1         15 a2      
+
+
+
+ ----------------------------------------------
+         Quadratically convergent ROKS
+
+ Convergence threshold     :          5.000E-04
+ Maximum no. of iterations :           50
+ Final Fock-matrix accuracy:          1.000E-08
+
+ PCG initial level shift   :              5.000
+ PCG change shift at maxg  :              0.500
+ PCG final level shift     :              0.000
+ NR  initial level shift   :              0.000
+ NR  change shift at maxg  :              0.000
+ NR  final level shift     :              0.000
+ NR  enabled at maxg       :              0.000
+ ----------------------------------------------
+
+     COSMO gas phase
+
+ Grid_pts file          = ./h2o_cg_opt_dat.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =      9        Max. recs in file   = 506625431
+
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8433516027  1.21D-01  6.00D-02      1.9
+                 2      -75.8447658835  6.20D-02  3.34D-02      1.9
+                 3      -75.8449608951  9.80D-03  5.01D-03      1.9
+                 4      -75.8449676973  1.81D-03  7.01D-04      2.0
+                 5      -75.8449678525  6.88D-04  3.01D-04      2.0
+                 6      -75.8449678702  8.49D-05  4.52D-05      2.1
+     COSMO solvation phase
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8561074720  1.04D-01  5.25D-02      2.1
+                 2      -75.8572871869  6.10D-02  3.26D-02      2.2
+                 3      -75.8574738434  1.01D-02  5.05D-03      2.2
+                 4      -75.8574801578  1.66D-03  6.36D-04      2.3
+                 5      -75.8574802844  3.12D-04  1.50D-04      2.3
+
+
+         Total DFT energy =      -75.857480284385
+      One electron energy =     -122.887667810081
+           Coulomb energy =       46.707976768509
+    Exchange-Corr. energy =       -8.756884770389
+ Nuclear repulsion energy =        9.001793377234
+
+             COSMO energy =        0.077302150342
+
+ Numeric. integr. density =       10.000000808472
+
+     Total iterative time =      0.5s
+
+
+                                   COSMO solvation results
+                                   -----------------------
+
+                 gas phase energy =       -75.844967870166
+                 sol phase energy =       -75.857480284385
+ (electrostatic) solvation energy =         0.012512414219 (    7.85 kcal/mol)
+
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+
+ Vector    1  Occ=2.000000D+00  E=-1.860204D+01  Symmetry=a1
+              MO Center=  1.8D-21,  2.6D-21,  1.3D-01, r^2= 1.5D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.990662  1 O  s          
+
+ Vector    2  Occ=2.000000D+00  E=-8.930646D-01  Symmetry=a1
+              MO Center= -1.1D-17,  1.2D-18, -7.7D-02, r^2= 5.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.458314  1 O  s                  6      0.455252  1 O  s          
+     1     -0.211072  1 O  s          
+
+ Vector    3  Occ=2.000000D+00  E=-4.530797D-01  Symmetry=b1
+              MO Center=  4.4D-17, -1.2D-19, -8.4D-02, r^2= 7.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.526050  1 O  px                 7      0.290049  1 O  px         
+    16     -0.224012  2 H  s                 18      0.224012  3 H  s          
+
+ Vector    4  Occ=2.000000D+00  E=-3.186814D-01  Symmetry=a1
+              MO Center=  5.7D-18, -3.5D-19,  2.3D-01, r^2= 6.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.552588  1 O  pz                 6      0.395342  1 O  s          
+     9      0.389820  1 O  pz                 2      0.165048  1 O  s          
+
+ Vector    5  Occ=2.000000D+00  E=-2.359051D-01  Symmetry=b2
+              MO Center= -6.6D-17,  1.6D-17,  1.1D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.635193  1 O  py                 8      0.516262  1 O  py         
+
+ Vector    6  Occ=0.000000D+00  E= 5.863426D-02  Symmetry=a1
+              MO Center= -6.9D-17,  3.4D-18, -6.0D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.128348  1 O  s                 17     -0.924272  2 H  s          
+    19     -0.924272  3 H  s                  9     -0.452211  1 O  pz         
+     5     -0.284122  1 O  pz                 2      0.174723  1 O  s          
+
+ Vector    7  Occ=0.000000D+00  E= 1.413003D-01  Symmetry=b1
+              MO Center= -9.2D-18, -7.3D-20, -5.4D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.207673  2 H  s                 19     -1.207673  3 H  s          
+     7      0.706806  1 O  px                 3      0.443831  1 O  px         
+
+ Vector    8  Occ=0.000000D+00  E= 7.358629D-01  Symmetry=b1
+              MO Center= -1.4D-16, -1.6D-19, -1.5D-01, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.828431  2 H  s                 18     -0.828431  3 H  s          
+    17     -0.678043  2 H  s                 19      0.678043  3 H  s          
+     7      0.439217  1 O  px                12      0.357988  1 O  dxz        
+
+ Vector    9  Occ=0.000000D+00  E= 7.930598D-01  Symmetry=a1
+              MO Center=  4.2D-17,  1.5D-16,  3.6D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.891419  1 O  pz                 9     -0.762376  1 O  pz         
+     6     -0.591041  1 O  s                 16      0.364907  2 H  s          
+    18      0.364907  3 H  s                  2      0.321964  1 O  s          
+    17     -0.294628  2 H  s                 19     -0.294628  3 H  s          
+    10      0.216083  1 O  dxx               15      0.153904  1 O  dzz        
+
+ Vector   10  Occ=0.000000D+00  E= 8.178739D-01  Symmetry=b2
+              MO Center= -1.8D-17, -2.3D-16,  1.3D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8     -1.033735  1 O  py                 4      0.965662  1 O  py         
+
+ Vector   11  Occ=0.000000D+00  E= 8.502168D-01  Symmetry=a1
+              MO Center= -9.2D-17,  2.7D-17, -2.5D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.287230  1 O  s                  2     -0.775939  1 O  s          
+    16      0.761168  2 H  s                 18      0.761168  3 H  s          
+    17     -0.627953  2 H  s                 19     -0.627953  3 H  s          
+     9      0.493788  1 O  pz                13     -0.344040  1 O  dyy        
+    15     -0.216424  1 O  dzz        
+
+ Vector   12  Occ=0.000000D+00  E= 9.922407D-01  Symmetry=b1
+              MO Center=  2.3D-16, -2.8D-31,  7.3D-02, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      1.622995  1 O  px                 3     -0.979214  1 O  px         
+    17      0.977808  2 H  s                 19     -0.977808  3 H  s          
+
+ Vector   13  Occ=0.000000D+00  E= 1.144320D+00  Symmetry=a1
+              MO Center=  2.1D-16,  2.1D-17, -3.6D-01, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.562936  1 O  s                  2     -1.452996  1 O  s          
+     9     -1.107454  1 O  pz                17     -0.778185  2 H  s          
+    19     -0.778185  3 H  s                 10     -0.655120  1 O  dxx        
+     5      0.397309  1 O  pz                15     -0.393311  1 O  dzz        
+    16     -0.348088  2 H  s                 18     -0.348088  3 H  s          
+
+ Vector   14  Occ=0.000000D+00  E= 1.653145D+00  Symmetry=a1
+              MO Center= -1.1D-17,  3.2D-17,  1.8D-01, r^2= 6.2D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      1.004379  1 O  dzz               10     -0.611017  1 O  dxx        
+    13     -0.325741  1 O  dyy                6     -0.249319  1 O  s          
+
+ Vector   15  Occ=0.000000D+00  E= 1.674424D+00  Symmetry=a2
+              MO Center= -1.0D-16,  9.2D-17,  1.3D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.732051  1 O  dxy        
+
+ Vector   16  Occ=0.000000D+00  E= 1.705773D+00  Symmetry=b2
+              MO Center=  1.9D-16, -2.2D-17,  1.6D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      1.730973  1 O  dyz        
+
+ Vector   17  Occ=0.000000D+00  E= 2.197562D+00  Symmetry=a1
+              MO Center= -6.8D-17, -1.2D-18,  6.8D-03, r^2= 8.4D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.526827  1 O  s                 13     -1.130176  1 O  dyy        
+    16     -0.806040  2 H  s                 18     -0.806040  3 H  s          
+     9     -0.742567  1 O  pz                10      0.714229  1 O  dxx        
+     2     -0.525611  1 O  s          
+
+ Vector   18  Occ=0.000000D+00  E= 2.484624D+00  Symmetry=b1
+              MO Center=  6.0D-18, -9.2D-17,  6.9D-02, r^2= 8.7D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      2.182533  1 O  dxz               16     -0.909879  2 H  s          
+    18      0.909879  3 H  s                  7     -0.817343  1 O  px         
+
+ Vector   19  Occ=0.000000D+00  E= 3.460042D+00  Symmetry=a1
+              MO Center=  1.3D-17,  1.2D-18,  1.3D-01, r^2= 1.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.695417  1 O  s                 13     -1.582292  1 O  dyy        
+    15     -1.547100  1 O  dzz               10     -1.521740  1 O  dxx        
+    17     -0.554989  2 H  s                 19     -0.554989  3 H  s          
+     1     -0.471384  1 O  s                  9     -0.343535  1 O  pz         
+     2      0.282534  1 O  s          
+
+ Line search: 
+     step= 1.00 grad=-5.5D-05 hess= 2.6D-05 energy=    -75.857480 mode=accept  
+ new step= 1.00                   predicted energy=    -75.857480
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+          --------
+          Step   2
+          --------
+
+
+                         Geometry "geometry" -> "geometry"
+                         ---------------------------------
+
+ Output coordinates in a.u. (scale by  1.000000000 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 O                    8.0000     0.00000000     0.00000000     0.25142265
+    2 H                    1.0000    -1.44553950     0.00000000    -0.90061132
+    3 H                    1.0000     1.44553950     0.00000000    -0.90061132
+
+      Atomic Mass 
+      ----------- 
+
+      O                 15.994910
+      H                  1.007825
+
+
+ Effective nuclear repulsion energy (a.u.)       9.0017933772
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.2101585260
+
+      Symmetry information
+      --------------------
+
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     2
+
+      Symmetry unique atoms
+
+     1    2
+
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1         10
+        a2          1
+        b1          5
+        b2          3
+
+
+ solvent parameters
+ solvname_short: h2o     
+ solvname_long:  water                              
+ dielec:       78.4000
+ dielecinf:     1.7769
+
+          ---------------
+          -cosmo- solvent
+          ---------------
+ Cosmo: York-Karplus, doi: 10.1021/jp992097l
+ dielectric constant -eps-     =  78.40
+ screen = (eps-1)/(eps    )    =   0.98724
+ surface charge correction     = lagrangian
+
+ solvent accessible surface
+ --------------------------
+
+ ---------- ATOMIC COORDINATES (A.U.) ------------ VDWR(ANG.) --
+     1    0.00000000    0.00000000    0.25142265     1.720
+     2   -1.44553950    0.00000000   -0.90061132     1.300
+     3    1.44553950    0.00000000   -0.90061132     1.300
+ number of segments per atom =         32
+ number of   points per atom =         32
+ atom (   nspa,  nppa )
+ ----------------------
+    1 (     20,     0 )       0
+    2 (     20,     0 )       0
+    3 (     20,     0 )       0
+ number of -cosmo- surface points =       60
+ molecular surface =     41.009 angstrom**2
+ molecular volume  =     21.019 angstrom**3
+ G(cav/disp)       =      1.065 kcal/mol
+ -lineq- algorithm             =   0
+ -bem- low  level              =   2
+ -bem- from -octahedral-
+ gaussian surface charge width =   4.50000
+ degree of switching           =   1.00000
+ switching function tolerance  =   0.00010
+ atomic radii = 
+ --------------
+    1  8.000  1.720
+    2  1.000  1.300
+    3  1.000  1.300
+ ...... end of -cosmo- initialization ......
+
+
+
+  The DFT is already converged 
+
+         Total DFT energy =    -75.857480284385
+
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+
+                            NWChem DFT Gradient Module
+                            --------------------------
+
+
+
+  charge          =   0.00
+  wavefunction    = closed shell
+
+XC gradient
+    -0.654125    -0.440380     0.320906
+     0.117554     0.021442     0.041229
+     0.536571     0.418937    -0.362135
+
+CD gradient
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+
+   1  -0.654125  -0.440380   0.320906
+   2   0.117554   0.021442   0.041229
+   3   0.536571   0.418937  -0.362135
+  Using symmetry
+
+
+                         DFT ENERGY GRADIENTS
+
+    atom               coordinates                        gradient
+                 x          y          z           x          y          z
+   1 O       0.000000   0.000000   0.251423    0.000000   0.000000  -0.000167
+   2 H      -1.445540   0.000000  -0.900611   -0.000089   0.000000   0.000083
+   3 H       1.445540   0.000000  -0.900611    0.000089   0.000000   0.000083
+
+                 ----------------------------------------
+                 |  Time  |  1-e(secs)   |  2-e(secs)   |
+                 ----------------------------------------
+                 |  CPU   |       0.00   |       0.02   |
+                 ----------------------------------------
+                 |  WALL  |       0.00   |       0.02   |
+                 ----------------------------------------
+  no constraints, skipping    0.0000000000000000     
+
+  Step       Energy      Delta E   Gmax     Grms     Xrms     Xmax   Walltime
+  ---- ---------------- -------- -------- -------- -------- -------- --------
+@    2     -75.85748028 -3.0D-05  0.00012  0.00007  0.00598  0.01008      2.5
+                                     ok       ok                    
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value     Gradient
+      ----------- --------  ----- ----- ----- ----- ----- ---------- ----------
+    1 Stretch                  1     2                       0.97816    0.00002
+    2 Stretch                  1     3                       0.97816    0.00002
+    3 Bend                     2     1     3               102.89327    0.00012
+
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1         10
+        a2          1
+        b1          5
+        b2          3
+
+
+ solvent parameters
+ solvname_short: h2o     
+ solvname_long:  water                              
+ dielec:       78.4000
+ dielecinf:     1.7769
+
+          ---------------
+          -cosmo- solvent
+          ---------------
+ Cosmo: York-Karplus, doi: 10.1021/jp992097l
+ dielectric constant -eps-     =  78.40
+ screen = (eps-1)/(eps    )    =   0.98724
+ surface charge correction     = lagrangian
+
+ solvent accessible surface
+ --------------------------
+
+ ---------- ATOMIC COORDINATES (A.U.) ------------ VDWR(ANG.) --
+     1    0.00000000    0.00000000    0.25212217     1.720
+     2   -1.44475675    0.00000000   -0.90096108     1.300
+     3    1.44475675    0.00000000   -0.90096108     1.300
+ number of segments per atom =         32
+ number of   points per atom =         32
+ atom (   nspa,  nppa )
+ ----------------------
+    1 (     20,     0 )       0
+    2 (     20,     0 )       0
+    3 (     20,     0 )       0
+ number of -cosmo- surface points =       60
+ molecular surface =     41.007 angstrom**2
+ molecular volume  =     21.018 angstrom**3
+ G(cav/disp)       =      1.065 kcal/mol
+ -lineq- algorithm             =   0
+ -bem- low  level              =   2
+ -bem- from -octahedral-
+ gaussian surface charge width =   4.50000
+ degree of switching           =   1.00000
+ switching function tolerance  =   0.00010
+ atomic radii = 
+ --------------
+    1  8.000  1.720
+    2  1.000  1.300
+    3  1.000  1.300
+ ...... end of -cosmo- initialization ......
+
+
+  Caching 1-el integrals 
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+ Loading old vectors from job with title :
+
+
+
+
+      Symmetry analysis of molecular orbitals - initial
+      -------------------------------------------------
+
+  Numbering of irreducible representations: 
+
+     1 a1          2 a2          3 b1          4 b2      
+
+  Orbital symmetries:
+
+     1 a1          2 a1          3 b1          4 a1          5 b2      
+     6 a1          7 b1          8 b1          9 a1         10 b2      
+    11 a1         12 b1         13 a1         14 a1         15 a2      
+
+
+
+ ----------------------------------------------
+         Quadratically convergent ROKS
+
+ Convergence threshold     :          5.000E-04
+ Maximum no. of iterations :           50
+ Final Fock-matrix accuracy:          1.000E-08
+
+ PCG initial level shift   :              5.000
+ PCG change shift at maxg  :              0.500
+ PCG final level shift     :              0.000
+ NR  initial level shift   :              0.000
+ NR  change shift at maxg  :              0.000
+ NR  final level shift     :              0.000
+ NR  enabled at maxg       :              0.000
+ ----------------------------------------------
+
+     COSMO gas phase
+
+ Grid_pts file          = ./h2o_cg_opt_dat.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =      9        Max. recs in file   = 506625431
+
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8434329179  1.17D-01  5.87D-02      2.5
+                 2      -75.8447719393  6.06D-02  3.28D-02      2.5
+                 3      -75.8449583111  9.57D-03  4.37D-03      2.6
+                 4      -75.8449646168  1.76D-03  7.05D-04      2.6
+                 5      -75.8449647627  6.67D-04  2.91D-04      2.7
+                 6      -75.8449647794  8.10D-05  4.25D-05      2.7
+     COSMO solvation phase
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1      -75.8561060147  1.04D-01  5.25D-02      2.7
+                 2      -75.8572870097  6.10D-02  3.26D-02      2.8
+                 3      -75.8574739835  1.01D-02  5.05D-03      2.8
+                 4      -75.8574803138  1.66D-03  6.37D-04      2.9
+                 5      -75.8574804407  3.13D-04  1.51D-04      2.9
+
+
+         Total DFT energy =      -75.857480440738
+      One electron energy =     -122.887402128328
+           Coulomb energy =       46.707706584894
+    Exchange-Corr. energy =       -8.756863080447
+ Nuclear repulsion energy =        9.001782745566
+
+             COSMO energy =        0.077295437577
+
+ Numeric. integr. density =       10.000000776675
+
+     Total iterative time =      0.5s
+
+
+                                   COSMO solvation results
+                                   -----------------------
+
+                 gas phase energy =       -75.844964779387
+                 sol phase energy =       -75.857480440738
+ (electrostatic) solvation energy =         0.012515661351 (    7.85 kcal/mol)
+
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+
+ Vector    1  Occ=2.000000D+00  E=-1.860208D+01  Symmetry=a1
+              MO Center=  3.8D-22,  2.7D-21,  1.3D-01, r^2= 1.5D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.990663  1 O  s          
+
+ Vector    2  Occ=2.000000D+00  E=-8.931214D-01  Symmetry=a1
+              MO Center= -1.8D-17,  1.2D-18, -7.7D-02, r^2= 5.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.458288  1 O  s                  6      0.455215  1 O  s          
+     1     -0.211058  1 O  s          
+
+ Vector    3  Occ=2.000000D+00  E=-4.529359D-01  Symmetry=b1
+              MO Center=  7.2D-17, -1.3D-19, -8.4D-02, r^2= 7.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.526091  1 O  px                 7      0.290131  1 O  px         
+    16     -0.223965  2 H  s                 18      0.223965  3 H  s          
+
+ Vector    4  Occ=2.000000D+00  E=-3.188373D-01  Symmetry=a1
+              MO Center= -6.4D-18, -3.6D-19,  2.3D-01, r^2= 6.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.552483  1 O  pz                 6      0.395531  1 O  s          
+     9      0.389652  1 O  pz                 2      0.165176  1 O  s          
+
+ Vector    5  Occ=2.000000D+00  E=-2.359239D-01  Symmetry=b2
+              MO Center= -6.6D-17,  1.6D-17,  1.1D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.635199  1 O  py                 8      0.516254  1 O  py         
+
+ Vector    6  Occ=0.000000D+00  E= 5.862625D-02  Symmetry=a1
+              MO Center= -1.9D-17,  3.5D-18, -6.0D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.128052  1 O  s                 17     -0.924161  2 H  s          
+    19     -0.924161  3 H  s                  9     -0.452471  1 O  pz         
+     5     -0.284289  1 O  pz                 2      0.174675  1 O  s          
+
+ Vector    7  Occ=0.000000D+00  E= 1.412677D-01  Symmetry=b1
+              MO Center= -1.2D-16,  2.2D-34, -5.4D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.207739  2 H  s                 19     -1.207739  3 H  s          
+     7      0.706617  1 O  px                 3      0.443826  1 O  px         
+
+ Vector    8  Occ=0.000000D+00  E= 7.355853D-01  Symmetry=b1
+              MO Center= -4.7D-17, -1.8D-20, -1.5D-01, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.828324  2 H  s                 18     -0.828324  3 H  s          
+    17     -0.678428  2 H  s                 19      0.678428  3 H  s          
+     7      0.439217  1 O  px                12      0.357758  1 O  dxz        
+
+ Vector    9  Occ=0.000000D+00  E= 7.930716D-01  Symmetry=a1
+              MO Center= -2.0D-17,  1.5D-16,  3.6D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.891831  1 O  pz                 9     -0.763633  1 O  pz         
+     6     -0.593169  1 O  s                 16      0.363151  2 H  s          
+    18      0.363151  3 H  s                  2      0.323452  1 O  s          
+    17     -0.293478  2 H  s                 19     -0.293478  3 H  s          
+    10      0.215973  1 O  dxx               15      0.154518  1 O  dzz        
+
+ Vector   10  Occ=0.000000D+00  E= 8.178594D-01  Symmetry=b2
+              MO Center= -1.8D-17, -2.3D-16,  1.3D-01, r^2= 1.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8     -1.033738  1 O  py                 4      0.965658  1 O  py         
+
+ Vector   11  Occ=0.000000D+00  E= 8.504569D-01  Symmetry=a1
+              MO Center=  2.0D-16,  2.7D-17, -2.5D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.289881  1 O  s                  2     -0.776996  1 O  s          
+    16      0.761672  2 H  s                 18      0.761672  3 H  s          
+    17     -0.629218  2 H  s                 19     -0.629218  3 H  s          
+     9      0.491043  1 O  pz                13     -0.344465  1 O  dyy        
+    15     -0.216257  1 O  dzz        
+
+ Vector   12  Occ=0.000000D+00  E= 9.921686D-01  Symmetry=b1
+              MO Center=  1.4D-16, -1.3D-19,  7.3D-02, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      1.622390  1 O  px                 3     -0.979214  1 O  px         
+    17      0.978016  2 H  s                 19     -0.978016  3 H  s          
+
+ Vector   13  Occ=0.000000D+00  E= 1.144610D+00  Symmetry=a1
+              MO Center= -4.0D-17,  2.0D-17, -3.6D-01, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.561452  1 O  s                  2     -1.452016  1 O  s          
+     9     -1.108722  1 O  pz                17     -0.777336  2 H  s          
+    19     -0.777336  3 H  s                 10     -0.655085  1 O  dxx        
+     5      0.397317  1 O  pz                15     -0.393516  1 O  dzz        
+    16     -0.349382  2 H  s                 18     -0.349382  3 H  s          
+
+ Vector   14  Occ=0.000000D+00  E= 1.652915D+00  Symmetry=a1
+              MO Center= -4.6D-18,  3.2D-17,  1.8D-01, r^2= 6.2D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      1.004075  1 O  dzz               10     -0.612321  1 O  dxx        
+    13     -0.324218  1 O  dyy                6     -0.248998  1 O  s          
+
+ Vector   15  Occ=0.000000D+00  E= 1.674492D+00  Symmetry=a2
+              MO Center= -1.0D-16,  9.2D-17,  1.3D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.732051  1 O  dxy        
+
+ Vector   16  Occ=0.000000D+00  E= 1.705682D+00  Symmetry=b2
+              MO Center=  1.9D-16, -2.2D-17,  1.6D-01, r^2= 6.1D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      1.730972  1 O  dyz        
+
+ Vector   17  Occ=0.000000D+00  E= 2.197557D+00  Symmetry=a1
+              MO Center= -6.6D-18, -1.3D-18,  6.9D-03, r^2= 8.4D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.527709  1 O  s                 13     -1.130690  1 O  dyy        
+    16     -0.806259  2 H  s                 18     -0.806259  3 H  s          
+     9     -0.743540  1 O  pz                10      0.712760  1 O  dxx        
+     2     -0.525945  1 O  s          
+
+ Vector   18  Occ=0.000000D+00  E= 2.484423D+00  Symmetry=b1
+              MO Center=  3.9D-17, -9.2D-17,  7.0D-02, r^2= 8.7D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      2.182571  1 O  dxz               16     -0.909580  2 H  s          
+    18      0.909580  3 H  s                  7     -0.816204  1 O  px         
+
+ Vector   19  Occ=0.000000D+00  E= 3.459891D+00  Symmetry=a1
+              MO Center= -4.2D-16,  1.2D-18,  1.3D-01, r^2= 1.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.695090  1 O  s                 13     -1.582300  1 O  dyy        
+    15     -1.546953  1 O  dzz               10     -1.521663  1 O  dxx        
+    17     -0.554815  2 H  s                 19     -0.554815  3 H  s          
+     1     -0.471369  1 O  s                  9     -0.343832  1 O  pz         
+     2      0.282609  1 O  s          
+
+ Line search: 
+     step= 1.00 grad=-3.2D-07 hess= 1.6D-07 energy=    -75.857480 mode=accept  
+ new step= 1.00                   predicted energy=    -75.857480
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+          --------
+          Step   3
+          --------
+
+
+                         Geometry "geometry" -> "geometry"
+                         ---------------------------------
+
+ Output coordinates in a.u. (scale by  1.000000000 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 O                    8.0000     0.00000000     0.00000000     0.25212217
+    2 H                    1.0000    -1.44475675     0.00000000    -0.90096108
+    3 H                    1.0000     1.44475675     0.00000000    -0.90096108
+
+      Atomic Mass 
+      ----------- 
+
+      O                 15.994910
+      H                  1.007825
+
+
+ Effective nuclear repulsion energy (a.u.)       9.0017827456
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.2150551649
+
+      Symmetry information
+      --------------------
+
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     2
+
+      Symmetry unique atoms
+
+     1    2
+
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ O                           6-31g*                  6       15   3s2p1d
+ H                           6-31g*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1         10
+        a2          1
+        b1          5
+        b2          3
+
+
+ solvent parameters
+ solvname_short: h2o     
+ solvname_long:  water                              
+ dielec:       78.4000
+ dielecinf:     1.7769
+
+          ---------------
+          -cosmo- solvent
+          ---------------
+ Cosmo: York-Karplus, doi: 10.1021/jp992097l
+ dielectric constant -eps-     =  78.40
+ screen = (eps-1)/(eps    )    =   0.98724
+ surface charge correction     = lagrangian
+
+ solvent accessible surface
+ --------------------------
+
+ ---------- ATOMIC COORDINATES (A.U.) ------------ VDWR(ANG.) --
+     1    0.00000000    0.00000000    0.25212217     1.720
+     2   -1.44475675    0.00000000   -0.90096108     1.300
+     3    1.44475675    0.00000000   -0.90096108     1.300
+ number of segments per atom =         32
+ number of   points per atom =         32
+ atom (   nspa,  nppa )
+ ----------------------
+    1 (     20,     0 )       0
+    2 (     20,     0 )       0
+    3 (     20,     0 )       0
+ number of -cosmo- surface points =       60
+ molecular surface =     41.007 angstrom**2
+ molecular volume  =     21.018 angstrom**3
+ G(cav/disp)       =      1.065 kcal/mol
+ -lineq- algorithm             =   0
+ -bem- low  level              =   2
+ -bem- from -octahedral-
+ gaussian surface charge width =   4.50000
+ degree of switching           =   1.00000
+ switching function tolerance  =   0.00010
+ atomic radii = 
+ --------------
+    1  8.000  1.720
+    2  1.000  1.300
+    3  1.000  1.300
+ ...... end of -cosmo- initialization ......
+
+
+
+  The DFT is already converged 
+
+         Total DFT energy =    -75.857480440738
+
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :     3
+          No. of electrons :    10
+           Alpha electrons :     5
+            Beta electrons :     5
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    19
+                     number of shells:    10
+          Convergence on energy requested:  1.00D-06
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+
+              XC Information
+              --------------
+                        Slater Exchange Functional  1.000 local    
+                      VWN V Correlation Functional  1.000 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  medium    
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          O                   0.60       49           5.0       434
+          H                   0.35       45           6.0       434
+          Grid pruning is: on 
+          Number of quadrature shells:    94
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-10
+          AO Gaussian exp screening on grid/accAOfunc:  14
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+
+
+                            NWChem DFT Gradient Module
+                            --------------------------
+
+
+
+  charge          =   0.00
+  wavefunction    = closed shell
+
+XC gradient
+    -0.653996    -0.440502     0.321323
+     0.117725     0.021490     0.041298
+     0.536271     0.419012    -0.362621
+
+CD gradient
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+     0.000000     0.000000     0.000000
+
+   1  -0.653996  -0.440502   0.321323
+   2   0.117725   0.021490   0.041298
+   3   0.536271   0.419012  -0.362621
+  Using symmetry
+
+
+                         DFT ENERGY GRADIENTS
+
+    atom               coordinates                        gradient
+                 x          y          z           x          y          z
+   1 O       0.000000   0.000000   0.252122    0.000000   0.000000   0.000001
+   2 H      -1.444757   0.000000  -0.900961    0.000001   0.000000  -0.000000
+   3 H       1.444757   0.000000  -0.900961   -0.000001   0.000000  -0.000000
+
+                 ----------------------------------------
+                 |  Time  |  1-e(secs)   |  2-e(secs)   |
+                 ----------------------------------------
+                 |  CPU   |       0.00   |       0.02   |
+                 ----------------------------------------
+                 |  WALL  |       0.00   |       0.02   |
+                 ----------------------------------------
+  no constraints, skipping    0.0000000000000000     
+
+  Step       Energy      Delta E   Gmax     Grms     Xrms     Xmax   Walltime
+  ---- ---------------- -------- -------- -------- -------- -------- --------
+@    3     -75.85748044 -1.6D-07  0.00000  0.00000  0.00047  0.00078      3.1
+                                     ok       ok       ok       ok  
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value     Gradient
+      ----------- --------  ----- ----- ----- ----- ----- ---------- ----------
+    1 Stretch                  1     2                       0.97818   -0.00000
+    2 Stretch                  1     3                       0.97818   -0.00000
+    3 Bend                     2     1     3               102.81216   -0.00000
+
+
+      ----------------------
+      Optimization converged
+      ----------------------
+
+
+  Step       Energy      Delta E   Gmax     Grms     Xrms     Xmax   Walltime
+  ---- ---------------- -------- -------- -------- -------- -------- --------
+@    3     -75.85748044 -1.6D-07  0.00000  0.00000  0.00047  0.00078      3.1
+                                     ok       ok       ok       ok  
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value     Gradient
+      ----------- --------  ----- ----- ----- ----- ----- ---------- ----------
+    1 Stretch                  1     2                       0.97818   -0.00000
+    2 Stretch                  1     3                       0.97818   -0.00000
+    3 Bend                     2     1     3               102.81216   -0.00000
+
+
+
+                         Geometry "geometry" -> "geometry"
+                         ---------------------------------
+
+ Output coordinates in a.u. (scale by  1.000000000 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 O                    8.0000     0.00000000     0.00000000     0.25212217
+    2 H                    1.0000    -1.44475675     0.00000000    -0.90096108
+    3 H                    1.0000     1.44475675     0.00000000    -0.90096108
+
+      Atomic Mass 
+      ----------- 
+
+      O                 15.994910
+      H                  1.007825
+
+
+ Effective nuclear repulsion energy (a.u.)       9.0017827456
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.2150551649
+
+      Symmetry information
+      --------------------
+
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     2
+
+      Symmetry unique atoms
+
+     1    2
+
+
+                Final and change from initial internal coordinates
+                --------------------------------------------------
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value       Change
+      ----------- --------  ----- ----- ----- ----- ----- ---------- ----------
+    1 Stretch                  1     2                       0.97818    0.02121
+    2 Stretch                  1     3                       0.97818    0.02121
+    3 Bend                     2     1     3               102.81216   -1.69908
+
+ ==============================================================================
+                                internuclear distances
+ ------------------------------------------------------------------------------
+       center one      |      center two      | atomic units |       a.u.
+ ------------------------------------------------------------------------------
+    2 H                |   1 O                |     1.84849  |     1.84849
+    3 H                |   1 O                |     1.84849  |     1.84849
+ ------------------------------------------------------------------------------
+                         number of included internuclear distances:          2
+ ==============================================================================
+
+
+
+ ==============================================================================
+                                 internuclear angles
+ ------------------------------------------------------------------------------
+        center 1       |       center 2       |       center 3       |  degrees
+ ------------------------------------------------------------------------------
+    2 H                |   1 O                |   3 H                |   102.81
+ ------------------------------------------------------------------------------
+                            number of included internuclear angles:          1
+ ==============================================================================
+
+
+
+
+ Task  times  cpu:        2.9s     wall:        3.0s
+
+
+                                NWChem Input Module
+                                -------------------
+
+
+ Summary of allocated global arrays
+-----------------------------------
+  No active global arrays
+
+
+MA_summarize_allocated_blocks: starting scan ...
+MA_summarize_allocated_blocks: scan completed: 0 heap blocks, 0 stack blocks
+MA usage statistics:
+
+	allocation statistics:
+					      heap	     stack
+					      ----	     -----
+	current number of blocks	         0	         0
+	maximum number of blocks	        27	        55
+	current total bytes		         0	         0
+	maximum total bytes		 269337480	  22509736
+	maximum total K-bytes		    269338	     22510
+	maximum total M-bytes		       270	        23
+
+
+                                     CITATION
+                                     --------
+                Please cite the following reference when publishing
+                           results obtained with NWChem:
+
+          E. Apra, E. J. Bylaska, W. A. de Jong, N. Govind, K. Kowalski,
+       T. P. Straatsma, M. Valiev, H. J. J. van Dam, Y. Alexeev, J. Anchell,
+       V. Anisimov, F. W. Aquino, R. Atta-Fynn, J. Autschbach, N. P. Bauman,
+     J. C. Becca, D. E. Bernholdt, K. Bhaskaran-Nair, S. Bogatko, P. Borowski,
+         J. Boschen, J. Brabec, A. Bruner, E. Cauet, Y. Chen, G. N. Chuev,
+      C. J. Cramer, J. Daily, M. J. O. Deegan, T. H. Dunning Jr., M. Dupuis,
+   K. G. Dyall, G. I. Fann, S. A. Fischer, A. Fonari, H. Fruchtl, L. Gagliardi,
+      J. Garza, N. Gawande, S. Ghosh, K. Glaesemann, A. W. Gotz, J. Hammond,
+       V. Helms, E. D. Hermes, K. Hirao, S. Hirata, M. Jacquelin, L. Jensen,
+   B. G. Johnson, H. Jonsson, R. A. Kendall, M. Klemm, R. Kobayashi, V. Konkov,
+      S. Krishnamoorthy, M. Krishnan, Z. Lin, R. D. Lins, R. J. Littlefield,
+      A. J. Logsdail, K. Lopata, W. Ma, A. V. Marenich, J. Martin del Campo,
+   D. Mejia-Rodriguez, J. E. Moore, J. M. Mullin, T. Nakajima, D. R. Nascimento,
+    J. A. Nichols, P. J. Nichols, J. Nieplocha, A. Otero-de-la-Roza, B. Palmer,
+    A. Panyala, T. Pirojsirikul, B. Peng, R. Peverati, J. Pittner, L. Pollack,
+   R. M. Richard, P. Sadayappan, G. C. Schatz, W. A. Shelton, D. W. Silverstein,
+   D. M. A. Smith, T. A. Soares, D. Song, M. Swart, H. L. Taylor, G. S. Thomas,
+            V. Tipparaju, D. G. Truhlar, K. Tsemekhman, T. Van Voorhis,
+      A. Vazquez-Mayagoitia, P. Verma, O. Villa, A. Vishnu, K. D. Vogiatzis,
+        D. Wang, J. H. Weare, M. J. Williamson, T. L. Windus, K. Wolinski,
+        A. T. Wong, Q. Wu, C. Yang, Q. Yu, M. Zacharias, Z. Zhang, Y. Zhao,
+                                and R. J. Harrison
+                        "NWChem: Past, present, and future
+                         J. Chem. Phys. 152, 184102 (2020)
+                               doi:10.1063/5.0004997
+
+                                      AUTHORS
+                                      -------
+  E. Apra, E. J. Bylaska, N. Govind, K. Kowalski, M. Valiev, D. Mejia-Rodriguez,
+       A. Kunitsa, N. P. Bauman, A. Panyala, W. A. de Jong, T. P. Straatsma,
+        H. J. J. van Dam, D. Wang, T. L. Windus, J. Hammond, J. Autschbach,
+    K. Bhaskaran-Nair, J. Brabec, K. Lopata, S. A. Fischer, S. Krishnamoorthy,
+     M. Jacquelin, W. Ma, M. Klemm, O. Villa, Y. Chen, V. Anisimov, F. Aquino,
+    S. Hirata, M. T. Hackler, Eric Hermes, L. Jensen, J. E. Moore, J. C. Becca,
+      V. Konjkov, T. Risthaus, M. Malagoli, A. Marenich, A. Otero-de-la-Roza,
+        J. Mullin, P. Nichols, R. Peverati, J. Pittner, Y. Zhao, P.-D. Fan,
+        A. Fonari, M. J. Williamson, R. J. Harrison, J. R. Rehr, M. Dupuis,
+     D. Silverstein, D. M. A. Smith, J. Nieplocha, V. Tipparaju, M. Krishnan,
+     B. E. Van Kuiken, A. Vazquez-Mayagoitia, M. Swart, Q. Wu, T. Van Voorhis,
+     A. A. Auer, M. Nooijen, L. D. Crosby, E. Brown, G. Cisneros, G. I. Fann,
+   H. Fruchtl, J. Garza, K. Hirao, R. A. Kendall, J. A. Nichols, K. Tsemekhman,
+    K. Wolinski, J. Anchell, D. E. Bernholdt, P. Borowski, T. Clark, D. Clerc,
+   H. Dachsel, M. J. O. Deegan, K. Dyall, D. Elwood, E. Glendening, M. Gutowski,
+   A. C. Hess, J. Jaffe, B. G. Johnson, J. Ju, R. Kobayashi, R. Kutteh, Z. Lin,
+   R. Littlefield, X. Long, B. Meng, T. Nakajima, S. Niu, L. Pollack, M. Rosing,
+   K. Glaesemann, G. Sandrone, M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe,
+                               A. T. Wong, Z. Zhang.
+
+ Total times  cpu:        3.0s     wall:        3.1s

--- a/src/nwdft/scf_dft_cg/dft_cg_info.F
+++ b/src/nwdft/scf_dft_cg/dft_cg_info.F
@@ -311,22 +311,22 @@ c
 c
 c     ----- cosmo initialization ----
 c
-      cosmo_last = .false.
-      if ( rtdb_get(rtdb,'slv:cosmo',mt_log,1,cosmo_on)) then
-         if(cosmo_on) then
-            osome = util_print('information', print_low)
+c      cosmo_last = .false.
+c      if ( rtdb_get(rtdb,'slv:cosmo',mt_log,1,cosmo_on)) then
+c         if(cosmo_on) then
+c            osome = util_print('information', print_low)
 c
-            call cosmo_initialize(rtdb,geom,basis,osome)
+c            call cosmo_initialize(rtdb,geom,basis,osome)
 c
 c           Turn cosmo on, we want to run the calculation
 c           Start with gas_phase run unless told otherwise
 c
-            cosmo_last = .true.
-            cosmo_on = .true.
-            if(.not.rtdb_get(rtdb,'cosmo_phase',mt_int,1,cosmo_phase))
-     >         cosmo_phase = 1
-         endif
-      endif
+c            cosmo_last = .true.
+c            cosmo_on = .true.
+c            if(.not.rtdb_get(rtdb,'cosmo_phase',mt_int,1,cosmo_phase))
+c     >         cosmo_phase = 1
+c         endif
+c      endif
       oinitialized = .true.
 c     
       end
@@ -379,13 +379,13 @@ c
 c
 c     ----- cosmo cleanup and reset -----
 c
-      if ( rtdb_get(rtdb,'slv:cosmo',mt_log,1,cosmo_on)) then
-         if(cosmo_on) then
-           call cosmo_tidy(rtdb)
-           cosmo_on = .false.
-           cosmo_phase = 1
-         endif
-      endif
+c      if ( rtdb_get(rtdb,'slv:cosmo',mt_log,1,cosmo_on)) then
+c         if(cosmo_on) then
+c           call cosmo_tidy(rtdb)
+c           cosmo_on = .false.
+c           cosmo_phase = 1
+c         endif
+c      endif
 c
 c     --- ri-scf cleanup ---
 c


### PR DESCRIPTION
An optimization with COSMO and CGMIN leads to an error due to unbalanced `cosmo_initialize()` and `cosmo_tidy()` calls.

The PR fixes this issue.