### PR TITLE
support for external libxc library

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -129,6 +129,16 @@ jobs:
             nwchem_modules: "tce"
             fc: gfortran-11
             cc: gcc-11
+          - os: ubuntu-20.04
+            experimental: true
+            mpi_impl: mpich
+            armci_network: MPI-TS
+            nwchem_modules: "nwdft solvation driver"
+            fc: gfortran
+            cc: gcc
+            use_libxc: -1
+            blas: "internal"
+            blas_size: 8
           - os: ubuntu-22.04
             experimental: true
             mpi_impl: mpich

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -136,6 +136,7 @@ jobs:
             nwchem_modules: "qmandpw qmd"
             fc: gfortran-11
             cc: gcc-11
+            use_libxc: -1
           - os: ubuntu-20.04
             experimental: true
             mpi_impl: mpich

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3634,9 +3634,9 @@ ifdef USE_LIBXC
 endif
 
 # we use an external libxc library out of LIBXC_DIR
-ifdef LIBXC_DIR
+ifdef LIBXC_LIB
     DEFINES += -DUSE_LIBXC
-    EXTRA_LIBS += -L$(LIBXC_DIR)/lib
+    EXTRA_LIBS += -L$(LIBXC_LIB)
     EXTRA_LIBS += -lxcf03 -lxc
 endif
 

--- a/src/libext/libxc/build_libxc.sh
+++ b/src/libext/libxc/build_libxc.sh
@@ -120,6 +120,7 @@ fi
 $CMAKE -E env CFLAGS="$cflags" LDFLAGS="$ldflags" FCFLAGS="$fcflags" FFLAGS="$fcflags" \
 $CMAKE  -DCMAKE_INSTALL_PREFIX=${NWCHEM_TOP}/src/libext/libxc/install -DCMAKE_C_COMPILER=$CC -DENABLE_FORTRAN=ON -DCMAKE_Fortran_COMPILER=$FC -DDISABLE_KXC=OFF \
 -DENABLE_XHOST="$enable_xhost_flag" \
+-DENABLE_FORTRAN03=ON \
 -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_BUILD_TYPE=Release ..
 
 make -j4 | tee make.log

--- a/src/nwdft/libxc/GNUmakefile
+++ b/src/nwdft/libxc/GNUmakefile
@@ -19,5 +19,7 @@ LIB_INCLUDES += -I$(LIBXC_INCLUDE)
 endif
 LIB_INCLUDES += -I.
 
+LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VERSION /usr/include/xc_version.h |cut -d " " -f 3)
+
 include ../../config/makefile.h
 include ../../config/makelib.h

--- a/src/nwdft/libxc/GNUmakefile
+++ b/src/nwdft/libxc/GNUmakefile
@@ -14,8 +14,8 @@ LIB_INCLUDES = -I../include
 ifdef USE_LIBXC
 LIB_INCLUDES += -I../../libext/libxc/install/include
 endif
-ifdef LIBXC_DIR
-LIB_INCLUDES += -I$(LIBXC_DIR)/include
+ifdef LIBXC_INCLUDE
+LIB_INCLUDES += -I$(LIBXC_INCLUDE)
 endif
 LIB_INCLUDES += -I.
 

--- a/src/nwdft/libxc/GNUmakefile
+++ b/src/nwdft/libxc/GNUmakefile
@@ -17,8 +17,7 @@ LIB_DEFINES += -DLIBXC_NP_SIZE=$(shell ./libxc_findsizenp.sh ../../libext/libxc/
 LIB_INCLUDES += -I../../libext/libxc/install/include
 endif
 ifdef LIBXC_INCLUDE
-LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VE
-RSION $(LIBXC_INCLUDE)/xc_version.h |cut -d " " -f 3)
+LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VERSION $(LIBXC_INCLUDE)/xc_version.h |cut -d " " -f 3)
 LIB_DEFINES += -DLIBXC_NP_SIZE=$(shell ./libxc_findsizenp.sh $(LIBXC_INCLUDE))
 LIB_INCLUDES += -I$(LIBXC_INCLUDE)
 endif

