### PR TITLE
use Fortran 95 CPU_TIME intrinsic unconditionally

### DIFF
--- a/src/util/util_cpusec.F
+++ b/src/util/util_cpusec.F
@@ -1,52 +1,23 @@
       double precision function util_cpusec()
       implicit none
-c $Id$
 *
 * routine to give cpu seconds since start of execution
 *  delta times are handled by all applications
 *
-#if defined(BGL) || defined(BGP) || defined(BGQ)
-      EXTERNAL MPI_WTIME
-      REAL*8 MPI_WTIME
-      util_cpusec = MPI_WTIME()
-#elif defined(IBM) || defined(SP1) ||defined(HPUX)
-      double precision ibm_cputime
-      external ibm_cputime
-      util_cpusec = ibm_cputime()
-#elif defined(SUN) || defined(SOLARIS) || defined(LINUXALPHA)
-      real*4 tarray(2)
-      real*4 etime
-#ifndef GCC4
-      external etime
-#endif
-      util_cpusec = etime(tarray)
-#elif (defined(LINUX) || defined(CYGNUS)) && !defined(LINUXIA64) && !defined(CATAMOUNT)
+#if 1
+! this is a Fortran 95 standard intrinsic.
+      call cpu_time (util_cpusec)
+#elif (defined(LINUX) || defined(CYGNUS))
       double precision linux_cputime
       external linux_cputime
       util_cpusec = linux_cputime()
-#elif defined(WIN32) &&!defined(__MINGW32__)
+#elif defined(WIN32) && !defined(__MINGW32__)
       double precision win32_cputime
       external win32_cputime
       util_cpusec = win32_cputime()
-#elif defined(CRAY)
-      double precision secondr
-      external secondr
-      double precision first
-      logical ofirst
-      save first, ofirst
-      data ofirst /.true./
-      if (ofirst) then
-        first = secondr()
-        ofirst = .false.
-      endif
-      util_cpusec = secondr() - first ! Actually wall time
-#elif defined(FUJITSU_SOLARIS) || defined(CATAMOUNT)
-#ifdef FUJITSU_SOLARIS
-      intrinsic cpu_time
-#endif
-      call cpu_time (util_cpusec)
 #else
-#include "tcgmsg.fh"
-      util_cpusec = TCGTIME()
+      EXTERNAL MPI_WTIME
+      REAL*8 MPI_WTIME
+      util_cpusec = MPI_WTIME()
 #endif
       end


### PR DESCRIPTION
it is essentially impossible to find a compiler that doesn't support Fortran 95 anymore.  it is a safe assumption and makes NWChem less sensitive to the operating system.

the Linux, Windows and MPI versions are preserved in case someone finds them necessary.  they can be enabled via preprocessing if the need arises.

the Linux timer was given incorrect results (0.0) on a relatively common platform (Intel), which motivated this changed. see https://github.com/nwchemgit/nwchem/issues/755 for details.

the obsolete platforms were removed from this file. Catamount, IBM (that isn't Linux), Fujitsu (that isn't Linux), and Cray (that isn't Linux) are no longer relevant to us.