### PR TITLE
restoring 2-D GA based 2-nd derivatives code

### DIFF
--- a/src/config/check_env.sh
+++ b/src/config/check_env.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-if [[ -z $1 ]]; then
+if [[ ! -z $GFORTRAN_MARCH ]] ; then
+    exit=0
+elif [[ -z $1 ]]; then
     #undefined
     exit=1
-elif [[ $1 == "N" ]] || [[ $1 == "n" ]] || [[ $1 == "0" ]] ; then
+elif [[ $1 == "N" ]] || [[ $1 == "n" ]] || [[ $1 == "0" ]] || [[ ! -z $GFORTRAN_MARCH ]] ; then
     exit=0
 else
     exit=1

--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -2534,7 +2534,7 @@ ifneq ($(TARGET),LINUX)
 #                       FOPTIMIZE += -xHost
                         ifndef USE_IFX
 #                           crazy simd options
-                            ifeq ($(shell $(CNFDIR)/check_env.sh $(USE_HWOPT)),1)
+#                            ifeq ($(shell $(CNFDIR)/check_env.sh $(USE_HWOPT)),1)
                                 ifeq ($(_IFCV17), Y)
                                     ifeq ($(_GOTAVX512F),Y)
                                         FOPTIMIZE += -axCORE-AVX512
@@ -2547,7 +2547,7 @@ ifneq ($(TARGET),LINUX)
                                     else ifeq ($(_GOTSSE3),Y) 
                                         FOPTIMIZE += -axSSE3
                                     endif
-                                endif
+#                                endif
                             endif
                             FOPTIONS += -finline-limit=250
                         endif
@@ -2745,6 +2745,9 @@ ifneq ($(TARGET),LINUX)
             ifeq ($(GNU_GE_4_6),true)
                 ifeq ($(shell $(CNFDIR)/check_env.sh $(USE_HWOPT)),1)
                     FOPTIMIZE +=  -mtune=native
+                endif
+                ifdef GFORTRAN_MARCH
+                    FOPTIMIZE += -march=$(GFORTRAN_MARCH)
                 endif
 #               causes slowdows in mp2/ccsd
 #               FOPTIONS += -finline-functions
@@ -3090,7 +3093,6 @@ ifneq ($(TARGET),LINUX)
 #                DEFINES +=-DUSE_F90_ALLOCATABLE -DUSE_OMP_TEAMS_DISTRIBUTE
             endif
         endif
-		
 
         ifeq ($(NWCHEM_TARGET),CATAMOUNT)
             DEFINES  += -DCATAMOUNT
@@ -3576,10 +3578,10 @@ ifdef USE_MPI
                 endif
                 ifdef MPI_LIB
                     $(info ***warning MPI_LIB ignored since FORCE_MPI_ENV not set***)
- 	        endif
+                endif
                 ifdef MPI_INCLUDE
                     $(info ***warning MPI_INCLUDE ignored since FORCE_MPI_ENV not set***)
- 	        endif
+                endif
 	    endif
 	endif
         # check if mpif90 is present

--- a/src/ddscf/GNUmakefile
+++ b/src/ddscf/GNUmakefile
@@ -44,7 +44,7 @@
         rohf_lagr.o 		rohf_diis.o \
 	rhf_fock.o              multipole.o ga_mat_to_vec.o \
         movecs_frag.o  localize.o int_dip_ga.o \
-        fock_xc.o fock_j_fit.o rohf_jkfac.o uhf_jkfac.o \
+        fock_xc.o fock_xc_dm3d.o fock_j_fit.o rohf_jkfac.o uhf_jkfac.o \
         rohf_hessv3.o \
 	fock_2e_cam.o ga_get2eri.o scf_frozemb.o print_integrals.o \
 	rohf_hessv2_ext.o rohf_hessv3_ext.o uhf_hessv2_ext.o uhf_precond_ext.o \

--- a/src/ddscf/fock_xc.F
+++ b/src/ddscf/fock_xc.F
@@ -68,14 +68,12 @@ c
       integer alo(3), ahi(3), blo(3), bhi(3)
       integer nfock_xc,i
       integer ityp, ndim
-      logical lcgmin,l3d_arg
+      logical lcgmin
       external xc_gotxc,xc_getipol
-      integer ga_create_atom_blocked,dft_npatch,dft_dm3d,dft_dm3d_calc5
-      external ga_create_atom_blocked,dft_dm3d,dft_dm3d_calc5
-      integer g_dens_3d,g_dens_save(2)
+      integer ga_create_atom_blocked,dft_npatch
+      external ga_create_atom_blocked
 c
-      integer nroots            !number of roots for the TDDFT gradient calculations
-      integer g_test,len_gxcd
+      integer nroots  !number of roots for the TDDFT gradient calculations
 c
       if(.not.xc_gotxc()) return
       oprint= util_print('fock_xc',print_debug)
@@ -167,9 +165,10 @@ c     (unperturbed) density matrices.
 c
 c     g_dens_xc is the density matrix used in the XC routines
 c
-       len_gxcd=2
       if(l3d) then
+c     -------------
 c     calc_type = 2
+c     -------------
 c     the number of density matrices 
 c     needed is nfock_xc+1 (typically 1 for perturbed density and 1
 c     for unperturbed SCF density) for RDFT and 2*nfock_xc+2 (typically
@@ -177,32 +176,60 @@ c     2 for perturbed densities and 2 for unperturbed SCF densities) for
 c     UDFT.
 c
          if(ndens.eq.1) then
-            len_gxcd = nfock_xc+1
+            dims(1) = nfock_xc+1
          else
-            len_gxcd = 2*nfock_xc+2
+            dims(1) = 2*nfock_xc+2
          endif
+         if (.not.MA_alloc_Get(MT_int,dims(1),'XCDens',lgxcd,igxcd))
+     &      call errquit('fock_xc: cannot allocate xcdens',0, MA_ERR)
+c
+c     alpha bit
+c
+         alo(1) = 1
+         ahi(1) = nfock_xc
+         blo(1) = 1
+         bhi(1) = nfock_xc
+         do i=1,nfock_xc
+            int_mb(igxcd+i-1)=
+     =           dft_npatch(g_dens,i,nbf_ao,geom,ao_bas_han)
+         enddo
+c
+c     beta bit
+c
+         if(ndens.eq.2)  then
+            alo(1) = nfock_xc*2+1
+            ahi(1) = nfock_xc*3
+            blo(1) = nfock_xc+1+1
+            bhi(1) = nfock_xc*2+1
+            do i=blo(1),bhi(1)
+               int_mb(igxcd+i-1)=dft_npatch(g_dens,i+nfock_xc-1,
+     N              nbf_ao,geom,ao_bas_han)
+            enddo
+         endif
+c Daniel (1-10-13): We will need to do things differently for TDDFT
+c gradients because we are (possibly) feeding in density matrices for 
+c many excited states.
       elseif (calc_type.eq.5) then