--- a/src/nwdft/libxc/GNUmakefile
+++ b/src/nwdft/libxc/GNUmakefile
@@ -13,10 +13,13 @@ LIBRARY = libnwdft.a
 LIB_INCLUDES = -I../include 
 ifdef USE_LIBXC
 LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VERSION ../../libext/libxc/install/include/xc_version.h |cut -d " " -f 3)
+LIB_DEFINES += -DLIBXC_NP_SIZE=$(shell ./libxc_findsizenp.sh ../../libext/libxc/install/include)
 LIB_INCLUDES += -I../../libext/libxc/install/include
 endif
 ifdef LIBXC_INCLUDE
-LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VERSION $(LIBXC_INCLUDE)/xc_version.h |cut -d " " -f 3)
+LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VE
+RSION $(LIBXC_INCLUDE)/xc_version.h |cut -d " " -f 3)
+LIB_DEFINES += -DLIBXC_NP_SIZE=$(shell ./libxc_findsizenp.sh $(LIBXC_INCLUDE))
 LIB_INCLUDES += -I$(LIBXC_INCLUDE)
 endif
 LIB_INCLUDES += -I.

--- a/src/nwdft/libxc/GNUmakefile
+++ b/src/nwdft/libxc/GNUmakefile
@@ -12,14 +12,15 @@ LIBRARY = libnwdft.a
 
 LIB_INCLUDES = -I../include 
 ifdef USE_LIBXC
+LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VERSION ../../libext/libxc/install/include/xc_version.h |cut -d " " -f 3)
 LIB_INCLUDES += -I../../libext/libxc/install/include
 endif
 ifdef LIBXC_INCLUDE
+LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VERSION $(LIBXC_INCLUDE)/xc_version.h |cut -d " " -f 3)
 LIB_INCLUDES += -I$(LIBXC_INCLUDE)
 endif
 LIB_INCLUDES += -I.
 
-LIB_DEFINES += -DXC_MAJOR_VERSION=$(shell grep XC_MAJOR_VERSION /usr/include/xc_version.h |cut -d " " -f 3)
 
 include ../../config/makefile.h
 include ../../config/makelib.h

--- a/src/nwdft/libxc/libxc.fh
+++ b/src/nwdft/libxc/libxc.fh
@@ -1,3 +1,6 @@
+#if XC_MAJOR_VERSION < 4
+#error "need libxc version > 4 "
+#endif
       integer, parameter :: maxfunc = 100
 
       integer :: libxc_nfuncs

--- a/src/nwdft/libxc/libxc.fh
+++ b/src/nwdft/libxc/libxc.fh
@@ -1,6 +1,6 @@
 #ifdef USE_LIBXC
 #if XC_MAJOR_VERSION < 4
-#error "need libxc version > 4 "
+#error "need libxc version > 3 "
 #endif
 #endif
       integer, parameter :: maxfunc = 100

--- a/src/nwdft/libxc/libxc.fh
+++ b/src/nwdft/libxc/libxc.fh
@@ -1,5 +1,7 @@
+#ifdef USE_LIBXC
 #if XC_MAJOR_VERSION < 4
 #error "need libxc version > 4 "
+#endif
 #endif
       integer, parameter :: maxfunc = 100
 

--- a/src/nwdft/libxc/libxc_findsizenp.sh
+++ b/src/nwdft/libxc/libxc_findsizenp.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+npstring=$(egrep np "$1"/xc.h|head -1)
+np_array=($npstring)
+count=-1
+sizenp_string=' '
+for substring in "${np_array[@]}"; do
+    [[ $substring == "np," ]] && sizenp_string=${np_array[$count]} && break
+    ((++count))
+done
+if [[ "$sizenp_string" == 'int' ]]; then
+    size_np=4	       	       
+elif [[ "$sizenp_string" == 'size_t' ]]; then
+    size_np=8
+else
+    echo "unexpected sizenp_string $sizenp_string"
+    exit 1
+fi
+echo $size_np

