### PR TITLE
MPI env variables are now ignored unless FORCE_MPI_ENV is set

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -243,10 +243,10 @@ endif
 # specified below.  Use of MPI requires substituting the tcgmsg-mpi
 # wrapper for the normal tcgmsg library.
 # the 2 following environmental variables are need for linking
-# LIBMPI - represents the name of mpi library (with -l)
-# MPI_LIB - represents the path to the mpi library
-#LIBMPI =  -lmpich
-#MPI_LIB= /usr/local/lib
+# NWLIBMPI - represents the name of mpi library (with -l)
+# NWMPI_LIB - represents the path to the mpi library
+#NWLIBMPI =  -lmpich
+#NWMPI_LIB= /usr/local/lib
 
 #JN: under the new structure, tools should be listed first as
 # their header files are needed for dependency analysis of
@@ -317,10 +317,10 @@ endif
 ifdef BUILD_MPICH
     NW_CORE_SUBDIRS += libext
     PATH := $(NWCHEM_TOP)/src/libext/bin:$(PATH)
-    MPI_INCLUDE = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH) $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_include)
-    MPI_LIB     = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH)  $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_lib)
-    LIBMPI      = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH) $(NWCHEM_TOP)/src/tools/guess-mpidefs --libmpi)
-    LIBMPI	+= $(shell /usr/local/bin/pkg-config --libs-only-L hwloc 2> /dev/null)
+    NWMPI_INCLUDE = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH) $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_include)
+    NWMPI_LIB     = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH)  $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_lib)
+    NWLIBMPI      = $(shell PATH=$(NWCHEM_TOP)/src/libext/bin:$(PATH) $(NWCHEM_TOP)/src/tools/guess-mpidefs --libmpi)
+    NWLIBMPI	+= $(shell /usr/local/bin/pkg-config --libs-only-L hwloc 2> /dev/null)
 endif
 
 
@@ -3521,37 +3521,69 @@ endif
 ifdef USE_MPI 
     #ifeq ($(FC),$(findstring $(FC),mpifrt mpfort mpif77 mpxlf mpif90 ftn scorep-ftn))
     ifeq ($(FC),$(findstring $(FC), ftn scorep-ftn))
-        LIBMPI =
-        MPI_INCLUDE =
-        MPI_LIB =
-    else
+        NWLIBMPI =
+        NWMPI_INCLUDE =
+        NWMPI_LIB =
+    else ifdef FORCE_MPI_ENV
         ifndef MPI_INCLUDE
-            # check if mpif90 is present
-            MPIF90YN = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_include)
-            ifeq ($(MPIF90YN),mpif90notfound)
-                errormpif90:
-	            $(info )
-	            $(info mpif90 not found. Please add its location to PATH)
-	            $(info e.g. export PATH=/usr/local/bin:/usr/lib64/openmpi/bin:...)
-	            $(info )
-            endif
-            MPI_INCLUDE = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_include)
-        endif
+                errormpi1:
+	            $(error )
+   	            $(error FORCE_MPI_ENV set but MPI_INCLUDE not set)
+	            $(error )
+        else
+	  NWMPI_INCLUDE = $(MPI_INCLUDE)
+	endif
         ifndef MPI_LIB
-            MPI_LIB     = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_lib)
-        endif
+                errormpi2:
+	            $(error )
+   	            $(error FORCE_MPI_ENV set but MPI_LIB not set)
+	            $(error )
+        else
+	  NWMPI_LIB = $(MPI_LIB)
+	endif
         ifndef LIBMPI
-            LIBMPI      = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --libmpi)
+                errormpi3:
+	            $(error )
+   	            $(error FORCE_MPI_ENV set but LIBMPI not set)
+	            $(error )
+        else
+	  NWLIBMPI = $(LIBMPI)
+	endif
+     else
+        ifeq ($(shell pwd), $(NWCHEM_TOP)/src)
+	    ifndef FORCE_MPI_ENV
+                ifdef LIBMPI
+$(info ***warning LIBMPI ignored since FORCE_MPI_ENV not set***)
+                endif
+                ifdef MPI_LIB
+$(info ***warning MPI_LIB ignored since FORCE_MPI_ENV not set***)
+ 	        endif
+                ifdef MPI_INCLUDE
+$(info ***warning MPI_INCLUDE ignored since FORCE_MPI_ENV not set***)
+ 	        endif
+	    endif
+	endif
+        # check if mpif90 is present
+        MPIF90YN = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_include)
+        ifeq ($(MPIF90YN),mpif90notfound)
+            errormpif90:
+                $(error )
+                $(error mpif90 not found. Please add its location to PATH)
+                $(error e.g. export PATH=/usr/local/bin:/usr/lib64/openmpi/bin:...)
+                $(error )
         endif
+        NWMPI_INCLUDE = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_include)
+        NWMPI_LIB     = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --mpi_lib)
+        NWLIBMPI      = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --libmpi)
     endif
 
-    ifdef MPI_LIB 
-        CORE_LIBS += $(patsubst -L-L%,-L%,-L$(MPI_LIB))
+    ifdef NWMPI_LIB 
+        CORE_LIBS += $(patsubst -L-L%,-L%,-L$(NWMPI_LIB))
     endif 
     ifdef OLD_GA
-        CORE_LIBS += -ltcgmsg-mpi $(LIBMPI) 
+        CORE_LIBS += -ltcgmsg-mpi $(NWLIBMPI) 
     else