-         len_gxcd=nfock+ndens
-      else
-c     calc_type = 1 or 3 or 4
-         len_gxcd=2
-      endif
-       if (.not.MA_alloc_Get(MT_int,len_gxcd,'XCDens',lgxcd,igxcd))
-     &        call errquit('fock_xc: cannot allocate xcdens',0, MA_ERR)
-      if (calc_type.eq.5) then
+c     -----------------------
+c     calc_type = 5
+c     -----------------------
 c Daniel (1-10-13): For the moment, I want the calculation to work for
 c a single root.  However, we at this point should have nfock+ndens
 c density matrices (nfock = nroots*ndens, and ndens accounts for the
 c spin-polarization, and hence the number of ground state density 
 c matrices).  I build the MA array anticipating testing the multiple
 c root situation in the future.
+         if (.not.MA_alloc_Get(MT_int,nfock+ndens,'XCDens',lgxcd,igxcd))
+     &      call errquit('fock_xc: cannot allocate xcdens',0, MA_ERR)
          do i = 1, nfock+ndens
             int_mb(igxcd+i-1) = g_dens(i)
          enddo
-      elseif(.not.l3d) then
+      else
 c     -----------------------
 c     calc_type = 1 or 3 or 4
 c     -----------------------
+         if (.not.MA_alloc_Get(MT_int,2,'XCDens',lgxcd,igxcd))
+     &      call errquit('fock_xc: cannot allocate xcdens',0, MA_ERR)
          int_mb(igxcd)=g_dens(1)
          if(ndens.eq.2) int_mb(igxcd+1)=g_dens(3)
       endif
@@ -210,11 +237,20 @@ c     -----------------------
          if (.not. bgj_get_scf_dens(g_dens_scf))
      &        call errquit('fock_xc: cant get scf density handles',0,
      &       UNKNOWN_ERR)
-          g_dens_3d=dft_dm3d(g_dens(1),g_dens_scf,
-     D        nbf_ao,geom,ao_bas_han,nfock_xc,ndens)
-         int_mb(igxcd)=g_dens_3d
-         g_dens_save(1)=g_dens(1)
-         g_dens(1)=g_dens_3d
+         alo(1) = 1
+         ahi(1) = nbf_ao
+         blo(1) = nfock_xc+1
+         bhi(1) = nfock_xc+1
+         int_mb(igxcd+nfock_xc) =
+     =        ga_create_atom_blocked(geom,ao_bas_han,'gdens+1')
+         call ga_copy(g_dens_scf(1),int_mb(igxcd+nfock_xc))
+         if(ndens.eq.2) then
+            blo(1) = 2*nfock_xc+1+1
+            bhi(1) = 2*nfock_xc+1+1
+            int_mb(igxcd+2*nfock_xc+1) =
+     =        ga_create_atom_blocked(geom,ao_bas_han,'gdens+2')
+            call ga_copy(g_dens_scf(2),int_mb(igxcd+2*nfock_xc+1))
+         endif
 c Daniel (1-10-13): The SCF density matrix is stored differently than
 c it is for calc_type = 1, 3, or 4
       elseif (calc_type.eq.5) then
@@ -222,11 +258,6 @@ c Use nroots to determine where the ground state density matrix is.
          nroots = nfock/ndens
          g_dens_scf(1) = int_mb(igxcd+nroots)
          if (ndens.eq.2) g_dens_scf(2) = int_mb(igxcd+2*nroots+1)
-          g_dens_3d=dft_dm3d_calc5(g_dens,
-     D        nbf_ao,geom,ao_bas_han,nfock,ndens)
-         g_dens_save(1)=g_dens(1)
-         g_dens(1)=g_dens_3d
-         int_mb(igxcd)=g_dens_3d
       else
          g_dens_scf(1) = int_mb(igxcd)
          if (ndens.eq.2) g_dens_scf(2) = int_mb(igxcd+1)
@@ -255,15 +286,31 @@ c
             endif
             call ga_print(g_dens_scf(2))
          endif
-         do i=1,len_gxcd
-            write(luout,*) i,'igxcd',int_mb(igxcd+i-1)
-            call ga_print(int_mb(igxcd+i-1))
-         enddo
+         if(ga_nodeid().eq.0) then
+            write(luout,*) 'g_dens_xc1',int_mb(igxcd)
+            call util_flush(luout)
+         endif
+         if(l3d) then
+            do i=1,ndens*(nfock_xc+1)
+               alo(1)=i
+               ahi(1)=i
+               call ga_print(int_mb(igxcd+i-1))
+            enddo
+         else
+            call ga_print(int_mb(igxcd))
+         endif
+         if(ndens.eq.2.and.(.not.l3d)) then
+            if(ga_nodeid().eq.0) then
+               write(luout,*) 'g_dens_xc2',int_mb(igxcd+1)
+               call util_flush(luout)
+            endif
+            call ga_print(int_mb(igxcd+1))
+         endif
       endif  
       call xc_init_index(geom,ndens,nbf_ao,ao_bas_han,
      &   g_dens_scf, l_cntoce, k_cntoce,
      &   l_cntobfr, k_cntobfr, l_cetobfr, k_cetobfr,
-     &     l_rdens_atom, k_rdens_atom)
+     &   l_rdens_atom, k_rdens_atom)
 c     
 c     check if we can get the grid from a file
 c         
@@ -272,30 +319,28 @@ c Daniel (2-18-13): For calc_type = 5, we don't use a 3D global array
 c and therefore don't want l3d to be set equal to true. 
 c      if (.not.lcgmin) then
       if (.not.lcgmin.and.calc_type.ne.5) then
-         l3d_arg=.true.
-      else
-         l3d_arg=l3d
-      endif
-      call grid_quadv0_gen(rtdb,  
+       call grid_quadv0_gen(rtdb, 
      &     int_mb(igxcd),
      &     g_xc, nexc,
      &     rho_n_dum, Exc,
-     &     nfock_xc, calc_type, tdum, l3d_arg, triplet)
+     &     nfock_xc, calc_type, tdum, .true., triplet)
+      else
+       call grid_quadv0_gen(rtdb, 
+     &     int_mb(igxcd),
+     &     g_xc, nexc,
+     &     rho_n_dum, Exc,
+     &     nfock_xc, calc_type, tdum, l3d, triplet)
+      end if
 c
       call dft_store_rhon(rho_n_dum)
 c
 c     Clean up
 c
-      if(calc_type.eq.2.or.calc_type.eq.5) then
-         g_dens(1)=g_dens_save(1)
-         if (.not. ga_destroy(g_dens_3d))
-     &        call errquit('fock_xc: could not destroy g_dens_3d',0,
-     &        GA_ERR)
-      elseif(l3d) then
+      if(l3d) then
          do i=1,dims(1)
-            if (.not. ga_destroy(int_mb(igxcd+i-1)))
-     &           call errquit('fock_xc: could not destroy g_dens_xc',0,
-     &           GA_ERR)
+         if (.not. ga_destroy(int_mb(igxcd+i-1)))
+     &      call errquit('fock_xc: could not destroy g_dens_xc',0,
+     &       GA_ERR)
          enddo
       endif
       if (.not.ma_free_heap(lgxcd))
@@ -311,17 +356,17 @@ c     move beta from block 2 to block 4
          ahi(1) = nfock_xc*2
          blo(1) = nfock_xc*3+1
          bhi(1) = nfock_xc*4