--- a/src/nwdft/libxc/nwchem_libxc_compute.F
+++ b/src/nwdft/libxc/nwchem_libxc_compute.F
@@ -57,6 +57,7 @@
       double precision :: Amat3(nq,NCOL_AMAT3)
       double precision :: Cmat3(nq,NCOL_CMAT3)
 
+#ifdef USE_LIBXC
       double precision :: fac 
 
       double precision, external :: ddot
@@ -67,10 +68,9 @@
       integer*4 nqs
 #elif LIBXC_NP_SIZE == 8
       integer(c_size_t) :: nqs
-#elif
+#else
 #error "unexpected value for LIBXC_NP_SIZE"
 #endif
-#ifdef USE_LIBXC      
       type(xc_f03_func_t) :: xcfunc      
 
       gga = .false.

--- a/src/nwdft/libxc/nwchem_libxc_compute.F
+++ b/src/nwdft/libxc/nwchem_libxc_compute.F
@@ -159,12 +159,13 @@
         fac = libxc_facts(ifunc)
 
         call xc_f03_func_init(xcfunc,libxc_funcs(ifunc),polarized)
+#if XC_MAJOR_VERSION > 4
         call xc_f03_func_set_dens_threshold(xcfunc, tol_rho)
         call xc_f03_func_set_sigma_threshold(xcfunc, tol_rho**2)
         call xc_f03_func_set_zeta_threshold(xcfunc, 1d-10)
-
+#endif
         select case(libxc_family(ifunc))
-#if XC_MAJOR_VERSION > 5
+#if XC_MAJOR_VERSION > 4
         case (XC_FAMILY_LDA, XC_FAMILY_HYB_LDA)
 #else
         case (XC_FAMILY_LDA)
@@ -173,12 +174,20 @@
             call xc_f03_lda_exc_vxc(xcfunc,nqs,
      $            dbl_mb(krho),dbl_mb(kexc),dbl_mb(kvrho))
           elseif (.not.do_3rd) then
+#if XC_MAJOR_VERSION > 4
             call xc_f03_lda_exc_vxc_fxc(xcfunc,nqs,dbl_mb(krho),
      $            dbl_mb(kexc),dbl_mb(kvrho),dbl_mb(kv2rho2))
+#else
+            call errquit(' libxc interface incomplete',0,0)
+#endif
           else
+#if XC_MAJOR_VERSION > 4
             call xc_f03_lda_exc_vxc_fxc_kxc(xcfunc,nqs,dbl_mb(krho),
      $            dbl_mb(kexc),dbl_mb(kvrho),dbl_mb(kv2rho2),
      $            dbl_mb(kv3rho3))
+#else
+            call errquit(' libxc interface incomplete',0,0)
+#endif
           endif
 
 
@@ -195,17 +204,25 @@
      $                                dbl_mb(kexc),
      $                                dbl_mb(kvrho),dbl_mb(kvsigma))
             elseif (.not.do_3rd) then
+#if XC_MAJOR_VERSION > 4
               call xc_f03_gga_exc_vxc_fxc(xcfunc,nqs,
      $             dbl_mb(krho),dbl_mb(ksigma),dbl_mb(kexc),
      $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
      $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2))
+#else
+            call errquit(' libxc interface incomplete',0,0)
+#endif
             else
+#if XC_MAJOR_VERSION > 4
               call xc_f03_gga_exc_vxc_fxc_kxc(xcfunc,nqs,
      $             dbl_mb(krho),dbl_mb(ksigma),dbl_mb(kexc),
      $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
      $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2),
      $             dbl_mb(kv3rho3),dbl_mb(kv3rho2sig),
      $             dbl_mb(kv3rhosig2),dbl_mb(kv3sig3))
