### PR TITLE
OPENBLAS_USES_OPENMP variable to handle OpenBLAS threaded  with OpenMP

### DIFF
--- a/src/config/makefile.h
+++ b/src/config/makefile.h
@@ -3888,7 +3888,14 @@ ifdef BUILD_OPENBLAS
     DEFINES += -DOPENBLAS
 endif
 ifeq ($(shell echo $(BLASOPT) |awk '/openblas/ {print "Y"; exit}'),Y)
-    DEFINES += -DOPENBLAS
+    ifdef OPENBLAS_USES_OPENMP
+        DEFINES += -DBLAS_OPENMP
+        ifndef USE_OPENMP
+           $(error USE_OPENMP must be set when OPENBLAS_USES_OPENMP is set)
+        endif
+    else
+        DEFINES += -DOPENBLAS
+    endif
 endif
 # NVHPC compilers are distributed wtih OpenBLAS named as libblas/liblapack
 ifeq ($(shell echo $(BLASOPT) |awk '/\/nvidia\/hpc_sdk\// {print "Y"; exit}'),Y)


### PR DESCRIPTION
This commit address performance issues on homebrew https://github.com/Homebrew/homebrew-core/blame/master/Formula/o/openblas.rb#L38