-         call nga_copy_patch('N',g_xc(1),alo,ahi,
-     &      g_xc(1),blo,bhi)
+         call nga_copy_patch('N',g_xc,alo,ahi,
+     &      g_xc,blo,bhi)
 c     move alpha from block 1 to block 2
          alo(1) = 1
          ahi(1) = nfock_xc
          blo(1) = nfock_xc+1
          bhi(1) = nfock_xc*2
-         call nga_copy_patch('N',g_xc(1),alo,ahi,
-     &      g_xc(1),blo,bhi)
+         call nga_copy_patch('N',g_xc,alo,ahi,
+     &      g_xc,blo,bhi)
 c     zero block 1 that was occupied by alpha
-         call nga_zero_patch(g_xc(1), alo, ahi)
+         call nga_zero_patch(g_xc, alo, ahi)
 c     flip sign to make it consistent with HF K (Exchange)
          call ga_scale(g_xc,-1d0)
       endif
@@ -339,7 +384,7 @@ c
 c
       if (oprint) then
          if(ga_nodeid().eq.0)write(luout,*)'XC matrix at end fock_xc:'
-         tdum=ga_ddot(g_xc(1),g_xc(1))
+         tdum=ga_ddot(g_xc,g_xc)
          if(ga_nodeid().eq.0)write(luout,*)'g_xc dotproduct',tdum
          do i=1,nfock
             alo(1)=i
@@ -382,9 +427,6 @@ c
       integer ga_create_atom_blocked
       external ga_create_atom_blocked
       integer alo(3), ahi(3), blo(2), bhi(2)
-      integer ityp,ndim,dims(3)
-      external ga_nodeid
-      integer ga_nodeid
 c
 c     2-d GA dens1 
 c
@@ -401,102 +443,6 @@ c
       bhi(2) = nbf
       call nga_copy_patch('N',g_dens,alo,ahi,g_dens1,blo,bhi)
       dft_npatch=g_dens1
-      return
-      end
-      integer function dft_dm3d(g_dens,g_dens_scf,
-     ,     nbf,geom,basis,nfock_xc,ndens)
-      implicit none
-c     integer dft_dm3d ! new GA handle
-      integer ndens,nfock_xc
-      integer g_dens ! N-D GA
-      integer g_dens_scf(2)
-      integer nbf
-      integer geom,basis
-c
-      integer ga_create_atom_blocked
-      external ga_create_atom_blocked
-      integer alo(3), ahi(3), blo(3), bhi(3)
-      integer ityp,ndim,dims(3)
-      external ga_nodeid,ga_create3d_atom_blocked
-      integer ga_nodeid,ga_create3d_atom_blocked
-c
-c     2-d GA dens1 
-c
-c     call nga_inquire(g_dens, ityp, ndim, dims)
-      ndim=3
-      dims(1)=ndens*(nfock_xc+1)
-      dft_dm3d=ga_create3d_atom_blocked(geom, basis,
-     S     'xcdm3d', dims(1))
-      alo(1) = 1
-      ahi(1) = nfock_xc
-      alo(2) = 1
-      ahi(2) = nbf
-      alo(3) = 1
-      ahi(3) = nbf
-      blo(1) = 1
-      bhi(1) = nfock_xc
-      blo(2) = 1
-      bhi(2) = nbf
-      blo(3) = 1
-      bhi(3) = nbf
-      call nga_copy_patch('N',g_dens,alo,ahi,dft_dm3d,blo,bhi)
-      if(ndens.eq.2) then
-         alo(1) = nfock_xc*2+1
-         ahi(1) = 3*nfock_xc
-         blo(1) = nfock_xc+2
-         bhi(1) = 2*nfock_xc+1
-         call nga_copy_patch('N',g_dens,alo,ahi,dft_dm3d,blo,bhi)
-      endif
-      alo(1) = 1
-      ahi(1) = nbf
-      alo(2) = 1
-      ahi(2) = nbf
-      blo(1) = nfock_xc+1
-      bhi(1) = nfock_xc+1
-      call nga_copy_patch('N',g_dens_scf(1),alo,ahi,dft_dm3d,blo,bhi)
-      if(ndens.eq.2) then
-         blo(1) = 2*nfock_xc+2
-         bhi(1) = 2*nfock_xc+2
-         call nga_copy_patch('N',g_dens_scf(2),alo,ahi,dft_dm3d,blo,bhi)
-      endif
-      return
-      end
-      integer function dft_dm3d_calc5(g_dens,
-     ,     nbf,geom,basis,nfock,ndens)
-      implicit none
-      integer ndens,nfock
-      integer g_dens(*) ! array of 2-D GA
-      integer nbf
-      integer geom,basis
-c
-      integer ga_create_atom_blocked
-      external ga_create_atom_blocked
-      integer alo(3), ahi(3), blo(3), bhi(3)
-      integer dims_3d, i
-      external ga_nodeid,ga_create3d_atom_blocked
-      integer ga_nodeid,ga_create3d_atom_blocked
-c
-      dims_3d=ndens+nfock
-      dft_dm3d_calc5=ga_create3d_atom_blocked(geom, basis,
-     S     'xcdm3d_calc5', dims_3d)
-c2d
-      alo(1) = 1
-      ahi(1) = nbf
-      alo(2) = 1
-      ahi(2) = nbf
-      alo(3) = 1
-      ahi(3) = 1
-c3d      
-      blo(2) = 1
-      bhi(2) = nbf
-      blo(3) = 1
-      bhi(3) = nbf
-      do i=1,nfock+ndens
-         blo(1)=i
-         bhi(1)=i
-         call nga_copy_patch('N',g_dens(i),
-     D        alo,ahi,dft_dm3d_calc5,blo,bhi)
-      enddo
       return
       end
       subroutine dft_store_rhon(dft_rho_n)