+#else
+            call errquit(' libxc interface incomplete',0,0)
+#endif
             endif
           else
             if ((.not.do_2nd).and.(.not.do_3rd)) then
@@ -213,17 +230,25 @@
      $                            dbl_mb(krho),dbl_mb(ksigma),
      $                            dbl_mb(kvrho),dbl_mb(kvsigma))
             elseif (.not.do_3rd) then
+#if XC_MAJOR_VERSION > 4
               call xc_f03_gga_vxc_fxc(xcfunc,nqs,
      $             dbl_mb(krho),dbl_mb(ksigma),
      $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
      $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2))
+#else
+            call errquit(' libxc interface incomplete',0,0)
+#endif
             else
+#if XC_MAJOR_VERSION > 4
               call xc_f03_gga_vxc_fxc_kxc(xcfunc,nqs,
      $             dbl_mb(krho),dbl_mb(ksigma),
      $             dbl_mb(kvrho),dbl_mb(kvsigma),dbl_mb(kv2rho2),
      $             dbl_mb(kv2rhosig),dbl_mb(kv2sig2),
      $             dbl_mb(kv3rho3),dbl_mb(kv3rho2sig),
      $             dbl_mb(kv3rhosig2),dbl_mb(kv3sig3))
+#else
+            call errquit(' libxc interface incomplete',0,0)
+#endif
             endif
             call dfill(nq,0d0,dbl_mb(kexc),1)
           endif

--- a/src/nwdft/libxc/nwchem_libxc_compute.F
+++ b/src/nwdft/libxc/nwchem_libxc_compute.F
@@ -231,7 +231,6 @@
           mgga = .true.
           dolap = iand(libxc_flags(ifunc),xc_flags_needs_laplacian).eq.
      $            xc_flags_needs_laplacian
-#endif
           
           if (iand(libxc_flags(ifunc),xc_flags_have_exc).eq.
      $                                xc_flags_have_exc) then

--- a/src/nwdft/libxc/nwchem_libxc_compute.F
+++ b/src/nwdft/libxc/nwchem_libxc_compute.F
@@ -63,7 +63,11 @@
       logical gga,mgga,dolap
       logical,external :: nwchem_libxc_family
 
+#if XC_MAJOR_VERSION > 5
       integer(c_size_t) :: nqs
+#else
+      integer*4 :: nqs
+#endif
 #ifdef USE_LIBXC      
       type(xc_f03_func_t) :: xcfunc      
 
@@ -158,8 +162,11 @@
         call xc_f03_func_set_zeta_threshold(xcfunc, 1d-10)
 
         select case(libxc_family(ifunc))
+#if XC_MAJOR_VERSION > 5
         case (XC_FAMILY_LDA, XC_FAMILY_HYB_LDA)
-
+#else
+        case (XC_FAMILY_LDA)
+#endif
           if ((.not.do_2nd) .and. (.not.do_3rd)) then
             call xc_f03_lda_exc_vxc(xcfunc,nqs,
      $            dbl_mb(krho),dbl_mb(kexc),dbl_mb(kvrho))
@@ -224,6 +231,7 @@
           mgga = .true.
           dolap = iand(libxc_flags(ifunc),xc_flags_needs_laplacian).eq.
      $            xc_flags_needs_laplacian
+#endif
           
           if (iand(libxc_flags(ifunc),xc_flags_have_exc).eq.
      $                                xc_flags_have_exc) then

--- a/src/nwdft/libxc/nwchem_libxc_compute.F
+++ b/src/nwdft/libxc/nwchem_libxc_compute.F
@@ -63,10 +63,12 @@
       logical gga,mgga,dolap
       logical,external :: nwchem_libxc_family
 
-#if XC_MAJOR_VERSION > 5
+#if LIBXC_NP_SIZE == 4
+      integer*4 nqs
+#elif LIBXC_NP_SIZE == 8
       integer(c_size_t) :: nqs