-        CORE_LIBS += $(LIBMPI) 
+        CORE_LIBS += $(NWLIBMPI) 
     endif
 else 
     ifdef OLD_GA

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3577,6 +3577,9 @@ $(info ***warning MPI_INCLUDE ignored since FORCE_MPI_ENV not set***)
         NWLIBMPI      = $(shell $(NWCHEM_TOP)/src/tools/guess-mpidefs --libmpi)
     endif
 
+    ifdef NWMPI_INCLUDE
+      LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(NWMPI_INCLUDE))
+    endif
     ifdef NWMPI_LIB 
         CORE_LIBS += $(patsubst -L-L%,-L%,-L$(NWMPI_LIB))
     endif 

--- a/src/nwpw/nwpwlib/C1dB/GNUmakefile
+++ b/src/nwpw/nwpwlib/C1dB/GNUmakefile
@@ -42,9 +42,6 @@ endif
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
 else
   LIB_DEFINES += -DTCGMSG
 endif

--- a/src/nwpw/nwpwlib/C3dB/GNUmakefile
+++ b/src/nwpw/nwpwlib/C3dB/GNUmakefile
@@ -47,9 +47,6 @@ endif
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
 else
   LIB_DEFINES += -DTCGMSG
 endif

--- a/src/nwpw/nwpwlib/CMatrix/GNUmakefile
+++ b/src/nwpw/nwpwlib/CMatrix/GNUmakefile
@@ -43,9 +43,6 @@ endif
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
 else
   LIB_DEFINES += -DTCGMSG
 endif

--- a/src/nwpw/nwpwlib/D1dB/GNUmakefile
+++ b/src/nwpw/nwpwlib/D1dB/GNUmakefile
@@ -43,9 +43,6 @@ endif
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
 else
   LIB_DEFINES += -DTCGMSG
 endif

--- a/src/nwpw/nwpwlib/D3dB/GNUmakefile
+++ b/src/nwpw/nwpwlib/D3dB/GNUmakefile
@@ -41,9 +41,6 @@ endif
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
 else
   USES_BLAS += D3dB-tcgmsg.F
   LIB_DEFINES += -DTCGMSG

--- a/src/nwpw/nwpwlib/DMatrix/GNUmakefile
+++ b/src/nwpw/nwpwlib/DMatrix/GNUmakefile
@@ -43,9 +43,6 @@ endif
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
 else
   LIB_DEFINES += -DTCGMSG
 endif

--- a/src/nwpw/nwpwlib/K1dB/GNUmakefile
+++ b/src/nwpw/nwpwlib/K1dB/GNUmakefile
@@ -41,9 +41,6 @@ endif
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
 else
   LIB_DEFINES += -DTCGMSG
 endif

--- a/src/nwpw/nwpwlib/Parallel/GNUmakefile
+++ b/src/nwpw/nwpwlib/Parallel/GNUmakefile
@@ -40,9 +40,6 @@ include ../../../config/makelib.h
 
 ifeq ($(USE_MPIF),y)
   LIB_DEFINES += -DMPI
-  ifneq ($(MPI_INCLUDE),)
-    LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
-  endif
   ifeq ($(DEV_GA),y)
     LIB_DEFINES += -DGA_DEV
   endif

--- a/src/tools/GNUmakefile
+++ b/src/tools/GNUmakefile
@@ -318,14 +318,14 @@ endif # SOCKETS
 ifdef USE_MPI
 
     MPI_COMBINED =
-    ifneq ($(MPI_INCLUDE),)
-        MPI_COMBINED += $(patsubst -I-I%,-I%,-I${MPI_INCLUDE})
+    ifneq ($(NWMPI_INCLUDE),)
+        MPI_COMBINED += $(patsubst -I-I%,-I%,-I${NWMPI_INCLUDE})
     endif
-    ifneq ($(MPI_LIB),)
-        MPI_COMBINED += $(patsubst -L-L%,-L%,-L${MPI_LIB})
+    ifneq ($(NWMPI_LIB),)
+        MPI_COMBINED += $(patsubst -L-L%,-L%,-L${NWMPI_LIB})
     endif
-    ifneq ($(LIBMPI),)
-        MPI_COMBINED += $(LIBMPI)
+    ifneq ($(NWLIBMPI),)
+        MPI_COMBINED += $(NWLIBMPI)
         ifeq ($(ARMCI_NETWORK),ARMCI)
            MPI_COMBINED += -lpthread
         endif

--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -148,9 +148,7 @@ endif
 ifneq ($(OLD_GA),)
   EXTRA_OBJ += ga_zgop.o
 endif
-ifneq ($(NWMPI_INCLUDE),)
-   LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(NWMPI_INCLUDE))
-endif
+
 
 ifdef USE_VTUNE
   EXTRA_OBJ += vtune_bind.o vtune.o

--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -148,9 +148,8 @@ endif
 ifneq ($(OLD_GA),)
   EXTRA_OBJ += ga_zgop.o
 endif
-#LIB_DEFINES += -I$(MPI_INCLUDE)
-ifneq ($(MPI_INCLUDE),)
-   LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(MPI_INCLUDE))
+ifneq ($(NWMPI_INCLUDE),)
+   LIB_INCLUDES += $(patsubst -I-I%,-I%,-I$(NWMPI_INCLUDE))
 endif
 
 ifdef USE_VTUNE


### PR DESCRIPTION
We get too many installation  problems of user choosing the wrong MPI env. variables.
guess-mpidefs does a pretty good job.
Input MPI env variables are used only if FORCE_MPI_ENV is set