--- a/src/ddscf/fock_xc_dm3d.F
+++ b/src/ddscf/fock_xc_dm3d.F
@@ -1,0 +1,462 @@
+C>
+C> \brief Wrapper for AO-basis XC matrices without fitting
+C>
+      subroutine fock_xc_dm3d(geom, nbf_ao, ao_bas_han,
+     &   nfock, g_dens, g_xc, Exc, nExc, l3d)
+c
+c     $Id$
+c
+c     Wrapper routine for AO-basis XC matrices without fitting
+c
+c     BGJ - 8/98
+c
+      implicit none
+#include "errquit.fh"
+c
+#include "global.fh"
+#include "geom.fh"
+#include "mafdecls.fh"
+c!!! BGJ
+#include "bgj.fh"
+#include "rtdb.fh"
+#include "util.fh"
+#include "stdio.fh"
+c!!! BGJ
+c
+      integer geom              !< [Input] Geometry handle
+      integer nbf_ao,ao_bas_han !< [Input] No. of AOs and AO handle
+      integer nfock             !< [Input] No. of XC matrices
+c                               !<         = No. of density matx (RDFT)
+c                               !<         = 4 * No. of density matx (UDFT)
+      integer ndens             !< [Local] = ipol
+      integer g_dens(*)         !< [Input] Array of handles to densities
+      integer g_xc(*)           !< [Input] Array of handles to XC matrices
+      integer calc_type         !< [Input] Type of XC matrix calculation
+c                               !<         = 1 XC contrib to Fock
+c                               !<         = 2 XC contrib to CPKS LHS
+c                               !<         = 3 XC contrib to CPKS RHS
+c                               !<         = 4 XC NMR contrib
+c                               !<         = 5 XC third-derivative contrib
+      logical l3d               !< [Local] Whether 3-D NGA density
+c                               !<         and fock matrices are used.
+c                               !<         Must be true when and only when
+c                               !<         calctype = 2
+      logical triplet           !< [Rtdb]  True if TDDFT triplet excitation
+c                               !<         energy calculations from RDFT.
+c                               !<         If not set, then .false. is
+c                               !<         assumed.  For Hessian, this must
+c                               !<         be false (or not set).
+c
+      integer nExc              !< [Input]  no. exchange-correlation energy
+c                               !<          components.
+      double precision Exc(nExc)!< [Output] Exchange-correlation energy
+c                               !<          components
+c
+c     Local declarations
+c
+      integer rtdb
+      integer g_wght_dum, g_xyz_dum, g_nq_dum,
+     &        l_cntoce, k_cntoce, l_cntobfr, k_cntobfr,
+     &        l_cetobfr, k_cetobfr, l_rdens_atom, k_rdens_atom
+      integer g_dens_scf(2)
+      logical wght_GA_dum,grid_reopen,xc_gotxc
+      double precision rho_n_dum,tdum
+      integer dims(3),chunk(3)
+      integer igxcd,lgxcd
+      integer xc_getipol
+      logical oprint, debug
+      integer alo(3), ahi(3), blo(3), bhi(3)
+      integer nfock_xc,i
+      integer ityp, ndim
+      logical lcgmin,l3d_arg
+      external xc_gotxc,xc_getipol
+      integer ga_create_atom_blocked,dft_npatch,dft_dm3d,dft_dm3d_calc5
+      external ga_create_atom_blocked,dft_dm3d,dft_dm3d_calc5
+      integer g_dens_3d,g_dens_save(2)
+c
+      integer nroots            !number of roots for the TDDFT gradient calculations
+      integer g_test,len_gxcd
+c
+      if(.not.xc_gotxc()) return
+      oprint= util_print('fock_xc',print_debug)
+
+c ... jochen: 
+      debug = .false.
+c
+c Note that ndens=ipol and is not necessarily
+c equal to No. of density matrices.  "nfock" or "nmat"
+c will be related to No. of density matrices. 
+c
+      ndens=1
+      if(xc_getipol().eq.2) ndens=2
+      rtdb = bgj_get_rtdb_handle()
+      alo(2) = 1
+      ahi(2) = nbf_ao
+      alo(3) = 1
+      ahi(3) = nbf_ao
+      blo(2) = 1
+      bhi(2) = nbf_ao
+      blo(3) = 1
+      bhi(3) = nbf_ao
+c
+c     Get fock_xc variables
+c
+      if (.not. rtdb_get(rtdb, 'fock_xc:calc_type', mt_int, 1,
+     &   calc_type)) then
+         if ((oprint.or.debug).and.ga_nodeid().eq.0)
+     &      write(luout,*)' fockxc: calc_type not set: setting to 1'
+         calc_type = 1
+      endif
+      if (calc_type .eq. 0) then
+         if ((oprint.or.debug).and.ga_nodeid().eq.0)
+     &      write(luout,*)' fockxc: calc_type not set: setting to 1'
+         calc_type = 1
+      endif
+c
+c     == need a better solution for this == NXG
+c Daniel (2-16-13): This line of code is VERY dangerous.  It caused 
+c difficult to locate problems in the TDDFT gradient routines.
+      if (.not.rtdb_get(rtdb, 'dft:cgmin', mt_log, 1, lcgmin))
+     &   lcgmin=.false.
+c
+c     Whether this is a triplet excitation energy calculation
+c
+      if (.not. rtdb_get(rtdb, 'fock_xc:triplet', mt_log, 1,
+     &   triplet)) triplet=.false.
+c
+c     for uhf calculations, nmat is 4*nvec. The nmat passed to _quadv0_gen
+c     should be the number of vectors 
+c
+      nfock_xc=nfock
+c Daniel (2-13-13): The original way this part was written malfunctions 
+c for third derivatives.  The routine, xc_rhogen, only cares about 
+c whether the calculation is restricted or unrestricted (via ndens/ipol) 
+c and how many Fock matrices we need to build (via nfock_xc).  We
+c therefore need to divide nfock by ndens for 3rd derivatives, since 
+c nfock is set to nroots*ipol in the TDDFT gradient routines.  This
+c is only important for unrestricted calculations.
+      if(ndens.eq.2)  then
+        if (calc_type.eq.5) then
+          nfock_xc=nfock/ndens
+        else
+          nfock_xc=nfock/4
+        endif
+      endif
+      if ((debug.or.oprint).and.ga_nodeid().eq.0) then
+         write(luout,*) '--------Entered fock_xc-------------'
+         write(luout,*) ' calc_type =',calc_type
+         write(luout,*) ' nfock ',nfock,' ndens ',ndens
+         write(luout,*) ' nfock_xc ',nfock_xc
+         write(luout,*) ' l3d ',l3d
+         write(luout,*) ' triplet ',triplet
+         call util_flush(luout)
+       endif
+       if(nfock_xc.eq.0) return
+c
+c     assumed l3d true AND calc_type=2
+c
+      if(l3d.and.calc_type.ne.2.or.
+     &   (.not.l3d).and.calc_type.eq.2) then
+        write (luout,*) 'l3d, calc_type =',l3d,calc_type
+        call errquit ('fxc: calc_type-l3d logic wrong ',0, UNKNOWN_ERR)
+      end if
+c
+c     Set up local copies of density matrix handles. The number of 
+c     density matrices needed is ndens*nvec+2. The last two are scf
+c     (unperturbed) density matrices.
+c
+c     g_dens_xc is the density matrix used in the XC routines
+c
+       len_gxcd=2
+      if(l3d) then
+c     calc_type = 2
+c     the number of density matrices 
+c     needed is nfock_xc+1 (typically 1 for perturbed density and 1
+c     for unperturbed SCF density) for RDFT and 2*nfock_xc+2 (typically
+c     2 for perturbed densities and 2 for unperturbed SCF densities) for
+c     UDFT.
+c
+         if(ndens.eq.1) then
+            len_gxcd = nfock_xc+1
+         else
+            len_gxcd = 2*nfock_xc+2
+         endif
+      elseif (calc_type.eq.5) then
+         len_gxcd=nfock+ndens
+      else
+c     calc_type = 1 or 3 or 4
+         len_gxcd=2
+      endif
+       if (.not.MA_alloc_Get(MT_int,len_gxcd,'XCDens',lgxcd,igxcd))
+     &        call errquit('fock_xc: cannot allocate xcdens',0, MA_ERR)
+      if (calc_type.eq.5) then
+c Daniel (1-10-13): For the moment, I want the calculation to work for
+c a single root.  However, we at this point should have nfock+ndens
+c density matrices (nfock = nroots*ndens, and ndens accounts for the
+c spin-polarization, and hence the number of ground state density 
+c matrices).  I build the MA array anticipating testing the multiple
+c root situation in the future.
+         do i = 1, nfock+ndens
+            int_mb(igxcd+i-1) = g_dens(i)
+         enddo
+      elseif(.not.l3d) then
+c     -----------------------
+c     calc_type = 1 or 3 or 4
+c     -----------------------
+         int_mb(igxcd)=g_dens(1)
+         if(ndens.eq.2) int_mb(igxcd+1)=g_dens(3)
+      endif
+      if (calc_type .eq. 2) then
+         if (.not. bgj_get_scf_dens(g_dens_scf))
+     &        call errquit('fock_xc: cant get scf density handles',0,
+     &       UNKNOWN_ERR)
+          g_dens_3d=dft_dm3d(g_dens(1),g_dens_scf,
+     D        nbf_ao,geom,ao_bas_han,nfock_xc,ndens)
+         int_mb(igxcd)=g_dens_3d
+         g_dens_save(1)=g_dens(1)
+         g_dens(1)=g_dens_3d
+c Daniel (1-10-13): The SCF density matrix is stored differently than
+c it is for calc_type = 1, 3, or 4
+      elseif (calc_type.eq.5) then
+c Use nroots to determine where the ground state density matrix is.
+         nroots = nfock/ndens
+         g_dens_scf(1) = int_mb(igxcd+nroots)
+         if (ndens.eq.2) g_dens_scf(2) = int_mb(igxcd+2*nroots+1)
+          g_dens_3d=dft_dm3d_calc5(g_dens,
+     D        nbf_ao,geom,ao_bas_han,nfock,ndens)
+         g_dens_save(1)=g_dens(1)
+         g_dens(1)=g_dens_3d
+         int_mb(igxcd)=g_dens_3d
+      else
+         g_dens_scf(1) = int_mb(igxcd)
+         if (ndens.eq.2) g_dens_scf(2) = int_mb(igxcd+1)
+      endif
+c
+c     Prepare to call xc_quadv0
+c
+      g_wght_dum = -1
+      g_xyz_dum = -1
+      g_nq_dum = -1
+      wght_GA_dum = .false.
+      rho_n_dum = 0
+      Exc(1) = 0.0d0
+      Exc(2) = 0.0d0
+      tdum = 0
+      if(oprint) then
+         if(ga_nodeid().eq.0) then
+            write(luout,*) 'gdenscf1',g_dens_scf(1)
+            call util_flush(luout)
+         endif
+         call ga_print(g_dens_scf(1))
+         if(ndens.eq.2) then
+            if(ga_nodeid().eq.0) then
+               write(luout,*) 'gdenscf2',g_dens_scf(2)
+               call util_flush(luout)
+            endif
+            call ga_print(g_dens_scf(2))
+         endif
+         do i=1,len_gxcd
+            write(luout,*) i,'igxcd',int_mb(igxcd+i-1)
+            call ga_print(int_mb(igxcd+i-1))
+         enddo
+      endif  
+      call xc_init_index(geom,ndens,nbf_ao,ao_bas_han,
+     &   g_dens_scf, l_cntoce, k_cntoce,
+     &   l_cntobfr, k_cntobfr, l_cetobfr, k_cetobfr,
+     &     l_rdens_atom, k_rdens_atom)
+c     
+c     check if we can get the grid from a file
+c         
+c
+c Daniel (2-18-13): For calc_type = 5, we don't use a 3D global array
+c and therefore don't want l3d to be set equal to true. 
+c      if (.not.lcgmin) then
+      if (.not.lcgmin.and.calc_type.ne.5) then
+         l3d_arg=.true.
+      else
+         l3d_arg=l3d
+      endif
+      call grid_quadv0_gen(rtdb,  
+     &     int_mb(igxcd),
+     &     g_xc, nexc,
+     &     rho_n_dum, Exc,
+     &     nfock_xc, calc_type, tdum, l3d_arg, triplet)
+c
+      call dft_store_rhon(rho_n_dum)
+c
+c     Clean up
+c
+      if(calc_type.eq.2.or.calc_type.eq.5) then
+         g_dens(1)=g_dens_save(1)
+         if (.not. ga_destroy(g_dens_3d))
+     &        call errquit('fock_xc: could not destroy g_dens_3d',0,
+     &        GA_ERR)
+      elseif(l3d) then
+         do i=1,dims(1)
+            if (.not. ga_destroy(int_mb(igxcd+i-1)))
+     &           call errquit('fock_xc: could not destroy g_dens_xc',0,
+     &           GA_ERR)
+         enddo
+      endif
+      if (.not.ma_free_heap(lgxcd))
+     &   call errquit('fockxc: cannot pop stack',0, MA_ERR)
+c
+      ndim = ga_ndim(g_xc)
+      if(ndens.eq.2.and.ndim.eq.3)  then
+c
+c     need to go from 2nfock ga to 4nfock (and sign flip)
+c
+c     move beta from block 2 to block 4
+         alo(1) = nfock_xc+1
+         ahi(1) = nfock_xc*2
+         blo(1) = nfock_xc*3+1
+         bhi(1) = nfock_xc*4
+         call nga_copy_patch('N',g_xc(1),alo,ahi,
+     &      g_xc(1),blo,bhi)
+c     move alpha from block 1 to block 2
+         alo(1) = 1
+         ahi(1) = nfock_xc
+         blo(1) = nfock_xc+1
+         bhi(1) = nfock_xc*2
+         call nga_copy_patch('N',g_xc(1),alo,ahi,
+     &      g_xc(1),blo,bhi)
+c     zero block 1 that was occupied by alpha
+         call nga_zero_patch(g_xc(1), alo, ahi)
+c     flip sign to make it consistent with HF K (Exchange)
+         call ga_scale(g_xc,-1d0)
+      endif
+c
+      call xc_exit_index(l_cntoce, l_cntobfr, l_cetobfr, l_rdens_atom)
+c
+      if (calc_type .eq. 2) then
+         if (.not. ga_destroy(g_dens_scf(1)))
+     &      call errquit('fock_xc: could not destroy DM',1, GA_ERR)
+         if (ndens. eq. 2) then
+            if (.not. ga_destroy(g_dens_scf(2)))
+     &         call errquit('fock_xc: could not destroy DM',2, GA_ERR)
+         endif
+      endif
+c
+      if (oprint) then
+         if(ga_nodeid().eq.0)write(luout,*)'XC matrix at end fock_xc:'
+         tdum=ga_ddot(g_xc(1),g_xc(1))
+         if(ga_nodeid().eq.0)write(luout,*)'g_xc dotproduct',tdum
+         do i=1,nfock
+            alo(1)=i
+            ahi(1)=i
+            tdum=nga_ddot_patch(g_xc, 'N', alo, ahi, 
+     &         g_xc, 'N', alo, ahi) 
+            if(ga_nodeid().eq.0) then
+               write(luout,*) ' matrix no. ',i,tdum
+               call util_flush(luout)
+            endif
+            if(abs(tdum).gt.1d-6) then
+            if(ga_nodeid().eq.0) then
+               call nga_inquire(g_xc, ityp, ndim, dims)
+               write(luout,*) ' ndim ',ndim,' dims ',dims
+               write(luout,*) ' alo ',alo
+               write(luout,*) ' ahi ',ahi
+               call util_flush(luout)
+            endif
+            call nga_print_patch(g_xc,alo,ahi,0)
+            endif
+         enddo
+      endif
+      return
+      end
+      integer function dft_dm3d(g_dens,g_dens_scf,
+     ,     nbf,geom,basis,nfock_xc,ndens)
+      implicit none
+c     integer dft_dm3d ! new GA handle
+      integer ndens,nfock_xc
+      integer g_dens ! N-D GA
+      integer g_dens_scf(2)
+      integer nbf
+      integer geom,basis
+c
+      integer ga_create_atom_blocked
+      external ga_create_atom_blocked
+      integer alo(3), ahi(3), blo(3), bhi(3)
+      integer ityp,ndim,dims(3)
+      external ga_nodeid,ga_create3d_atom_blocked
+      integer ga_nodeid,ga_create3d_atom_blocked
+c
+c     2-d GA dens1 
+c
+c     call nga_inquire(g_dens, ityp, ndim, dims)
+      ndim=3
+      dims(1)=ndens*(nfock_xc+1)
+      dft_dm3d=ga_create3d_atom_blocked(geom, basis,
+     S     'xcdm3d', dims(1))
+      alo(1) = 1
+      ahi(1) = nfock_xc
+      alo(2) = 1
+      ahi(2) = nbf
+      alo(3) = 1
+      ahi(3) = nbf
+      blo(1) = 1
+      bhi(1) = nfock_xc
+      blo(2) = 1
+      bhi(2) = nbf
+      blo(3) = 1
+      bhi(3) = nbf
+      call nga_copy_patch('N',g_dens,alo,ahi,dft_dm3d,blo,bhi)
+      if(ndens.eq.2) then
+         alo(1) = nfock_xc*2+1
+         ahi(1) = 3*nfock_xc
+         blo(1) = nfock_xc+2
+         bhi(1) = 2*nfock_xc+1
+         call nga_copy_patch('N',g_dens,alo,ahi,dft_dm3d,blo,bhi)
+      endif
+      alo(1) = 1
+      ahi(1) = nbf
+      alo(2) = 1
+      ahi(2) = nbf
+      blo(1) = nfock_xc+1
+      bhi(1) = nfock_xc+1
+      call nga_copy_patch('N',g_dens_scf(1),alo,ahi,dft_dm3d,blo,bhi)
+      if(ndens.eq.2) then
+         blo(1) = 2*nfock_xc+2
+         bhi(1) = 2*nfock_xc+2
+         call nga_copy_patch('N',g_dens_scf(2),alo,ahi,dft_dm3d,blo,bhi)
+      endif
+      return
+      end
+      integer function dft_dm3d_calc5(g_dens,
+     ,     nbf,geom,basis,nfock,ndens)
+      implicit none
+      integer ndens,nfock
+      integer g_dens(*) ! array of 2-D GA
+      integer nbf
+      integer geom,basis
+c
+      integer ga_create_atom_blocked
+      external ga_create_atom_blocked
+      integer alo(3), ahi(3), blo(3), bhi(3)
+      integer dims_3d, i
+      external ga_nodeid,ga_create3d_atom_blocked
+      integer ga_nodeid,ga_create3d_atom_blocked
+c
+      dims_3d=ndens+nfock
+      dft_dm3d_calc5=ga_create3d_atom_blocked(geom, basis,
+     S     'xcdm3d_calc5', dims_3d)
+c2d
+      alo(1) = 1
+      ahi(1) = nbf
+      alo(2) = 1
+      ahi(2) = nbf
+      alo(3) = 1
+      ahi(3) = 1
+c3d      
+      blo(2) = 1
+      bhi(2) = nbf
+      blo(3) = 1
+      bhi(3) = nbf
+      do i=1,nfock+ndens
+         blo(1)=i
+         bhi(1)=i
+         call nga_copy_patch('N',g_dens(i),
+     D        alo,ahi,dft_dm3d_calc5,blo,bhi)
+      enddo
+      return
+      end