-#else
-      integer*4 :: nqs
+#elif
+#error "unexpected value for LIBXC_NP_SIZE"
 #endif
 #ifdef USE_LIBXC      
       type(xc_f03_func_t) :: xcfunc      

--- a/src/nwdft/libxc/nwchem_libxc_read.F
+++ b/src/nwdft/libxc/nwchem_libxc_read.F
@@ -41,7 +41,11 @@
       xcfamily = xc_f03_func_info_get_family(xcinfo)
 
       select case(xcfamily)
+#if XC_MAJOR_VERSION > 5
       case (XC_FAMILY_LDA, XC_FAMILY_HYB_LDA)
+#else
+      case (XC_FAMILY_LDA)
+#endif
       case (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA)
       case (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
       case default
@@ -50,7 +54,11 @@
       endselect
 
       select case(xcfamily)
+#if XC_MAJOR_VERSION > 5
       case (XC_FAMILY_HYB_LDA, XC_FAMILY_HYB_GGA, XC_FAMILY_HYB_MGGA)
+#else
+      case (XC_FAMILY_HYB_GGA, XC_FAMILY_HYB_MGGA)
+#endif
         if (iand(xcflags,xc_flags_hyb_cam).eq.xc_flags_hyb_cam) then
           call xc_f03_hyb_cam_coef(xcfunc,cam_omega,cam_alpha,cam_beta)
 

--- a/src/nwdft/libxc/nwchem_libxc_read.F
+++ b/src/nwdft/libxc/nwchem_libxc_read.F
@@ -41,7 +41,7 @@
       xcfamily = xc_f03_func_info_get_family(xcinfo)
 
       select case(xcfamily)
-#if XC_MAJOR_VERSION > 5
+#if XC_MAJOR_VERSION > 4
       case (XC_FAMILY_LDA, XC_FAMILY_HYB_LDA)
 #else
       case (XC_FAMILY_LDA)
@@ -54,7 +54,7 @@
       endselect
 
       select case(xcfamily)
-#if XC_MAJOR_VERSION > 5
+#if XC_MAJOR_VERSION > 4
       case (XC_FAMILY_HYB_LDA, XC_FAMILY_HYB_GGA, XC_FAMILY_HYB_MGGA)
 #else
       case (XC_FAMILY_HYB_GGA, XC_FAMILY_HYB_MGGA)

--- a/src/nwdft/libxc/nwchem_libxc_util.F
+++ b/src/nwdft/libxc/nwchem_libxc_util.F
@@ -74,7 +74,7 @@
       use,intrinsic :: iso_c_binding
 #ifdef USE_LIBXC
       use xc_f03_lib_m, only: xc_f03_version_string,
-#if XC_MAJOR_VERSION > 5
+#if XC_MAJOR_VERSION > 4
      $     xc_f03_reference,
 #endif
      $     xc_f03_functional_get_name
@@ -112,7 +112,7 @@
       use,intrinsic :: iso_c_binding
 #ifdef USE_LIBXC
       use xc_f03_lib_m, only: xc_f03_version_string,
-#if XC_MAJOR_VERSION > 5
+#if XC_MAJOR_VERSION > 4
      $     xc_f03_reference,
 #endif
      $     xc_f03_functional_get_name

--- a/src/nwdft/libxc/nwchem_libxc_util.F
+++ b/src/nwdft/libxc/nwchem_libxc_util.F
@@ -74,8 +74,10 @@
       use,intrinsic :: iso_c_binding
 #ifdef USE_LIBXC
       use xc_f03_lib_m, only: xc_f03_version_string,
-     $                        xc_f03_reference,
-     $                        xc_f03_functional_get_name
+#if XC_MAJOR_VERSION > 5
+     $     xc_f03_reference,
+#endif
+     $     xc_f03_functional_get_name
 #endif
       implicit none
 
@@ -110,8 +112,10 @@
       use,intrinsic :: iso_c_binding
 #ifdef USE_LIBXC
       use xc_f03_lib_m, only: xc_f03_version_string,
-     $                        xc_f03_reference,
-     $                        xc_f03_functional_get_name
+#if XC_MAJOR_VERSION > 5
+     $     xc_f03_reference,
+#endif
+     $     xc_f03_functional_get_name
 #endif
       implicit none
 

--- a/src/tools/GNUmakefile
+++ b/src/tools/GNUmakefile
@@ -726,7 +726,7 @@ $(BUILDDIR)/config.status: $(GA_DIR)/configure $(STAMP_FC) $(STAMP_CC) $(STAMP_D
 	@echo ''
 	@(test -d $(BUILDDIR)) || mkdir $(BUILDDIR);
 	@echo ' '
-	@if [[ "$V" != "1" ]]; then echo '*** autoconf output redirected to config.log ****' ; echo '*** type make V=1 to get verbose output ***'; fi
+	@if [ "$V" != "1" ]; then echo '*** autoconf output redirected to config.log ****' ; echo '*** type make V=1 to get verbose output ***'; fi
 	@echo ' '
 	@(cd $(BUILDDIR) && echo $(CONFIGURE_PATH) $(CONFIGURE_ARGS) && $(CONFIGURE_PATH) $(CONFIGURE_ARGS)) || exit 1
 $(GA_DIR)/Makefile.in:

--- a/travis/build_env.sh
+++ b/travis/build_env.sh
@@ -155,6 +155,9 @@ fi
         sudo  apt-get -y install gcc-11 gfortran-11 g++-11
     fi
     fi
+    if [[ "$USE_LIBXC" == "-1" ]]; then
+	sudo apt-get -y install libxc-dev
+    fi
     if [[ "$FC" == "ifort" ]] || [[ "$FC" == "ifx" ]]; then
         sh ./"$base".sh -a -c -s --action remove --install-dir $IONEAPI_ROOT   --eula accept
         sh ./"$hpc".sh -a -c -s --action remove --install-dir  $IONEAPI_ROOT  --eula accept

--- a/travis/nwchem.bashrc
+++ b/travis/nwchem.bashrc
@@ -188,3 +188,9 @@ if [[ "$FC" == "gfortran" ]]; then
      export NWCHEM_MODULES=$(echo $NWCHEM_MODULES |sed  's/xtb//')
    fi
 fi
+
+if [[ "$USE_LIBXC" == "-1" ]]; then
+    unset USE_LIBXC
+    export LIBXC_LIB=/usr/lib/x86_64-linux-gnu
+    export LIBXC_INCLUDE=/usr/include
+fi

--- a/travis/run_qas.sh
+++ b/travis/run_qas.sh
@@ -162,7 +162,7 @@ fi
 	     cd $TRAVIS_BUILD_DIR/QA && ./runtests.mpi.unix procs $nprocs tddftgrad_h2o_cis_lda
 	     cd $TRAVIS_BUILD_DIR/QA && ./runtests.mpi.unix procs $nprocs au2-sarc-zora-mp
 	     cd $TRAVIS_BUILD_DIR/QA && ./runtests.mpi.unix procs $nprocs x2c-h2se
-	   if [[ ! -z "$USE_LIBXC" ]]; then
+	   if [[ ! -z "$USE_LIBXC" ]] || [[ ! -z "$LIBXC_INCLUDE" ]]; then
 	       cd $TRAVIS_BUILD_DIR/QA && ./runtests.mpi.unix procs $nprocs libxc_he2+
 	       cd $TRAVIS_BUILD_DIR/QA && ./runtests.mpi.unix procs $nprocs libxc_scanl
 	   fi


### PR DESCRIPTION
* tested with ubuntu:22.04 (github action)
* since the debian/ubuntu packages install of libraries and headers are not under the same `LIBXC_DIR`, I have modified the makefile structure to use `LIBXC_LIB` and `LIBXC_INCLUDE`, instead.