### PR TITLE
fix libxc build with USE_LIBXC

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3646,7 +3646,7 @@ endif
 ifdef USE_LIBXC
     DEFINES += -DUSE_LIBXC
     EXTRA_LIBS += -L$(NWCHEM_TOP)/src/libext/libxc/install/lib
-    EXTRA_LIBS += -lxcf03 -lxc
+    EXTRA_LIBS += -lnwc_xcf03 -lnwc_xc
 endif
 
 # we use an external libxc library out of LIBXC_DIR

--- a/src/libext/libxc/GNUmakefile
+++ b/src/libext/libxc/GNUmakefile
@@ -5,7 +5,7 @@
 
 include ../../config/makefile.h
 
-install/lib/libxc.a:
+install/lib/libnwc_xc.a:
 	./build_libxc.sh $(LIBXC_VERSION)
 
 LIB_TARGETS += libxc

--- a/src/libext/libxc/build_libxc.sh
+++ b/src/libext/libxc/build_libxc.sh
@@ -125,4 +125,6 @@ $CMAKE  -DCMAKE_INSTALL_PREFIX=${NWCHEM_TOP}/src/libext/libxc/install -DCMAKE_C_
 
 make -j4 | tee make.log
 make install
+ln -sf  ../install/lib/libxc.a ../install/lib/libnwc_xc.a
+ln -sf  ../install/lib/libxcf03.a ../install/lib/libnwc_xcf03.a
 

--- a/src/libext/libxc/build_libxc.sh
+++ b/src/libext/libxc/build_libxc.sh
@@ -125,6 +125,6 @@ $CMAKE  -DCMAKE_INSTALL_PREFIX=${NWCHEM_TOP}/src/libext/libxc/install -DCMAKE_C_
 
 make -j4 | tee make.log
 make install
-ln -sf  ../install/lib/libxc.a ../install/lib/libnwc_xc.a
-ln -sf  ../install/lib/libxcf03.a ../install/lib/libnwc_xcf03.a
+ln -sf  ../../install/lib/libxc.a ../../install/lib/libnwc_xc.a
+ln -sf  ../../install/lib/libxcf03.a ../../install/lib/libnwc_xcf03.a
 


### PR DESCRIPTION
rename libraries to libnwc_* to avoid conflict with system libraries