--- a/src/hessian/analytic/shell_fock_build.F
+++ b/src/hessian/analytic/shell_fock_build.F
@@ -848,7 +848,7 @@ c
 #ifdef NXT
       next = nxtask(-nproc,task_size)
 #endif
-      call ga_igop(65331, cache_hitmiss, 12, '+')
+      call ga_igop(65331, cache_hitmiss(1,1), 12, '+')
       cache_hit=0
       cache_miss=0
       do jj=1,6
@@ -1241,6 +1241,7 @@ c
 #include "errquit.fh"
 #include "global.fh"
 #include "bgj.fh"
+#include "rtdb.fh"
 #include "mafdecls.fh"
 #include "util.fh"
 #include "stdio.fh"
@@ -1258,6 +1259,8 @@ c
       integer i
       logical oprint
       integer ilo(3),ihi(3)
+      logical dm3d
+      integer rtdb_out
       integer ga_create3d_atom_blocked
       external ga_create3d_atom_blocked
 c
@@ -1267,6 +1270,9 @@ c
      ,        ' ndens ',ndens
          call util_flush(luout)
       endif
+      rtdb_out=bgj_get_rtdb_handle()
+      if (.not.rtdb_get(rtdb_out,'dft:dm3d',mt_log,1,dm3d)) 
+     D     dm3d=.false.
 #if 0
       dims(1) = nfock
       dims(2) = nbf
