### PR TITLE
fix for QA script

### DIFF
--- a/QA/runtests.mpi.unix
+++ b/QA/runtests.mpi.unix
@@ -466,8 +466,8 @@ sync
     fi
 
     diff -w ${STUB}.ok.out.nwparse ${STUB}.out.nwparse >& /dev/null
-    cat ${ERRORFILE}
     diff1status=$?
+    cat ${ERRORFILE}
 #
   fi
 #


### PR DESCRIPTION
wrong placement of cat stderr in runtests.mpi.unix