### PR TITLE
update to fix 32-bit integers' issues on big endian architectures

### DIFF
--- a/src/nwpw/nwpwlib/Parallel/Parallel-mpi.F
+++ b/src/nwpw/nwpwlib/Parallel/Parallel-mpi.F
@@ -55,7 +55,8 @@ ccc#include "ga_mpi.fh"
 *     **** local variables ****
       integer MASTER
       parameter (MASTER=0)
-      integer i,mpierr,mygroup,myio,mydepth
+      integer i,mygroup,myio,mydepth
+      integer*4  mpierr
       character*50 nwfilename
       character*7 c_index_name
       external    c_index_name
@@ -100,8 +101,13 @@ c      call MPI_COMM_SIZE(MPI_COMM_WORLD,np,mpierr)
 
 #ifdef USE_SUBGROUPS
 #ifdef GA_DEV
+#if 0
       call MPI_COMM_RANK(comm_world,taskid,mpierr)
       call MPI_COMM_SIZE(comm_world,np,mpierr)
+#else      
+      np     = ga_nnodes()
+      taskid = ga_nodeid()
+#endif      
       mydepth = util_sgroup_depth()
       mygroup = util_sgroup_mygroup()
       if ((taskid.eq.MASTER).and.(mydepth.gt.0)) then
@@ -109,13 +115,12 @@ c      call MPI_COMM_SIZE(MPI_COMM_WORLD,np,mpierr)
      >              "nwpw"//c_index_name(mygroup)//".output")
       end if
 #else
-      np     = nnodes()
-      taskid = nodeid()
+      taskid = ga_nodeid()
 #endif
 
 #else
-      np     = nnodes()
-      taskid = nodeid()
+      np     = ga_nnodes()
+      taskid = ga_nodeid()
 #endif
 
 

--- a/src/tools/ga_diag_seg_i4_patch.sh
+++ b/src/tools/ga_diag_seg_i4_patch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+rm -f ga_diag_seg_i4.patch
+cat > ga_diag_seg_i4.patch <<EOF
+--- $1/global/src/ga_diag_seq.F.org	2023-10-30 11:07:22.963036506 -0700
++++ $1/global/src/ga_diag_seq.F	        2023-10-28 20:21:34.000000000 -0700
+@@ -28,11 +28,12 @@
+       integer l_wrk
+       MA_ACCESS_INDEX_TYPE k_wrk
+       integer n2
++      INTGR4 n2_4
+ #endif
+       integer l_a, l_s
+       MA_ACCESS_INDEX_TYPE k_a, k_s
+       integer dim1, dim2, type, me
+-      INTGR4 n4,ierr
++      INTGR4 n4,ierr,one4
+       logical status
+ c
+ c
+@@ -94,8 +95,10 @@
+          call rsg(n, n, dbl_mb(k_a), dbl_mb(k_s), evals, 1,
+      $        dbl_mb(k_v), dbl_mb(k_fv1), dbl_mb(k_fv2), ierr)
+ #else
+-         call dsygv(1,'V','U',n4,dbl_mb(k_a),n,dbl_mb(k_s),n4,
+-     $              evals,dbl_mb(k_wrk),n2, ierr)
++         one4=1
++         n2_4=n2
++         call dsygv(one4,'V','U',n4,dbl_mb(k_a),n4,dbl_mb(k_s),n4,
++     $              evals,dbl_mb(k_wrk),n2_4, ierr)
+          if (ierr.ne.0)
+      $       call ga_error('ga_diag_seq: dsygv failed',ierr)
+ c We used to copy to preserve code symmetry with EISPACK
+EOF
+patch -p0 -s -N < ./ga_diag_seg_i4.patch
+echo ga_diag_seg_i4.patch applied

--- a/src/tools/get-tools-github
+++ b/src/tools/get-tools-github
@@ -207,6 +207,7 @@ if [[ -d "ga-5.8.2" ]]; then
 	./mpipr-too-many_patch.sh $GA_DIR
 	./ga_ma_align_patch.sh $GA_DIR
 	./scalapacki4_patch.sh $GA_DIR
+	./ga_diag_seg_i4_patch.sh $GA_DIR
 	if [ $(uname -s) != "Darwin" ]; then
 	    ./autoconf_patch.sh $GA_DIR
 	fi


### PR DESCRIPTION
* ga_diag_seq(): make all integer arguments 32-bit in the call to dsygv
* Parallel_Init(): [replaced TCGMSG and MPI calls with GA calls to avoid 32-bit integer issues

See https://github.com/nwchemgit/nwchem/issues/864#issuecomment-1770549014 