@@ -1292,8 +1298,13 @@ c      write(6,123) ga_nodeid(),' gxc distr ihi',ihi
       Exc(1) = 0.0d0
       Exc(2) = 0.0d0
       nExc = 1
-      call fock_xc(geom, nbf,basis,
-     ,             ndens,  g_dens, g_xc,Exc,nExc,.true.)
+      if(dm3d) then
+         call fock_xc_dm3d(geom, nbf,basis,
+     ,        ndens,  g_dens, g_xc,Exc,nExc,.true.)
+      else
+         call fock_xc(geom, nbf,basis,
+     ,        ndens,  g_dens, g_xc,Exc,nExc,.true.)
+      endif
       call ga_add(1.0d0, g_xc, 1.0d0, g_fock,
      &     g_fock)
       if (oprint) then

--- a/src/libext/openblas/f_check.patch
+++ b/src/libext/openblas/f_check.patch
@@ -11,16 +11,6 @@
                  if [ "$major" -ge 4 ]; then
                      vendor=GFORTRAN
                      openmp='-fopenmp'
---- Makefile.prebuild.org	2023-07-31 11:27:53.629587426 -0700
-+++ Makefile.prebuild	2023-07-31 11:27:58.129611660 -0700
-@@ -60,6 +60,7 @@
- 	./getarch_2nd  1 >> $(TARGET_CONF)
- 
- $(TARGET_CONF): c_check$(SCRIPTSUFFIX) f_check$(SCRIPTSUFFIX) getarch
-+	echo excting @@ ./c_check$(SCRIPTSUFFIX) $(TARGET_MAKE) $(TARGET_CONF) "$(HOSTCC)" $(TARGET_FLAGS) $(CFLAGS) > /tmp/edoo.log
- 	./c_check$(SCRIPTSUFFIX) $(TARGET_MAKE) $(TARGET_CONF) "$(HOSTCC)" $(TARGET_FLAGS) $(CFLAGS)
- ifneq ($(ONLY_CBLAS), 1)
- 	./f_check$(SCRIPTSUFFIX) $(TARGET_MAKE) $(TARGET_CONF) "$(FC)" $(TARGET_FLAGS)
 --- c_check.org	2023-07-31 11:38:45.649079370 -0700
 +++ c_check	2023-07-31 11:39:02.001165470 -0700
 @@ -279,6 +279,7 @@

--- a/src/nwdft/grid/grid_quadv0.F
+++ b/src/nwdft/grid/grid_quadv0.F
@@ -165,7 +165,8 @@ c
       integer g_s
 
       integer nshells_bas,nbf_mxnbf_ce2
-      integer basis,g_dens_2d
+      integer basis,g_dens_org(2)
+      integer type,ndim,dims(3)
       integer dft_npatch
       external dft_npatch
 
@@ -198,6 +199,11 @@ c
       npol = (ipol*(ipol+1))/2
       if (.not.rtdb_get(rtdb,'dft:largenode', mt_log, 1, largenode))
      &     largenode=.false.
+      call nga_inquire(g_dens(1), type, ndim, dims)
+      if(ga_nodeid().eq.0.and.oprint) then
+         write(luout,*) ' ndim ',ndim
+         write(luout,*) ' dims ',(dims(ii),ii=1,ndim)
+      endif
 c
 c     Open grid pts file
 c     
@@ -448,20 +454,34 @@ c Daniel (1-11-13): I think we can stay similar to calc_type = 2 for
 c XC-third derivatives in this portion of the code, since this part
 c doesn't depend on having 3-dimensional GAs.
       if (calc_type.eq.2.or.calc_type.eq.5) then
-      call dfill(ipol*nctrs*nctrs, 0.0d0, dbl_mb(irdens_atom), 1)
+         call dfill(ipol*nctrs*nctrs, 0.0d0, dbl_mb(irdens_atom), 1)
+         if(ndim.eq.3) then
+            do isp=1,ipol
+               g_dens_org(isp)=g_dens(isp)
+            enddo
+         endif
          do isp=1,ipol
             do ii=1,nmat+1
-            g_dens_2d =
-     =           dft_npatch(g_dens,ii,nbf_ao,geom,ao_bas_han)
+               if(ndim.eq.3) then
+                  g_dens =
+     =                 dft_npatch(g_dens_org,ii,nbf_ao,geom,ao_bas_han)
+               endif
 c DM in last position is the scf DM               
                call util_ga_mat_reduce(nbf_ao,nctrs,int_mb(icetobfr), 
-     A              g_dens_2d,  1, 
+     A              g_dens,  1, 
      A              dbl_mb(irdens_atom+(isp-1)*nctrs*nctrs), 'absmax', 
      &              dbl_mb(iscr), nbf_ao_mxnbf_ce,.false.)
-               if (.not. ga_destroy(g_dens_2d))
-     &            call errquit(pname//'failed destroy',g_dens_2d,GA_ERR)
+               if(ndim.eq.3) then
+                  if (.not. ga_destroy(g_dens)) call errquit
+     P                 (pname//'failed destroy',g_dens,GA_ERR)
+               endif
             enddo
          enddo
+         if(ndim.eq.3) then
+            do isp=1,ipol
+               g_dens(isp)=g_dens_org(isp)
+            enddo
+         endif
       elseif (adft) then
         call adft_reduce(nbf_xc, nctrs, int_mb(icetobfr), tmat, ipol,
      &                   dbl_mb(irdens_atom))

--- a/src/nwdft/grid/grid_quadv0.F
+++ b/src/nwdft/grid/grid_quadv0.F
@@ -167,7 +167,7 @@ c
       integer nshells_bas,nbf_mxnbf_ce2
       integer basis,g_dens_org(2)
       integer type,ndim,dims(3)
-      integer dft_npatch
+      integer dft_npatch, iptr
       external dft_npatch
 
 #ifdef SOLARIS
@@ -462,17 +462,18 @@ c doesn't depend on having 3-dimensional GAs.
          endif
          do isp=1,ipol
             do ii=1,nmat+1
+               iptr=ii+(isp-1)*(nmat+1)
                if(ndim.eq.3) then
-                  g_dens =
+                  g_dens(iptr) =
      =                 dft_npatch(g_dens_org,ii,nbf_ao,geom,ao_bas_han)
                endif
 c DM in last position is the scf DM               
                call util_ga_mat_reduce(nbf_ao,nctrs,int_mb(icetobfr), 
-     A              g_dens,  1, 
+     A              g_dens(iptr),  1, 
      A              dbl_mb(irdens_atom+(isp-1)*nctrs*nctrs), 'absmax', 
      &              dbl_mb(iscr), nbf_ao_mxnbf_ce,.false.)
                if(ndim.eq.3) then
-                  if (.not. ga_destroy(g_dens)) call errquit
+                  if (.not. ga_destroy(g_dens(iptr))) call errquit
      P                 (pname//'failed destroy',g_dens,GA_ERR)
                endif
             enddo

--- a/src/nwdft/lr_tddft_grad/tddft_grad_compute_g.F
+++ b/src/nwdft/lr_tddft_grad/tddft_grad_compute_g.F
@@ -257,6 +257,7 @@ c
       external dft_dm3d_calc5
       logical  grid_reopen
       external grid_reopen
+      logical dm3d
       logical  xc_gotxc   ! do we have a density functional?
       external xc_gotxc
 c
@@ -929,26 +930,33 @@ c Daniel (1-16-13): Here I modified the gradient routine to include
 c the number of perturbed density matrices.  This is necessary so that we
 c can define a value for looping in xc_3rd_deriv and build the
 c perturbed density in xc_rhogen.  Since we loop over the roots, 
-c the number of Fock matrices is always equal to 1.
+c     the number of Fock matrices is always equal to 1.
+          if (.not.rtdb_get(rtdb,'dft:dm3d',mt_log,1,dm3d))
+     D         dm3d=.false.
 c
 c 3d
-c     
-          g_dens_3d=dft_dm3d_calc5(g_dtmp,
-     D        nao,ihdl_geom,ihdl_bfao,2*ipol,0)
-      if (xc_gotxc()) then
-        do ip = 1, 2*ipol
-          if (.not.ga_destroy(g_dtmp(ip)))
-     1      call errquit(pname//"could not destroy g_dtmp_ao", 0,
-     2        GA_ERR) 
-        enddo
-      endif
+c
+          if(dm3d) then
+             g_dens_3d=dft_dm3d_calc5(g_dtmp,
+     D            nao,ihdl_geom,ihdl_bfao,2*ipol,0)
+             if (xc_gotxc()) then
+                do ip = 1, 2*ipol
+                   if (.not.ga_destroy(g_dtmp(ip)))
+     1                call errquit(pname//"could not destroy g_dtmp_ao",
+     2                  0,  GA_ERR) 
+                enddo
+                g_dtmp(1)=g_dens_3d
+             endif
+          endif
 
           call dftgh_gridv0(rtdb,ihdl_geom,ihdl_bfao, ipol,nao,
-     &         g_dens_3d, dbl_mb(k_frc_dft), dum, idum, calc_type,
+     &         g_dtmp, dbl_mb(k_frc_dft), dum, idum, calc_type,
      &         nat, log_mb(k_act), nat, dbl_mb(k_rdens_atom),
-     &         int_mb(k_cetobfr), 1, otriplet, 0d0, .false.)
-       if (.not.ga_destroy(g_dens_3d))
-     +     call errquit(pname//"could not destroy g_dens_3d",0,GA_ERR)
+     &            int_mb(k_cetobfr), 1, otriplet, 0d0, .false.)
+          if(dm3d) then
+             if (.not.ga_destroy(g_dens_3d)) call errquit
+     P            (pname//"could not destroy g_dens_3d",0,GA_ERR)
+          endif
 c          call dftgh_gridv0(rtdb,ihdl_geom,ihdl_bfao, ipol,nao,
 c     &         g_dtmp, dbl_mb(k_frc_dft), dum, idum, calc_type,
 c     &         nat, log_mb(k_act), nat, dbl_mb(k_rdens_atom),

--- a/src/nwdft/lr_tddft_grad/tddft_grad_compute_g.F
+++ b/src/nwdft/lr_tddft_grad/tddft_grad_compute_g.F
@@ -1391,6 +1391,13 @@ c
       if (.not.ga_destroy(g_rhs_xc(1))) 
      +  call errquit(pname//"could not destroy g_rhs_xc",0,GA_ERR)
 c
+      if (xc_gotxc().and.(.not.dm3d)) then
+        do ip = 1, 2*ipol
+          if (.not.ga_destroy(g_dtmp(ip)))
+     1      call errquit(pname//"could not destroy g_dtmp_ao", 0,
+     2        GA_ERR) 
+        enddo
+      endif
 c
       do ip = 1, ipol
         if (.not.ga_destroy(g_d(0+ip)))

--- a/src/nwdft/lr_tddft_grad/tddft_grad_quadv0b.F
+++ b/src/nwdft/lr_tddft_grad/tddft_grad_quadv0b.F
@@ -18,6 +18,8 @@ c
 #include "errquit.fh"
 c
 #include "mafdecls.fh"
+#include "global.fh"
+#include "stdio.fh"
 #include "dftpara.fh"
 c     
       logical ldew              ! true if weight derivatives are included [input]
@@ -30,6 +32,8 @@ c
       integer ibf(mbf_ao), iniz(natoms), ifin(natoms)
       integer cetobfr(2,*)
       integer calctype
+      integer type,ndim,dims(3)
+
 c
 c Scratch array for product of XC functional, basis functions, and 
 c gradients of basis functions.
@@ -70,6 +74,15 @@ c
       double precision out(3)
       double precision ccdel(nq,mbf_ao,*)
 c
+c     check if 3d DM
+      call nga_inquire(g_dens(1), type, ndim, dims)
+#ifdef DEBUG      
+      if(ga_nodeid().eq.0) then
+         write(luout,*) ' ndim ',ndim
+         write(luout,*) ' dims ',(dims(imat),
+     ,        imat=1,ndim)
+      endif
+#endif      
       if (grad) then
         do imat = 1, nmat
           do ispin = 1, ipol
@@ -128,26 +141,26 @@ c Use this for the ground state density matrix (for the gradient of
 c the ground state density).  Note that g_dens(2) and g_dens(4) store
 c the ground state density matrices in TDDFT gradients.
                  if (calctype.eq.1) then
-#if 1                  
-                  call xc_get3ddm(g_dens(1),
-     I                           2*imat+ipol*(ispin-1),
-     %                   ifirst, ilast, 1, nbf_ao, ppp,nbfia)
-#else                  
-                  call ga_get(g_dens(2*imat+2*(ispin-1)), 
-     1                 ifirst, ilast, 1, nbf_ao, PPP, nbfia)
-#endif                  
+                    if(ndim.eq.3) then
+                       call xc_get3ddm(g_dens(1),
+     I                      2*imat+ipol*(ispin-1),
+     %                      ifirst, ilast, 1, nbf_ao, ppp,nbfia)
+                  else
+                     call ga_get(g_dens(2*imat+2*(ispin-1)),
+     1                    ifirst, ilast, 1, nbf_ao, PPP, nbfia)
+                  endif
 c Use this for the perturbed density matrix (for the gradient of the
 c perturbed density).  Note that g_dens(1) and g_dens(3) store the
 c penturbed density matrices in TDDFT gradients.
                else if (calctype.eq.2) then
-#if 1                  
-                  call xc_get3ddm(g_dens(1),
-     I                           imat+ipol*(ispin-1),
-     %                 ifirst, ilast, 1, nbf_ao, ppp,nbfia)
-#else                  
-                  call ga_get(g_dens(imat+2*(ispin-1)), 
-     1                 ifirst, ilast, 1, nbf_ao, PPP, nbfia)
-#endif                  
+                  if(ndim.eq.3) then
+                     call xc_get3ddm(g_dens(1),
+     I                    imat+ipol*(ispin-1),
+     %                    ifirst, ilast, 1, nbf_ao, ppp,nbfia)
+                  else
+                     call ga_get(g_dens(imat+2*(ispin-1)),
+     1                    ifirst, ilast, 1, nbf_ao, PPP, nbfia)
+                  endif
                 endif
                 do mu = inizia, ifinia
 c mu1 is used for indexing the scratch array hh (which starts at 1, 

--- a/src/nwdft/xc/xc_rhogen.F
+++ b/src/nwdft/xc/xc_rhogen.F
@@ -115,10 +115,6 @@ c
       integer sizeblk, gindx
       integer what
       logical zapnegatives
-#ifdef DEBUG
-      integer ga_nodeid
-      external ga_nodeid
-#endif
       integer type,ndim,dims(3)
       g_keepd(1)=0
       g_keepd(2)=0
@@ -157,15 +153,13 @@ c
          endif
       elseif(what.eq.1) then
          call nga_inquire(g_dens(1), type, ndim, dims)
-         if(ndim.lt.3.and.npert.gt.1) then
-            if(ga_nodeid().eq.0) then
-               write(luout,*) ' ndim ',ndim
-               write(luout,*) ' dims ',dims
-               write(luout,*) ' npert ',npert
-            endif
-            call ga_sync()
-            call errquit(' xcrhogen: 3dm fail',npert,0)
+#ifdef DEBUG         
+         if(ga_nodeid().eq.0) then
+            write(luout,*) ' ndim ',ndim
+            write(luout,*) ' dims ',(dims(ii),ii=1,ndim)
+            write(luout,*) ' npert ',npert
          endif
+#endif         
          call dcopy(nq*ipol*npert,0d0,0,rho,1)
          if (grad) call dcopy(3*nq*ipol*npert,0d0,0,delrho,1)
          if (kske) call dcopy(nq*ipol*npert,0d0,0,ttau,1)   ! total
@@ -316,7 +310,7 @@ c
      %                      ifirst, ilast, jfirst, jlast, Pmat,nbfia)
                       else
 c3d
-                         if(what.eq.1) then
+                         if(what.eq.1.and.ndim.eq.3) then
                             call xc_get3ddm(g_dens(1),
      I                           ipert+(ii-1)*npert,
      %                         ifirst, ilast, jfirst, jlast, Pmat,nbfia)


### PR DESCRIPTION
The commits to use  3-D GA from https://github.com/nwchemgit/nwchem/pull/835 result in large performance slowdowns.
This pull request restore the original 2-D GA based 2-nd derivatives code.
The 3-D GA code can still be enabled with the directive
```
set dft:dm3d t
```