### PR TITLE
localization functionality extensions

### DIFF
--- a/QA/doafewqmtests.mpi
+++ b/QA/doafewqmtests.mpi
@@ -58,6 +58,7 @@ fi
 #--- localization tests
 ./runtests.mpi.unix procs $np localize-ibo-aa
 ./runtests.mpi.unix procs $np localize-ibo-allyl
+./runtests.mpi.unix procs $np localize-pm-allyl
 #
 #--- relativity tests
 ./runtests.mpi.unix procs $np x2c-h2se

--- a/QA/doafewqmtests.mpi
+++ b/QA/doafewqmtests.mpi
@@ -57,6 +57,7 @@ fi
 #
 #--- localization tests
 ./runtests.mpi.unix procs $np localize-ibo-aa
+./runtests.mpi.unix procs $np localize-ibo-allyl
 #
 #--- relativity tests
 ./runtests.mpi.unix procs $np x2c-h2se

--- a/QA/tests/localize-ibo-allyl/dplot.nw
+++ b/QA/tests/localize-ibo-allyl/dplot.nw
@@ -1,0 +1,553 @@
+start testjob
+
+title "allylic_radical IBO localization"
+
+geometry units angstrom
+C         -0.25784636     1.21851111     0.00000000
+H         -1.34417006     1.24248062     0.00000000
+H          0.25678777     2.17304362     0.00000000
+C          0.43614025     0.01428420     0.00000000
+H          1.52527261     0.06222464     0.00000000
+C         -0.14953749    -1.24624893     0.00000000
+H         -1.22943924    -1.36577805     0.00000000
+H          0.44767502    -2.15141880     0.00000000
+end
+
+basis "ao basis"
+  * library 6-31G*
+end
+
+basis "iao basis"
+   * library STO-6G
+ end
+
+dft
+  xc b3lyp
+  mult 2
+end
+
+property
+localization ibo 2
+end
+
+#task dft property
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;1
+output allyl_radical-alpha-00001.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;2
+output allyl_radical-alpha-00002.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;3
+output allyl_radical-alpha-00003.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;4
+output allyl_radical-alpha-00004.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;5
+output allyl_radical-alpha-00005.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;6
+output allyl_radical-alpha-00006.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;7
+output allyl_radical-alpha-00007.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;8
+output allyl_radical-alpha-00008.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;9
+output allyl_radical-alpha-00009.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;10
+output allyl_radical-alpha-00010.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;11
+output allyl_radical-alpha-00011.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;12
+output allyl_radical-alpha-00012.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;13
+output allyl_radical-alpha-00013.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;14
+output allyl_radical-alpha-00014.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;15
+output allyl_radical-alpha-00015.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;16
+output allyl_radical-alpha-00016.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;17
+output allyl_radical-alpha-00017.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;18
+output allyl_radical-alpha-00018.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;19
+output allyl_radical-alpha-00019.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin alpha
+orbitals view;1;20
+output allyl_radical-alpha-00020.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;1
+output allyl_radical-beta-00001.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;2
+output allyl_radical-beta-00002.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;3
+output allyl_radical-beta-00003.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;4
+output allyl_radical-beta-00004.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;5
+output allyl_radical-beta-00005.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;6
+output allyl_radical-beta-00006.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;7
+output allyl_radical-beta-00007.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;8
+output allyl_radical-beta-00008.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;9
+output allyl_radical-beta-00009.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;10
+output allyl_radical-beta-00010.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;11
+output allyl_radical-beta-00011.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;12
+output allyl_radical-beta-00012.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;13
+output allyl_radical-beta-00013.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;14
+output allyl_radical-beta-00014.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;15
+output allyl_radical-beta-00015.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;16
+output allyl_radical-beta-00016.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;17
+output allyl_radical-beta-00017.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;18
+output allyl_radical-beta-00018.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;19
+output allyl_radical-beta-00019.cube
+end
+task dplot
+
+dplot
+vectors locorb.movecs
+limitxyz
+-5.34417006 5.52527261 50
+-6.1514188 6.17304362 50
+-4.0 4.0 50
+gaussian
+spin beta
+orbitals view;1;20
+output allyl_radical-beta-00020.cube
+end
+task dplot

--- a/QA/tests/localize-ibo-allyl/localize-ibo-allyl.nw
+++ b/QA/tests/localize-ibo-allyl/localize-ibo-allyl.nw
@@ -1,0 +1,33 @@
+start testjob
+
+title "allylic_radical IBO localization"
+
+geometry units angstrom
+C         -0.25784636     1.21851111     0.00000000
+H         -1.34417006     1.24248062     0.00000000
+H          0.25678777     2.17304362     0.00000000
+C          0.43614025     0.01428420     0.00000000
+H          1.52527261     0.06222464     0.00000000
+C         -0.14953749    -1.24624893     0.00000000
+H         -1.22943924    -1.36577805     0.00000000
+H          0.44767502    -2.15141880     0.00000000
+end
+
+basis "ao basis"
+  * library 6-31G*
+end
+
+basis "iao basis"
+   * library STO-6G
+ end
+
+dft
+  xc b3lyp
+  mult 2
+end
+
+property
+localization ibo 2
+end
+
+task dft property

--- a/QA/tests/localize-ibo-allyl/localize-ibo-allyl.out
+++ b/QA/tests/localize-ibo-allyl/localize-ibo-allyl.out
@@ -1,0 +1,1985 @@
+running on 6 processors
+ argument  1 = allyl_radical.nw
+                                         
+                                         
+ 
+ 
+             Northwest Computational Chemistry Package (NWChem) 7.2.1
+             --------------------------------------------------------
+ 
+ 
+                    Environmental Molecular Sciences Laboratory
+                       Pacific Northwest National Laboratory
+                                Richland, WA 99352
+ 
+                              Copyright (c) 1994-2022
+                       Pacific Northwest National Laboratory
+                            Battelle Memorial Institute
+ 
+             NWChem is an open-source computational chemistry package
+                        distributed under the terms of the
+                      Educational Community License (ECL) 2.0
+             A copy of the license is included with this distribution
+                              in the LICENSE.TXT file
+ 
+                                  ACKNOWLEDGMENT
+                                  --------------
+
+            This software and its documentation were developed at the
+            EMSL at Pacific Northwest National Laboratory, a multiprogram
+            national laboratory, operated for the U.S. Department of Energy
+            by Battelle under Contract Number DE-AC05-76RL01830. Support
+            for this work was provided by the Department of Energy Office
+            of Biological and Environmental Research, Office of Basic
+            Energy Sciences, and the Office of Advanced Scientific Computing.
+
+
+           Job information
+           ---------------
+
+    hostname        = ja04
+    program         = /home/workspace/jochena/nwchem/loc-unr-pr/bin/LINUX64/nwchem
+    date            = Wed Dec 27 15:42:46 2023
+
+    compiled        = Wed_Dec_27_15:35:48_2023
+    source          = /home/workspace/jochena/nwchem/loc-unr-pr
+    nwchem branch   = 7.2.1
+    nwchem revision = nwchem_on_git-5262-g4cee1d3a03
+    ga revision     = 5.8.0
+    use scalapack   = F
+    input           = allyl_radical.nw
+    prefix          = testjob.
+    data base       = ./testjob.db
+    status          = startup
+    nproc           =        5
+    time left       =     -1s
+
+
+
+           Memory information
+           ------------------
+
+    heap     =     26214400 doubles =      200.0 Mbytes
+    stack    =     26214397 doubles =      200.0 Mbytes
+    global   =     52428800 doubles =      400.0 Mbytes (distinct from heap & stack)
+    total    =    104857597 doubles =      800.0 Mbytes
+    verify   = yes
+    hardfail = no 
+
+
+           Directory information
+           ---------------------
+ 
+  0 permanent = .
+  0 scratch   = /tmp
+ 
+ 
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+                         allylic_radical IBO localization
+                         --------------------------------
+
+ Scaling coordinates for geometry "geometry" by  1.889725989
+ (inverse scale =  0.529177249)
+
+ C2V symmetry detected
+
+          ------
+          auto-z
+          ------
+  no constraints, skipping   0.000000000000000E+000
+  no constraints, skipping   0.000000000000000E+000
+ 
+ 
+                             Geometry "geometry" -> ""
+                             -------------------------
+ 
+ Output coordinates in angstroms (scale by  1.889725989 to convert to a.u.)
+ 
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 C                    6.0000     1.23356930     0.00000000    -0.19643284
+    2 H                    1.0000     1.30539041     0.00000000    -1.28059891
+    3 H                    1.0000     2.16433665     0.00000000     0.36003805
+    4 C                    6.0000     0.00000000     0.00000000     0.44401841
+    5 H                    1.0000     0.00000000     0.00000000     1.53420536
+    6 C                    6.0000    -1.23356930     0.00000000    -0.19643284
+    7 H                    1.0000    -1.30539041     0.00000000    -1.28059891
+    8 H                    1.0000    -2.16433665     0.00000000     0.36003805
+ 
+      Atomic Mass 
+      ----------- 
+ 
+      C                 12.000000
+      H                  1.007825
+ 
+
+ Effective nuclear repulsion energy (a.u.)      64.6894447651
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+    -0.0000000000     0.0000000000    -0.0000000000
+ 
+      Symmetry information
+      --------------------
+ 
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     5
+ 
+      Symmetry unique atoms
+ 
+     1    2    3    4    5
+ 
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+ 
+      Type          Name      I     J     K     L     M      Value
+      ----------- --------  ----- ----- ----- ----- ----- ----------
+    1 Stretch                  1     2                       1.08654
+    2 Stretch                  1     3                       1.08443
+    3 Stretch                  1     4                       1.38992
+    4 Stretch                  4     5                       1.09019
+    5 Stretch                  4     6                       1.38992
+    6 Stretch                  6     7                       1.08654
+    7 Stretch                  6     8                       1.08443
+    8 Bend                     1     4     5               117.43768
+    9 Bend                     1     4     6               125.12463
+   10 Bend                     2     1     3               117.08357
+   11 Bend                     2     1     4               121.22773
+   12 Bend                     3     1     4               121.68870
+   13 Bend                     4     6     7               121.22773
+   14 Bend                     4     6     8               121.68870
+   15 Bend                     5     4     6               117.43768
+   16 Bend                     7     6     8               117.08357
+   17 Torsion                  1     4     6     7           0.00000
+   18 Torsion                  1     4     6     8         180.00000
+   19 Torsion                  2     1     4     5         180.00000
+   20 Torsion                  2     1     4     6           0.00000
+   21 Torsion                  3     1     4     5           0.00000
+   22 Torsion                  3     1     4     6         180.00000
+   23 Torsion                  5     4     6     7         180.00000
+   24 Torsion                  5     4     6     8           0.00000
+ 
+ 
+            XYZ format geometry
+            -------------------
+     8
+ geometry
+ C                     1.23356930     0.00000000    -0.19643284
+ H                     1.30539041     0.00000000    -1.28059891
+ H                     2.16433665     0.00000000     0.36003805
+ C                     0.00000000     0.00000000     0.44401841
+ H                     0.00000000     0.00000000     1.53420536
+ C                    -1.23356930     0.00000000    -0.19643284
+ H                    -1.30539041     0.00000000    -1.28059891
+ H                    -2.16433665     0.00000000     0.36003805
+ 
+ ==============================================================================
+                                internuclear distances
+ ------------------------------------------------------------------------------
+       center one      |      center two      | atomic units |  angstroms
+ ------------------------------------------------------------------------------
+    2 H                |   1 C                |     2.05327  |     1.08654
+    3 H                |   1 C                |     2.04927  |     1.08443
+    4 C                |   1 C                |     2.62656  |     1.38992
+    5 H                |   4 C                |     2.06015  |     1.09019
+    6 C                |   4 C                |     2.62656  |     1.38992
+    7 H                |   6 C                |     2.05327  |     1.08654
+    8 H                |   6 C                |     2.04927  |     1.08443
+ ------------------------------------------------------------------------------
+                         number of included internuclear distances:          7
+ ==============================================================================
+
+
+
+ ==============================================================================
+                                 internuclear angles
+ ------------------------------------------------------------------------------
+        center 1       |       center 2       |       center 3       |  degrees
+ ------------------------------------------------------------------------------
+    2 H                |   1 C                |   3 H                |   117.08
+    2 H                |   1 C                |   4 C                |   121.23
+    3 H                |   1 C                |   4 C                |   121.69
+    1 C                |   4 C                |   5 H                |   117.44
+    1 C                |   4 C                |   6 C                |   125.12
+    5 H                |   4 C                |   6 C                |   117.44
+    4 C                |   6 C                |   7 H                |   121.23
+    4 C                |   6 C                |   8 H                |   121.69
+    7 H                |   6 C                |   8 H                |   117.08
+ ------------------------------------------------------------------------------
+                            number of included internuclear angles:          9
+ ==============================================================================
+
+
+
+  library name resolved from: environment
+  library file name is: <
+ /home/workspace/jochena/nwchem/loc-unr-pr/src/basis/libraries/>
+  
+
+
+ Summary of "ao basis" -> "" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ *                           6-31G*                   on all atoms 
+
+
+  library name resolved from: environment
+  library file name is: <
+ /home/workspace/jochena/nwchem/loc-unr-pr/src/basis/libraries/>
+  
+
+
+ Summary of "iao basis" -> "" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ *                           STO-6G                   on all atoms 
+
+
+                              NWChem Property Module
+                              ----------------------
+ 
+ 
+                         allylic_radical IBO localization
+ 
+ 
+                                 NWChem DFT Module
+                                 -----------------
+ 
+ 
+                         allylic_radical IBO localization
+ 
+ 
+                      Basis "ao basis" -> "ao basis" (cartesian)
+                      -----
+  C (Carbon)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  3.04752490E+03  0.001835
+  1 S  4.57369510E+02  0.014037
+  1 S  1.03948690E+02  0.068843
+  1 S  2.92101550E+01  0.232184
+  1 S  9.28666300E+00  0.467941
+  1 S  3.16392700E+00  0.362312
+ 
+  2 S  7.86827240E+00 -0.119332
+  2 S  1.88128850E+00 -0.160854
+  2 S  5.44249300E-01  1.143456
+ 
+  3 P  7.86827240E+00  0.068999
+  3 P  1.88128850E+00  0.316424
+  3 P  5.44249300E-01  0.744308
+ 
+  4 S  1.68714400E-01  1.000000
+ 
+  5 P  1.68714400E-01  1.000000
+ 
+  6 D  8.00000000E-01  1.000000
+ 
+  H (Hydrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  1.87311370E+01  0.033495
+  1 S  2.82539370E+00  0.234727
+  1 S  6.40121700E-01  0.813757
+ 
+  2 S  1.61277800E-01  1.000000
+ 
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           6-31G*                  6       15   3s2p1d
+ H                           6-31G*                  2        2   2s
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           6-31G*                  6       15   3s2p1d
+ H                           6-31G*                  2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+ 
+        a1         25
+        a2          5
+        b1         18
+        b2          7
+ 
+  Caching 1-el integrals 
+ 
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  spin polarized.
+          No. of atoms     :     8
+          No. of electrons :    23
+           Alpha electrons :    12
+            Beta electrons :    11
+          Charge           :     0
+          Spin multiplicity:     2
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    55
+                     number of shells:    28
+          Convergence on energy requested:  1.00D-07
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+ 
+              XC Information
+              --------------
+                         B3LYP Method XC Potential
+                     Hartree-Fock (Exact) Exchange  0.200          
+                        Slater Exchange Functional  0.800 local    
+                    Becke 1988 Exchange Functional  0.720 non-local
+              Lee-Yang-Parr Correlation Functional  0.810          
+                  VWN I RPA Correlation Functional  0.190 local    
+ 
+             Grid Information
+             ----------------
+          Grid used for XC integration:  fine      
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          C                   0.70       70          10.0       590
+          H                   0.35       60          11.0       590
+          Grid pruning is: on 
+          Number of quadrature shells:   320
+          Spatial weights used:  Erf1
+ 
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+ 
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-11
+          AO Gaussian exp screening on grid/accAOfunc:  16
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+ 
+      Superposition of Atomic Density Guess
+      -------------------------------------
+ 
+ Sum of atomic energies:        -115.47192514
+ 
+      Non-variational initial energy
+      ------------------------------
+
+ Total energy =    -117.175105
+ 1-e energy   =    -281.394383
+ 2-e energy   =      99.529834
+ HOMO         =      -0.147082
+ LUMO         =       0.082612
+ 
+ 
+   Symmetry analysis of molecular orbitals - initial alpha
+   -------------------------------------------------------
+ 
+  Numbering of irreducible representations: 
+ 
+     1 a1          2 a2          3 b1          4 b2      
+ 
+  Orbital symmetries:
+ 
+     1 a1          2 b1          3 a1          4 a1          5 b1      
+     6 a1          7 a1          8 b1          9 b1         10 a1      
+    11 b2         12 a2         13 b2         14 a1         15 a1      
+    16 b1         17 a1         18 b1         19 a1         20 b1      
+    21 b1         22 a1      
+ 
+ 
+   Symmetry analysis of molecular orbitals - initial beta
+   ------------------------------------------------------
+ 
+  Numbering of irreducible representations: 
+ 
+     1 a1          2 a2          3 b1          4 b2      
+ 
+  Orbital symmetries:
+ 
+     1 a1          2 b1          3 a1          4 a1          5 b1      
+     6 a1          7 a1          8 b1          9 b1         10 a1      
+    11 b2         12 a2         13 b2         14 a1         15 a1      
+    16 b1         17 a1         18 b1         19 a1         20 b1      
+    21 b1         22 a1      
+ 
+   Time after variat. SCF:      0.1
+   Time prior to 1st pass:      0.1
+
+ Integral file          = /tmp/testjob.aoints.0
+ Record size in doubles =  65536        No. of integs per rec  =  43688
+ Max. records in memory =      5        Max. records in file   =  27610
+ No. of bits per label  =      8        No. of bits per value  =     64
+
+
+ #quartets = 4.289D+04 #integrals = 3.559D+05 #direct =  0.0% #cached =100.0%
+
+
+File balance: exchanges=     0  moved=     0  time=   0.0
+
+
+ Grid_pts file          = /tmp/testjob.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =     15        Max. recs in file   =    147215
+
+
+           Memory utilization after 1st SCF pass: 
+           Heap Space remaining (MW):       25.70            25698824
+          Stack Space remaining (MW):       26.21            26213652
+
+   convergence    iter        energy       DeltaE   RMS-Dens  Diis-err    time
+ ---------------- ----- ----------------- --------- --------- ---------  ------
+ d= 0,ls=0.0,diis     1   -117.2264534786 -1.82D+02  4.20D-03  7.87D-02     0.2
+                                                     4.37D-03  7.80D-02
+ d= 0,ls=0.0,diis     2   -117.2587196631 -3.23D-02  7.78D-04  1.26D-03     0.2
+                                                     1.07D-03  1.84D-03
+ d= 0,ls=0.0,diis     3   -117.2598149263 -1.10D-03  4.64D-04  8.89D-04     0.3
+                                                     2.72D-04  3.90D-04
+ d= 0,ls=0.0,diis     4   -117.2602063095 -3.91D-04  8.96D-05  3.18D-05     0.3
+                                                     2.25D-04  1.42D-04
+ d= 0,ls=0.0,diis     5   -117.2602941371 -8.78D-05  1.43D-04  2.90D-05     0.4
+                                                     7.98D-05  6.96D-06
+  Resetting Diis
+ d= 0,ls=0.0,diis     6   -117.2603166651 -2.25D-05  3.71D-05  4.15D-06     0.4
+                                                     6.09D-05  7.84D-06
+ d= 0,ls=0.0,diis     7   -117.2603215407 -4.88D-06  1.28D-05  2.23D-07     0.5
+                                                     8.81D-06  1.11D-07
+ d= 0,ls=0.0,diis     8   -117.2603216043 -6.36D-08  4.92D-06  1.14D-07     0.5
+                                                     6.04D-06  1.72D-07
+
+
+         Total DFT energy =     -117.260321604256
+      One electron energy =     -284.181892325080
+           Coulomb energy =      120.312079357638
+    Exchange-Corr. energy =      -18.079953401880
+ Nuclear repulsion energy =       64.689444765066
+
+ Numeric. integr. density =       23.000000853283
+
+     Total iterative time =      0.4s
+
+
+ 
+                  Occupations of the irreducible representations
+                  ----------------------------------------------
+ 
+                     irrep           alpha         beta
+                     --------     --------     --------
+                     a1                6.0          6.0
+                     a2                1.0          0.0
+                     b1                4.0          4.0
+                     b2                1.0          1.0
+ 
+ 
+                    DFT Final Alpha Molecular Orbital Analysis
+                    ------------------------------------------
+ 
+ Vector    1  Occ=1.000000D+00  E=-1.019144D+01  Symmetry=a1
+              MO Center= -5.4D-18,  0.0D+00,  3.9D-01, r^2= 1.8D-01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      0.952067  4 C  s                  1      0.198740  1 C  s          
+    37      0.198740  6 C  s                 21      0.046701  4 C  s          
+ 
+ Vector    2  Occ=1.000000D+00  E=-1.019007D+01  Symmetry=b1
+              MO Center=  1.6D-10, -5.1D-18, -2.0D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.701862  1 C  s                 37     -0.701862  6 C  s          
+     2      0.035620  1 C  s                 38     -0.035620  6 C  s          
+ 
+ Vector    3  Occ=1.000000D+00  E=-1.018994D+01  Symmetry=a1
+              MO Center= -1.6D-10,  1.5D-26, -1.4D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.673109  1 C  s                 37      0.673109  6 C  s          
+    20     -0.281663  4 C  s                  2      0.034080  1 C  s          
+    38      0.034080  6 C  s          
+ 
+ Vector    4  Occ=1.000000D+00  E=-7.875894D-01  Symmetry=a1
+              MO Center=  3.4D-17,  2.2D-32,  8.8D-02, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.309509  4 C  s                  2      0.226557  1 C  s          
+    38      0.226557  6 C  s                  6      0.188990  1 C  s          
+    42      0.188990  6 C  s                 25      0.181774  4 C  s          
+    20     -0.157778  4 C  s                  1     -0.116999  1 C  s          
+    37     -0.116999  6 C  s                 35      0.078408  5 H  s          
+ 
+ Vector    5  Occ=1.000000D+00  E=-6.775622D-01  Symmetry=b1
+              MO Center=  4.8D-16,  1.6D-16, -1.1D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.291922  1 C  s                 38     -0.291922  6 C  s          
+     6      0.265325  1 C  s                 42     -0.265325  6 C  s          
+    22      0.213375  4 C  px                 1     -0.146878  1 C  s          
+    37      0.146878  6 C  s                 18      0.110854  3 H  s          
+    54     -0.110854  8 H  s                 16      0.097001  2 H  s          
+ 
+ Vector    6  Occ=1.000000D+00  E=-5.546573D-01  Symmetry=a1
+              MO Center= -3.2D-15,  1.4D-17,  4.6D-02, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.244705  4 C  s                 25      0.225790  4 C  s          
+    35      0.177421  5 H  s                  6     -0.162120  1 C  s          
+    42     -0.162120  6 C  s                 24      0.153932  4 C  pz         
+     2     -0.150295  1 C  s                 38     -0.150295  6 C  s          
+     5      0.138568  1 C  pz                41      0.138568  6 C  pz         
+ 
+ Vector    7  Occ=1.000000D+00  E=-4.739162D-01  Symmetry=a1
+              MO Center=  1.8D-15, -5.4D-32,  1.8D-01, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24      0.272435  4 C  pz                 3      0.258895  1 C  px         
+    39     -0.258895  6 C  px                18      0.172194  3 H  s          
+    54      0.172194  8 H  s                  5      0.134660  1 C  pz         
+    41      0.134660  6 C  pz                35      0.123062  5 H  s          
+    19      0.110893  3 H  s                 55      0.110893  8 H  s          
+ 
+ Vector    8  Occ=1.000000D+00  E=-4.318944D-01  Symmetry=b1
+              MO Center=  5.9D-16, -8.2D-18, -4.1D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.304576  1 C  pz                41     -0.304576  6 C  pz         
+    22      0.302763  4 C  px                16     -0.185944  2 H  s          
+    52      0.185944  7 H  s                 17     -0.131875  2 H  s          
+    53      0.131875  7 H  s                  3     -0.130192  1 C  px         
+    39     -0.130192  6 C  px                 9      0.126798  1 C  pz         
+ 
+ Vector    9  Occ=1.000000D+00  E=-3.826093D-01  Symmetry=b1
+              MO Center=  9.6D-15, -4.4D-18,  4.8D-03, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.319026  1 C  px                39      0.319026  6 C  px         
+    22     -0.255149  4 C  px                18      0.204618  3 H  s          
+    54     -0.204618  8 H  s                 19      0.195949  3 H  s          
+    55     -0.195949  8 H  s                  7      0.125357  1 C  px         
+    43      0.125357  6 C  px                 5      0.120630  1 C  pz         
+ 
+ Vector   10  Occ=1.000000D+00  E=-3.580975D-01  Symmetry=a1
+              MO Center= -8.6D-15, -1.4D-17,  1.3D-01, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24      0.325098  4 C  pz                 5     -0.253720  1 C  pz         
+    41     -0.253720  6 C  pz                36      0.247735  5 H  s          
+    35      0.239050  5 H  s                 17      0.183461  2 H  s          
+    53      0.183461  7 H  s                 16      0.167195  2 H  s          
+    52      0.167195  7 H  s                 28      0.095924  4 C  pz         
+ 
+ Vector   11  Occ=1.000000D+00  E=-3.155329D-01  Symmetry=b2
+              MO Center= -7.5D-15, -4.9D-16,  5.4D-02, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    23      0.352195  4 C  py                 4      0.315364  1 C  py         
+    40      0.315364  6 C  py                 8      0.215742  1 C  py         
+    44      0.215742  6 C  py                27      0.205267  4 C  py         
+ 
+ Vector   12  Occ=1.000000D+00  E=-1.929868D-01  Symmetry=a2
+              MO Center=  5.8D-15, -1.4D-17, -1.9D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.435275  1 C  py                40     -0.435275  6 C  py         
+     8      0.383745  1 C  py                44     -0.383745  6 C  py         
+    30      0.053428  4 C  dxy        
+ 
+ Vector   13  Occ=0.000000D+00  E= 4.890987D-02  Symmetry=b2
+              MO Center=  1.5D-15, -2.7D-16,  1.8D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    27      0.742887  4 C  py                23      0.494038  4 C  py         
+     8     -0.479756  1 C  py                44     -0.479756  6 C  py         
+     4     -0.283243  1 C  py                40     -0.283243  6 C  py         
+    11     -0.044094  1 C  dxy               47      0.044094  6 C  dxy        
+    14      0.029054  1 C  dyz               50      0.029054  6 C  dyz        
+ 
+ Vector   14  Occ=0.000000D+00  E= 1.104751D-01  Symmetry=a1
+              MO Center= -1.6D-14,  9.3D-18,  6.1D-01, r^2= 5.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      1.062176  3 H  s                 55      1.062176  8 H  s          
+    36      1.013713  5 H  s                 25     -0.950195  4 C  s          
+     6     -0.888054  1 C  s                 42     -0.888054  6 C  s          
+     7     -0.512130  1 C  px                43      0.512130  6 C  px         
+    28     -0.422910  4 C  pz                17      0.361915  2 H  s          
+ 
+ Vector   15  Occ=0.000000D+00  E= 1.344455D-01  Symmetry=a1
+              MO Center=  5.9D-15, -2.9D-17, -7.2D-01, r^2= 4.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.251323  2 H  s                 53      1.251323  7 H  s          
+    36     -0.943937  5 H  s                  6     -0.877562  1 C  s          
+    42     -0.877562  6 C  s                  9      0.569401  1 C  pz         
+    45      0.569401  6 C  pz                25      0.565100  4 C  s          
+    28      0.278675  4 C  pz                 5      0.227735  1 C  pz         
+ 
+ Vector   16  Occ=0.000000D+00  E= 1.506067D-01  Symmetry=b1
+              MO Center=  1.1D-14, -1.0D-16, -4.5D-01, r^2= 6.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.774875  1 C  s                 42     -1.774875  6 C  s          
+    17     -1.008690  2 H  s                 53      1.008690  7 H  s          
+    19     -0.943304  3 H  s                 55      0.943304  8 H  s          
+    26     -0.643813  4 C  px                 7      0.195376  1 C  px         
+    43      0.195376  6 C  px                 2      0.138501  1 C  s          
+ 
+ Vector   17  Occ=0.000000D+00  E= 1.954423D-01  Symmetry=b1
+              MO Center=  1.9D-14,  4.7D-17, -2.9D-01, r^2= 6.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      1.319508  3 H  s                 55     -1.319508  8 H  s          
+    17     -1.035376  2 H  s                 53      1.035376  7 H  s          
+     9     -0.830809  1 C  pz                45      0.830809  6 C  pz         
+     7     -0.680088  1 C  px                43     -0.680088  6 C  px         
+     5     -0.238701  1 C  pz                41      0.238701  6 C  pz         
+ 
+ Vector   18  Occ=0.000000D+00  E= 1.999659D-01  Symmetry=a1
+              MO Center= -3.5D-14,  4.1D-17,  7.5D-01, r^2= 5.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      2.196924  4 C  s                 36     -1.558443  5 H  s          
+    19      0.966646  3 H  s                 55      0.966646  8 H  s          
+     9     -0.957942  1 C  pz                45     -0.957942  6 C  pz         
+    28      0.747022  4 C  pz                17     -0.703306  2 H  s          
+    53     -0.703306  7 H  s                  6     -0.649042  1 C  s          
+ 
+ Vector   19  Occ=0.000000D+00  E= 3.087357D-01  Symmetry=a1
+              MO Center=  2.7D-14,  3.6D-17, -2.0D-01, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      3.443353  4 C  s                 28     -2.413506  4 C  pz         
+     7      2.043869  1 C  px                43     -2.043869  6 C  px         
+     6     -1.868957  1 C  s                 42     -1.868957  6 C  s          
+    36      1.335345  5 H  s                 19     -0.863600  3 H  s          
+    55     -0.863600  8 H  s                 17      0.503457  2 H  s          
+ 
+ Vector   20  Occ=0.000000D+00  E= 3.730297D-01  Symmetry=b1
+              MO Center= -1.8D-14,  7.8D-18, -1.3D-01, r^2= 4.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      3.400554  4 C  px                 6     -1.984631  1 C  s          
+    42      1.984631  6 C  s                  9     -1.649824  1 C  pz         
+    45      1.649824  6 C  pz                 7      1.581122  1 C  px         
+    43      1.581122  6 C  px                17     -1.070686  2 H  s          
+    53      1.070686  7 H  s                 22      0.359473  4 C  px         
+ 
+ Vector   21  Occ=0.000000D+00  E= 4.993834D-01  Symmetry=b1
+              MO Center=  5.0D-15,  2.9D-16,  3.5D-01, r^2= 3.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      1.032454  4 C  px                 7     -0.495359  1 C  px         
+    43     -0.495359  6 C  px                22     -0.476636  4 C  px         
+     9      0.405745  1 C  pz                45     -0.405745  6 C  pz         
+     6     -0.372762  1 C  s                 42      0.372762  6 C  s          
+     5     -0.338940  1 C  pz                41      0.338940  6 C  pz         
+ 
+ Vector   22  Occ=0.000000D+00  E= 5.173637D-01  Symmetry=a1
+              MO Center= -1.1D-16,  1.9D-16, -2.9D-01, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      0.582212  1 C  px                43     -0.582212  6 C  px         
+     3     -0.509268  1 C  px                39      0.509268  6 C  px         
+    18     -0.288713  3 H  s                 54     -0.288713  8 H  s          
+     2      0.250541  1 C  s                 38      0.250541  6 C  s          
+     6     -0.245895  1 C  s                 42     -0.245895  6 C  s          
+ 
+ Vector   23  Occ=0.000000D+00  E= 5.255651D-01  Symmetry=b2
+              MO Center=  9.0D-17, -2.6D-16, -1.4D-01, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.678296  1 C  py                40      0.678296  6 C  py         
+     8     -0.672551  1 C  py                44     -0.672551  6 C  py         
+    23      0.408212  4 C  py                27     -0.163960  4 C  py         
+    33     -0.061001  4 C  dyz               11     -0.034594  1 C  dxy        
+    47      0.034594  6 C  dxy               14      0.031037  1 C  dyz        
+ 
+ Vector   24  Occ=0.000000D+00  E= 5.897374D-01  Symmetry=a2
+              MO Center= -6.1D-16, -2.6D-15, -2.0D-01, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      0.872708  1 C  py                44     -0.872708  6 C  py         
+     4     -0.746595  1 C  py                40      0.746595  6 C  py         
+    30     -0.101783  4 C  dxy               11      0.049938  1 C  dxy        
+    47      0.049938  6 C  dxy        
+ 
+ Vector   25  Occ=0.000000D+00  E= 6.216112D-01  Symmetry=a1
+              MO Center= -1.2D-14,  9.7D-16,  5.9D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.160720  4 C  s                 21     -0.593664  4 C  s          
+    35     -0.541803  5 H  s                  2     -0.533280  1 C  s          
+    38     -0.533280  6 C  s                  6      0.493805  1 C  s          
+    42      0.493805  6 C  s                  9      0.427398  1 C  pz         
+    45      0.427398  6 C  pz                18     -0.301836  3 H  s          
+ 
+ Vector   26  Occ=0.000000D+00  E= 6.440811D-01  Symmetry=a1
+              MO Center= -7.8D-16,  4.3D-17, -3.8D-01, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      0.879404  4 C  s                  9     -0.718417  1 C  pz         
+    45     -0.718417  6 C  pz                 6      0.540189  1 C  s          
+    42      0.540189  6 C  s                 21     -0.513749  4 C  s          
+     7      0.488187  1 C  px                43     -0.488187  6 C  px         
+    16     -0.419258  2 H  s                 52     -0.419258  7 H  s          
+ 
+ Vector   27  Occ=0.000000D+00  E= 6.575335D-01  Symmetry=b1
+              MO Center=  1.4D-14,  2.2D-15, -1.9D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      0.803179  4 C  px                22     -0.674073  4 C  px         
+     7      0.659369  1 C  px                43      0.659369  6 C  px         
+     6      0.523118  1 C  s                 42     -0.523118  6 C  s          
+    16     -0.379205  2 H  s                 52      0.379205  7 H  s          
+    18     -0.357264  3 H  s                 54      0.357264  8 H  s          
+ 
+ Vector   28  Occ=0.000000D+00  E= 6.633980D-01  Symmetry=b2
+              MO Center=  3.6D-16, -5.2D-16,  4.1D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    27      1.581315  4 C  py                23     -0.996718  4 C  py         
+     8     -0.751345  1 C  py                44     -0.751345  6 C  py         
+     4      0.321506  1 C  py                40      0.321506  6 C  py         
+    11      0.047041  1 C  dxy               47     -0.047041  6 C  dxy        
+    33      0.044518  4 C  dyz        
+ 
+ Vector   29  Occ=0.000000D+00  E= 8.464557D-01  Symmetry=a1
+              MO Center=  1.7D-15, -4.0D-18, -5.2D-01, r^2= 4.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      2.301288  4 C  pz                 9     -1.764844  1 C  pz         
+    45     -1.764844  6 C  pz                17     -1.494908  2 H  s          
+    53     -1.494908  7 H  s                  6      1.073629  1 C  s          
+    19      1.071625  3 H  s                 42      1.073629  6 C  s          
+    55      1.071625  8 H  s                  7     -1.033651  1 C  px         
+ 
+ Vector   30  Occ=0.000000D+00  E= 8.626675D-01  Symmetry=b1
+              MO Center=  2.2D-15, -1.1D-17, -1.4D-01, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      1.619782  1 C  pz                45     -1.619782  6 C  pz         
+    19     -1.493012  3 H  s                 55      1.493012  8 H  s          
+    17      1.129982  2 H  s                 53     -1.129982  7 H  s          
+     7      0.916104  1 C  px                43      0.916104  6 C  px         
+    26     -0.713957  4 C  px                 5     -0.676726  1 C  pz         
+ 
+ Vector   31  Occ=0.000000D+00  E= 8.833233D-01  Symmetry=a1
+              MO Center= -1.7D-16, -1.8D-17,  1.2D+00, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      2.486162  4 C  pz                36     -2.429060  5 H  s          
+    24     -0.937162  4 C  pz                 6      0.828182  1 C  s          
+    42      0.828182  6 C  s                 35      0.715027  5 H  s          
+    21     -0.581910  4 C  s                 25      0.523518  4 C  s          
+     7     -0.481149  1 C  px                43      0.481149  6 C  px         
+ 
+ Vector   32  Occ=0.000000D+00  E= 9.215954D-01  Symmetry=a1
+              MO Center=  2.8D-16,  9.9D-17, -1.5D-01, r^2= 5.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.242249  4 C  s                 19     -1.175595  3 H  s          
+    55     -1.175595  8 H  s                  6      1.120802  1 C  s          
+    42      1.120802  6 C  s                  7      0.857390  1 C  px         
+    43     -0.857390  6 C  px                 2     -0.718653  1 C  s          
+    38     -0.718653  6 C  s                 17     -0.588252  2 H  s          
+ 
+ Vector   33  Occ=0.000000D+00  E= 9.405175D-01  Symmetry=b1
+              MO Center= -3.4D-15, -4.5D-17, -4.0D-01, r^2= 4.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      2.588414  4 C  px                 7      1.422824  1 C  px         
+    43      1.422824  6 C  px                17     -1.163193  2 H  s          
+    53      1.163193  7 H  s                  9     -1.151413  1 C  pz         
+    45      1.151413  6 C  pz                 6     -1.014710  1 C  s          
+    42      1.014710  6 C  s                 19     -0.679485  3 H  s          
+ 
+ Vector   34  Occ=0.000000D+00  E= 9.945514D-01  Symmetry=b1
+              MO Center= -5.0D-15,  1.1D-16, -1.8D-01, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      4.130016  1 C  s                 42     -4.130016  6 C  s          
+    26     -2.570724  4 C  px                 2     -1.394886  1 C  s          
+    38      1.394886  6 C  s                  7     -0.768769  1 C  px         
+    43     -0.768769  6 C  px                17     -0.677197  2 H  s          
+    53      0.677197  7 H  s                 19     -0.563915  3 H  s          
+ 
+ Vector   35  Occ=0.000000D+00  E= 1.116321D+00  Symmetry=b1
+              MO Center=  1.8D-13,  2.9D-18, -2.4D-02, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      3.458815  4 C  px                 9     -2.391694  1 C  pz         
+    45      2.391694  6 C  pz                 6     -2.088155  1 C  s          
+    42      2.088155  6 C  s                 19      0.752081  3 H  s          
+    55     -0.752081  8 H  s                 17     -0.653128  2 H  s          
+    53      0.653128  7 H  s                 18      0.570703  3 H  s          
+ 
+ Vector   36  Occ=0.000000D+00  E= 1.136036D+00  Symmetry=a1
+              MO Center= -1.9D-13,  1.3D-16,  3.7D-01, r^2= 3.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      6.019867  4 C  s                  6     -3.465096  1 C  s          
+    42     -3.465096  6 C  s                 21     -1.571328  4 C  s          
+     2      0.999257  1 C  s                 38      0.999257  6 C  s          
+     9     -0.902995  1 C  pz                45     -0.902995  6 C  pz         
+     7      0.707987  1 C  px                43     -0.707987  6 C  px         
+ 
+ Vector   37  Occ=0.000000D+00  E= 1.324032D+00  Symmetry=a1
+              MO Center=  1.7D-14, -2.4D-17,  3.3D-02, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      4.802933  4 C  pz                25     -3.657206  4 C  s          
+     6      3.150575  1 C  s                 42      3.150575  6 C  s          
+     7     -1.831442  1 C  px                43      1.831442  6 C  px         
+    36     -1.471117  5 H  s                  9     -1.452212  1 C  pz         
+    45     -1.452212  6 C  pz                21      0.836613  4 C  s          
+ 
+ Vector   38  Occ=0.000000D+00  E= 1.363767D+00  Symmetry=a2
+              MO Center=  9.5D-17, -1.9D-18,  6.6D-02, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    30      0.977038  4 C  dxy               11     -0.612249  1 C  dxy        
+    47     -0.612249  6 C  dxy               14      0.514480  1 C  dyz        
+    50     -0.514480  6 C  dyz                4     -0.125983  1 C  py         
+    40      0.125983  6 C  py         
+ 
+ Vector   39  Occ=0.000000D+00  E= 1.464994D+00  Symmetry=b2
+              MO Center=  1.9D-15, -1.1D-18,  1.4D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    33      1.122325  4 C  dyz               11      0.751855  1 C  dxy        
+    47     -0.751855  6 C  dxy               14      0.289870  1 C  dyz        
+    50      0.289870  6 C  dyz               23      0.147716  4 C  py         
+     4      0.045745  1 C  py                40      0.045745  6 C  py         
+    27     -0.039799  4 C  py         
+ 
+ Vector   40  Occ=0.000000D+00  E= 1.662901D+00  Symmetry=a2
+              MO Center= -3.1D-15, -6.8D-17, -2.0D-01, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.969638  1 C  dyz               50     -0.969638  6 C  dyz        
+    11      0.748505  1 C  dxy               47      0.748505  6 C  dxy        
+     8     -0.046891  1 C  py                44      0.046891  6 C  py         
+     4      0.032141  1 C  py                40     -0.032141  6 C  py         
+    30     -0.026174  4 C  dxy        
+ 
+ Vector   41  Occ=0.000000D+00  E= 1.708594D+00  Symmetry=b2
+              MO Center=  1.0D-15,  3.2D-19, -1.3D-01, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      1.186376  1 C  dyz               50      1.186376  6 C  dyz        
+    33     -0.446334  4 C  dyz               27     -0.161436  4 C  py         
+     8      0.112504  1 C  py                44      0.112504  6 C  py         
+    23     -0.088939  4 C  py                11     -0.053411  1 C  dxy        
+    47      0.053411  6 C  dxy                4     -0.049333  1 C  py         
+ 
+ Vector   42  Occ=0.000000D+00  E= 1.855904D+00  Symmetry=a1
+              MO Center=  1.4D-16,  2.2D-17,  7.4D-02, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.528929  4 C  s                 32     -0.617958  4 C  dyy        
+    28     -0.600888  4 C  pz                13     -0.573473  1 C  dyy        
+    49     -0.573473  6 C  dyy                7      0.504617  1 C  px         
+    43     -0.504617  6 C  px                21     -0.498308  4 C  s          
+    34      0.435676  4 C  dzz               18     -0.328060  3 H  s          
+ 
+ Vector   43  Occ=0.000000D+00  E= 1.913622D+00  Symmetry=b1
+              MO Center= -1.5D-15, -8.9D-18,  7.1D-03, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    31      1.107155  4 C  dxz               26     -0.487225  4 C  px         
+    15      0.437988  1 C  dzz               51     -0.437988  6 C  dzz        
+    10     -0.414988  1 C  dxx               46      0.414988  6 C  dxx        
+    16     -0.394860  2 H  s                 52      0.394860  7 H  s          
+     2      0.273865  1 C  s                 38     -0.273865  6 C  s          
+ 
+ Vector   44  Occ=0.000000D+00  E= 1.947782D+00  Symmetry=a1
+              MO Center=  2.4D-15, -6.9D-18,  1.8D-01, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      1.127875  4 C  pz                12      0.756990  1 C  dxz        
+    48     -0.756990  6 C  dxz               35     -0.626151  5 H  s          
+    25     -0.561612  4 C  s                 34      0.554063  4 C  dzz        
+    29     -0.512869  4 C  dxx               21      0.399315  4 C  s          
+     6      0.312872  1 C  s                 42      0.312872  6 C  s          
+ 
+ Vector   45  Occ=0.000000D+00  E= 2.101913D+00  Symmetry=b1
+              MO Center=  4.0D-15,  5.3D-17, -1.6D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.367107  1 C  s                 42     -1.367107  6 C  s          
+    26     -0.975344  4 C  px                13     -0.658017  1 C  dyy        
+    49      0.658017  6 C  dyy               12      0.653829  1 C  dxz        
+    48      0.653829  6 C  dxz               18     -0.535185  3 H  s          
+    54      0.535185  8 H  s                 15      0.372899  1 C  dzz        
+ 
+ Vector   46  Occ=0.000000D+00  E= 2.189658D+00  Symmetry=b2
+              MO Center= -2.6D-16,  7.0D-17,  5.8D-02, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    33      1.336057  4 C  dyz               11     -1.065414  1 C  dxy        
+    47      1.065414  6 C  dxy               27     -0.440012  4 C  py         
+     8      0.249083  1 C  py                44      0.249083  6 C  py         
+    14      0.221783  1 C  dyz               50      0.221783  6 C  dyz        
+    23     -0.096204  4 C  py                 4      0.026693  1 C  py         
+ 
+ Vector   47  Occ=0.000000D+00  E= 2.216936D+00  Symmetry=a1
+              MO Center=  3.2D-17,  8.4D-18, -1.4D-01, r^2= 2.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.667641  1 C  dxz               48     -0.667641  6 C  dxz        
+    15      0.609105  1 C  dzz               25     -0.606195  4 C  s          
+    51      0.609105  6 C  dzz               21      0.586217  4 C  s          
+    16     -0.460339  2 H  s                 52     -0.460339  7 H  s          
+    32      0.444709  4 C  dyy                6      0.390761  1 C  s          
+ 
+ Vector   48  Occ=0.000000D+00  E= 2.314741D+00  Symmetry=b1
+              MO Center= -5.0D-15,  4.4D-18, -1.9D-01, r^2= 2.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      1.192320  1 C  dxz               48      1.192320  6 C  dxz        
+     6     -0.791078  1 C  s                 42      0.791078  6 C  s          
+     7      0.786820  1 C  px                43      0.786820  6 C  px         
+    22      0.612468  4 C  px                16      0.415523  2 H  s          
+    52     -0.415523  7 H  s                 13      0.399540  1 C  dyy        
+ 
+ Vector   49  Occ=0.000000D+00  E= 2.443102D+00  Symmetry=a2
+              MO Center=  2.9D-16,  1.6D-17,  1.7D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    30      1.654040  4 C  dxy               11      0.862748  1 C  dxy        
+    47      0.862748  6 C  dxy               14     -0.609110  1 C  dyz        
+    50      0.609110  6 C  dyz                8     -0.129900  1 C  py         
+    44      0.129900  6 C  py                 4     -0.085619  1 C  py         
+    40      0.085619  6 C  py         
+ 
+ Vector   50  Occ=0.000000D+00  E= 2.533427D+00  Symmetry=a1
+              MO Center=  1.5D-14, -1.1D-17,  9.2D-02, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      3.191104  4 C  s                  6     -1.848199  1 C  s          
+    42     -1.848199  6 C  s                 28     -0.997763  4 C  pz         
+    32     -0.859842  4 C  dyy                7      0.757279  1 C  px         
+    43     -0.757279  6 C  px                10     -0.669902  1 C  dxx        
+    46     -0.669902  6 C  dxx               13      0.523227  1 C  dyy        
+ 
+ Vector   51  Occ=0.000000D+00  E= 2.778110D+00  Symmetry=b1
+              MO Center= -1.7D-14,  1.1D-18,  1.4D-01, r^2= 1.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    31     -1.994653  4 C  dxz               26      1.832278  4 C  px         
+     6     -1.425226  1 C  s                 42      1.425226  6 C  s          
+     9     -0.772377  1 C  pz                45      0.772377  6 C  pz         
+    10     -0.693518  1 C  dxx               46      0.693518  6 C  dxx        
+    22      0.587356  4 C  px                 7      0.580886  1 C  px         
+ 
+ Vector   52  Occ=0.000000D+00  E= 2.904610D+00  Symmetry=a1
+              MO Center=  1.6D-15,  6.5D-18,  1.5D-01, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.749688  4 C  s                 12      1.130343  1 C  dxz        
+    48     -1.130343  6 C  dxz               29      1.052800  4 C  dxx        
+     6     -0.892805  1 C  s                 42     -0.892805  6 C  s          
+    34     -0.815443  4 C  dzz               28     -0.760417  4 C  pz         
+     7      0.527528  1 C  px                43     -0.527528  6 C  px         
+ 
+ Vector   53  Occ=0.000000D+00  E= 4.069168D+00  Symmetry=a1
+              MO Center= -1.5D-13,  3.4D-18,  3.3D-02, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      1.860006  4 C  s                  2      1.783752  1 C  s          
+    38      1.783752  6 C  s                 32     -1.118573  4 C  dyy        
+    34     -1.063242  4 C  dzz               15     -1.026317  1 C  dzz        
+    51     -1.026317  6 C  dzz               13     -1.011424  1 C  dyy        
+    49     -1.011424  6 C  dyy               10     -1.005816  1 C  dxx        
+ 
+ Vector   54  Occ=0.000000D+00  E= 4.132941D+00  Symmetry=b1
+              MO Center=  1.3D-13, -3.6D-17, -2.1D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      2.109301  1 C  s                 38     -2.109301  6 C  s          
+     6      1.402044  1 C  s                 10     -1.403387  1 C  dxx        
+    42     -1.402044  6 C  s                 46      1.403387  6 C  dxx        
+    13     -1.300055  1 C  dyy               15     -1.305840  1 C  dzz        
+    49      1.300055  6 C  dyy               51      1.305840  6 C  dzz        
+ 
+ Vector   55  Occ=0.000000D+00  E= 4.378798D+00  Symmetry=a1
+              MO Center=  2.2D-14,  6.3D-18,  2.2D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      2.305576  4 C  s                 25      2.249791  4 C  s          
+    29     -1.981788  4 C  dxx               34     -1.533685  4 C  dzz        
+     6     -1.404717  1 C  s                 32     -1.411679  4 C  dyy        
+    42     -1.404717  6 C  s                  2     -1.226340  1 C  s          
+    38     -1.226340  6 C  s                 10      1.041020  1 C  dxx        
+ 
+ 
+                     DFT Final Beta Molecular Orbital Analysis
+                     -----------------------------------------
+ 
+ Vector    1  Occ=1.000000D+00  E=-1.019474D+01  Symmetry=a1
+              MO Center= -3.1D-16, -5.6D-29,  4.4D-01, r^2= 3.0D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      0.992296  4 C  s                 21      0.049641  4 C  s          
+ 
+ Vector    2  Occ=1.000000D+00  E=-1.018112D+01  Symmetry=b1
+              MO Center= -6.3D-10, -3.2D-18, -2.0D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.702106  1 C  s                 37     -0.702106  6 C  s          
+     2      0.033995  1 C  s                 38     -0.033995  6 C  s          
+ 
+ Vector    3  Occ=1.000000D+00  E=-1.018110D+01  Symmetry=a1
+              MO Center=  6.3D-10,  8.6D-26, -2.0D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.701782  1 C  s                 37      0.701782  6 C  s          
+     2      0.033779  1 C  s                 38      0.033779  6 C  s          
+    20     -0.029557  4 C  s          
+ 
+ Vector    4  Occ=1.000000D+00  E=-7.769008D-01  Symmetry=a1
+              MO Center= -9.4D-15, -1.9D-17,  1.4D-01, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.331598  4 C  s                 25      0.223429  4 C  s          
+     2      0.209418  1 C  s                 38      0.209418  6 C  s          
+    20     -0.167496  4 C  s                  6      0.155659  1 C  s          
+    42      0.155659  6 C  s                  1     -0.109586  1 C  s          
+    37     -0.109586  6 C  s                 35      0.085654  5 H  s          
+ 
+ Vector    5  Occ=1.000000D+00  E=-6.523638D-01  Symmetry=b1
+              MO Center=  8.0D-16, -2.0D-16, -1.0D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.283500  1 C  s                 38     -0.283500  6 C  s          
+     6      0.227390  1 C  s                 42     -0.227390  6 C  s          
+    22      0.225704  4 C  px                 1     -0.143150  1 C  s          
+    37      0.143150  6 C  s                 18      0.118511  3 H  s          
+    54     -0.118511  8 H  s                 16      0.101912  2 H  s          
+ 
+ Vector    6  Occ=1.000000D+00  E=-5.479289D-01  Symmetry=a1
+              MO Center=  8.5D-15, -1.2D-16,  7.0D-03, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.227759  4 C  s                 25      0.206542  4 C  s          
+    35      0.176909  5 H  s                 24      0.171048  4 C  pz         
+     2     -0.156381  1 C  s                 38     -0.156381  6 C  s          
+     6     -0.149238  1 C  s                 42     -0.149238  6 C  s          
+    16     -0.142813  2 H  s                 52     -0.142813  7 H  s          
+ 
+ Vector    7  Occ=1.000000D+00  E=-4.691647D-01  Symmetry=a1
+              MO Center= -1.9D-15, -6.5D-32,  2.0D-01, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24      0.277367  4 C  pz                 3      0.256734  1 C  px         
+    39     -0.256734  6 C  px                18      0.179240  3 H  s          
+    54      0.179240  8 H  s                  5      0.122014  1 C  pz         
+    19      0.122187  3 H  s                 35      0.122149  5 H  s          
+    41      0.122014  6 C  pz                55      0.122187  8 H  s          
+ 
+ Vector    8  Occ=1.000000D+00  E=-4.259626D-01  Symmetry=b1
+              MO Center= -2.0D-15, -1.3D-18, -4.2D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      0.310586  4 C  px                 5      0.296500  1 C  pz         
+    41     -0.296500  6 C  pz                16     -0.191491  2 H  s          
+    52      0.191491  7 H  s                 17     -0.142955  2 H  s          
+    53      0.142955  7 H  s                  3     -0.129585  1 C  px         
+    39     -0.129585  6 C  px                 9      0.116956  1 C  pz         
+ 
+ Vector    9  Occ=1.000000D+00  E=-3.768311D-01  Symmetry=b1
+              MO Center=  7.8D-16,  5.4D-33,  5.9D-03, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.310358  1 C  px                39      0.310358  6 C  px         
+    22     -0.261922  4 C  px                18      0.209723  3 H  s          
+    19      0.209612  3 H  s                 54     -0.209723  8 H  s          
+    55     -0.209612  8 H  s                  5      0.120007  1 C  pz         
+    41     -0.120007  6 C  pz                 7      0.115093  1 C  px         
+ 
+ Vector   10  Occ=1.000000D+00  E=-3.555026D-01  Symmetry=a1
+              MO Center=  3.1D-15,  2.0D-17,  9.0D-02, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24      0.323425  4 C  pz                 5     -0.251006  1 C  pz         
+    41     -0.251006  6 C  pz                36      0.242927  5 H  s          
+    35      0.232571  5 H  s                 17      0.193946  2 H  s          
+    53      0.193946  7 H  s                 16      0.172854  2 H  s          
+    52      0.172854  7 H  s                 18     -0.097878  3 H  s          
+ 
+ Vector   11  Occ=1.000000D+00  E=-2.835423D-01  Symmetry=b2
+              MO Center=  5.4D-16, -1.5D-16,  1.8D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    23      0.442357  4 C  py                27      0.298528  4 C  py         
+     4      0.239399  1 C  py                40      0.239399  6 C  py         
+     8      0.163551  1 C  py                44      0.163551  6 C  py         
+ 
+ Vector   12  Occ=0.000000D+00  E=-6.761653D-02  Symmetry=a2
+              MO Center= -3.0D-15,  1.5D-16, -1.9D-01, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      0.428097  1 C  py                44     -0.428097  6 C  py         
+     4      0.394844  1 C  py                40     -0.394844  6 C  py         
+    30      0.060469  4 C  dxy        
+ 
+ Vector   13  Occ=0.000000D+00  E= 7.656088D-02  Symmetry=b2
+              MO Center=  2.7D-15, -1.8D-17,  4.4D-02, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    27      0.697685  4 C  py                 8     -0.549964  1 C  py         
+    44     -0.549964  6 C  py                23      0.446269  4 C  py         
+     4     -0.291966  1 C  py                40     -0.291966  6 C  py         
+    33      0.035516  4 C  dyz               11     -0.034002  1 C  dxy        
+    47      0.034002  6 C  dxy               14      0.025565  1 C  dyz        
+ 
+ Vector   14  Occ=0.000000D+00  E= 1.140651D-01  Symmetry=a1
+              MO Center=  9.5D-17,  1.1D-17,  8.4D-01, r^2= 5.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    36     -1.200264  5 H  s                 25      1.141660  4 C  s          
+    19     -1.010472  3 H  s                 55     -1.010472  8 H  s          
+     6      0.711198  1 C  s                 42      0.711198  6 C  s          
+     7      0.513141  1 C  px                43     -0.513141  6 C  px         
+    28      0.470279  4 C  pz                24      0.240722  4 C  pz         
+ 
+ Vector   15  Occ=0.000000D+00  E= 1.390082D-01  Symmetry=a1
+              MO Center=  3.3D-14,  2.0D-18, -9.1D-01, r^2= 4.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      1.297363  2 H  s                 53      1.297363  7 H  s          
+     6     -0.992114  1 C  s                 42     -0.992114  6 C  s          
+    36     -0.785627  5 H  s                  9      0.576911  1 C  pz         
+    45      0.576911  6 C  pz                25      0.365577  4 C  s          
+    28      0.229626  4 C  pz                 5      0.220610  1 C  pz         
+ 
+ Vector   16  Occ=0.000000D+00  E= 1.597482D-01  Symmetry=b1
+              MO Center= -2.8D-14,  4.2D-17, -4.3D-01, r^2= 6.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.773036  1 C  s                 42     -1.773036  6 C  s          
+    17     -1.015291  2 H  s                 53      1.015291  7 H  s          
+    19     -0.971727  3 H  s                 55      0.971727  8 H  s          
+    26     -0.614711  4 C  px                 7      0.227097  1 C  px         
+    43      0.227097  6 C  px                 2      0.138620  1 C  s          
+ 
+ Vector   17  Occ=0.000000D+00  E= 1.995138D-01  Symmetry=b1
+              MO Center=  1.2D-13,  6.8D-17, -3.2D-01, r^2= 6.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      1.311277  3 H  s                 55     -1.311277  8 H  s          
+    17     -1.056658  2 H  s                 53      1.056658  7 H  s          
+     9     -0.842794  1 C  pz                45      0.842794  6 C  pz         
+     7     -0.679599  1 C  px                43     -0.679599  6 C  px         
+     5     -0.239504  1 C  pz                41      0.239504  6 C  pz         
+ 
+ Vector   18  Occ=0.000000D+00  E= 2.028556D-01  Symmetry=a1
+              MO Center= -1.3D-13,  2.0D-16,  7.3D-01, r^2= 5.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      2.099978  4 C  s                 36     -1.526444  5 H  s          
+    19      1.035244  3 H  s                 55      1.035244  8 H  s          
+     9     -0.962849  1 C  pz                45     -0.962849  6 C  pz         
+    28      0.760791  4 C  pz                17     -0.696301  2 H  s          
+    53     -0.696301  7 H  s                  6     -0.667051  1 C  s          
+ 
+ Vector   19  Occ=0.000000D+00  E= 3.114851D-01  Symmetry=a1
+              MO Center=  7.9D-15,  3.5D-17, -2.3D-01, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      3.500319  4 C  s                 28     -2.411788  4 C  pz         
+     7      2.047145  1 C  px                43     -2.047145  6 C  px         
+     6     -1.910944  1 C  s                 42     -1.910944  6 C  s          
+    36      1.309739  5 H  s                 19     -0.834764  3 H  s          
+    55     -0.834764  8 H  s                 17      0.516670  2 H  s          
+ 
+ Vector   20  Occ=0.000000D+00  E= 3.768865D-01  Symmetry=b1
+              MO Center= -4.8D-15,  9.6D-18, -1.2D-01, r^2= 4.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      3.437614  4 C  px                 6     -2.016033  1 C  s          
+    42      2.016033  6 C  s                  9     -1.656339  1 C  pz         
+    45      1.656339  6 C  pz                 7      1.582232  1 C  px         
+    43      1.582232  6 C  px                17     -1.059208  2 H  s          
+    53      1.059208  7 H  s                 22      0.341559  4 C  px         
+ 
+ Vector   21  Occ=0.000000D+00  E= 5.028433D-01  Symmetry=b1
+              MO Center= -1.9D-15, -1.3D-16,  3.3D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      1.021134  4 C  px                 7     -0.505202  1 C  px         
+    43     -0.505202  6 C  px                22     -0.485513  4 C  px         
+     9      0.404882  1 C  pz                45     -0.404882  6 C  pz         
+     6     -0.364198  1 C  s                 42      0.364198  6 C  s          
+     5     -0.332847  1 C  pz                41      0.332847  6 C  pz         
+ 
+ Vector   22  Occ=0.000000D+00  E= 5.202561D-01  Symmetry=a1
+              MO Center=  2.0D-15,  5.0D-17, -2.9D-01, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      0.555773  1 C  px                43     -0.555773  6 C  px         
+     3     -0.501161  1 C  px                39      0.501161  6 C  px         
+    18     -0.290099  3 H  s                 54     -0.290099  8 H  s          
+    16      0.250158  2 H  s                 52      0.250158  7 H  s          
+     2      0.246382  1 C  s                 38      0.246382  6 C  s          
+ 
+ Vector   23  Occ=0.000000D+00  E= 5.571645D-01  Symmetry=b2
+              MO Center=  5.5D-15,  4.7D-16,  4.1D-02, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.614597  1 C  py                40      0.614597  6 C  py         
+    23      0.597619  4 C  py                27     -0.529409  4 C  py         
+     8     -0.465392  1 C  py                44     -0.465392  6 C  py         
+    33     -0.075274  4 C  dyz               11     -0.042663  1 C  dxy        
+    47      0.042663  6 C  dxy               14      0.028284  1 C  dyz        
+ 
+ Vector   24  Occ=0.000000D+00  E= 6.241132D-01  Symmetry=a1
+              MO Center=  3.8D-15, -1.8D-16,  6.5D-01, r^2= 2.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.099269  4 C  s                 35     -0.574098  5 H  s          
+    21     -0.549661  4 C  s                  9      0.490151  1 C  pz         
+    45      0.490151  6 C  pz                 2     -0.483123  1 C  s          
+    38     -0.483123  6 C  s                  6      0.375126  1 C  s          
+    42      0.375126  6 C  s                  5     -0.304644  1 C  pz         
+ 
+ Vector   25  Occ=0.000000D+00  E= 6.352573D-01  Symmetry=a2
+              MO Center=  1.4D-14, -4.4D-16, -2.0D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      0.851980  1 C  py                44     -0.851980  6 C  py         
+     4     -0.767113  1 C  py                40      0.767113  6 C  py         
+    30     -0.114976  4 C  dxy               11      0.050706  1 C  dxy        
+    47      0.050706  6 C  dxy        
+ 
+ Vector   26  Occ=0.000000D+00  E= 6.548109D-01  Symmetry=a1
+              MO Center=  2.5D-14, -1.4D-15, -4.2D-01, r^2= 3.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.052954  4 C  s                  9     -0.661538  1 C  pz         
+    45     -0.661538  6 C  pz                21     -0.605618  4 C  s          
+     6      0.597462  1 C  s                 42      0.597462  6 C  s          
+     7      0.524471  1 C  px                43     -0.524471  6 C  px         
+    16     -0.419259  2 H  s                 52     -0.419259  7 H  s          
+ 
+ Vector   27  Occ=0.000000D+00  E= 6.662205D-01  Symmetry=b2
+              MO Center= -2.0D-14,  1.2D-15,  2.4D-01, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    27      1.506410  4 C  py                23     -0.881895  4 C  py         
+     8     -0.865502  1 C  py                44     -0.865502  6 C  py         
+     4      0.471442  1 C  py                40      0.471442  6 C  py         
+    11      0.038261  1 C  dxy               47     -0.038261  6 C  dxy        
+    33      0.027194  4 C  dyz        
+ 
+ Vector   28  Occ=0.000000D+00  E= 6.717053D-01  Symmetry=b1
+              MO Center= -2.2D-14,  6.8D-16, -1.7D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      0.837672  4 C  px                22     -0.700328  4 C  px         
+     7      0.678637  1 C  px                43      0.678637  6 C  px         
+     6      0.495234  1 C  s                 42     -0.495234  6 C  s          
+    16     -0.379357  2 H  s                 52      0.379357  7 H  s          
+    18     -0.348244  3 H  s                 54      0.348244  8 H  s          
+ 
+ Vector   29  Occ=0.000000D+00  E= 8.520725D-01  Symmetry=a1
+              MO Center= -3.7D-15, -4.9D-17, -4.2D-01, r^2= 4.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      2.457751  4 C  pz                 9     -1.758125  1 C  pz         
+    45     -1.758125  6 C  pz                17     -1.449322  2 H  s          
+    53     -1.449322  7 H  s                 36     -1.175460  5 H  s          
+    19      1.098130  3 H  s                 55      1.098130  8 H  s          
+     7     -1.077018  1 C  px                43      1.077018  6 C  px         
+ 
+ Vector   30  Occ=0.000000D+00  E= 8.688124D-01  Symmetry=b1
+              MO Center=  4.3D-15, -8.1D-18, -1.6D-01, r^2= 4.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      1.597590  1 C  pz                45     -1.597590  6 C  pz         
+    19     -1.451285  3 H  s                 55      1.451285  8 H  s          
+    17      1.143315  2 H  s                 53     -1.143315  7 H  s          
+     7      0.883049  1 C  px                43      0.883049  6 C  px         
+     5     -0.687320  1 C  pz                26     -0.684001  4 C  px         
+ 
+ Vector   31  Occ=0.000000D+00  E= 8.814865D-01  Symmetry=a1
+              MO Center= -1.2D-15,  3.0D-17,  1.2D+00, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    36     -2.366623  5 H  s                 28      2.321887  4 C  pz         
+    24     -0.896338  4 C  pz                 6      0.747294  1 C  s          
+    42      0.747294  6 C  s                 35      0.710213  5 H  s          
+    25      0.617774  4 C  s                 21     -0.604905  4 C  s          
+     7     -0.391498  1 C  px                43      0.391498  6 C  px         
+ 
+ Vector   32  Occ=0.000000D+00  E= 9.300733D-01  Symmetry=a1
+              MO Center=  5.2D-16, -2.1D-16, -1.7D-01, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.450458  4 C  s                 19     -1.125088  3 H  s          
+    55     -1.125088  8 H  s                  6      0.986474  1 C  s          
+    42      0.986474  6 C  s                  7      0.867397  1 C  px         
+    43     -0.867397  6 C  px                 2     -0.691022  1 C  s          
+    38     -0.691022  6 C  s                 17     -0.606399  2 H  s          
+ 
+ Vector   33  Occ=0.000000D+00  E= 9.475574D-01  Symmetry=b1
+              MO Center= -3.5D-15, -5.0D-17, -3.9D-01, r^2= 4.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      2.582639  4 C  px                 7      1.434236  1 C  px         
+    43      1.434236  6 C  px                17     -1.137535  2 H  s          
+    53      1.137535  7 H  s                  9     -1.131585  1 C  pz         
+    45      1.131585  6 C  pz                 6     -1.047775  1 C  s          
+    42      1.047775  6 C  s                 19     -0.696168  3 H  s          
+ 
+ Vector   34  Occ=0.000000D+00  E= 1.012077D+00  Symmetry=b1
+              MO Center=  6.2D-15, -6.9D-17, -1.7D-01, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      4.147133  1 C  s                 42     -4.147133  6 C  s          
+    26     -2.585887  4 C  px                 2     -1.392914  1 C  s          
+    38      1.392914  6 C  s                  7     -0.743497  1 C  px         
+    43     -0.743497  6 C  px                17     -0.655361  2 H  s          
+    53      0.655361  7 H  s                 19     -0.582730  3 H  s          
+ 
+ Vector   35  Occ=0.000000D+00  E= 1.121951D+00  Symmetry=b1
+              MO Center= -8.1D-16,  1.4D-17, -3.3D-02, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    26      3.426464  4 C  px                 9     -2.401597  1 C  pz         
+    45      2.401597  6 C  pz                 6     -2.051000  1 C  s          
+    42      2.051000  6 C  s                 19      0.769800  3 H  s          
+    55     -0.769800  8 H  s                 17     -0.668465  2 H  s          
+    53      0.668465  7 H  s                 18      0.566084  3 H  s          
+ 
+ Vector   36  Occ=0.000000D+00  E= 1.142663D+00  Symmetry=a1
+              MO Center= -1.3D-14, -1.2D-17,  3.5D-01, r^2= 3.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      5.900483  4 C  s                  6     -3.482659  1 C  s          
+    42     -3.482659  6 C  s                 21     -1.529561  4 C  s          
+     2      1.026622  1 C  s                 38      1.026622  6 C  s          
+     9     -0.906502  1 C  pz                45     -0.906502  6 C  pz         
+     7      0.666599  1 C  px                43     -0.666599  6 C  px         
+ 
+ Vector   37  Occ=0.000000D+00  E= 1.325929D+00  Symmetry=a1
+              MO Center=  1.7D-15, -6.2D-18,  3.0D-02, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      4.804745  4 C  pz                25     -3.700914  4 C  s          
+     6      3.192136  1 C  s                 42      3.192136  6 C  s          
+     7     -1.833731  1 C  px                43      1.833731  6 C  px         
+    36     -1.464407  5 H  s                  9     -1.452669  1 C  pz         
+    45     -1.452669  6 C  pz                21      0.853267  4 C  s          
+ 
+ Vector   38  Occ=0.000000D+00  E= 1.385096D+00  Symmetry=a2
+              MO Center= -3.8D-17,  3.9D-18,  7.9D-02, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    30      1.015955  4 C  dxy               11     -0.593627  1 C  dxy        
+    47     -0.593627  6 C  dxy               14      0.495927  1 C  dyz        
+    50     -0.495927  6 C  dyz                4     -0.135300  1 C  py         
+    40      0.135300  6 C  py         
+ 
+ Vector   39  Occ=0.000000D+00  E= 1.478302D+00  Symmetry=b2
+              MO Center=  1.2D-15,  5.3D-18,  1.7D-01, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    33      1.186783  4 C  dyz               11      0.716035  1 C  dxy        
+    47     -0.716035  6 C  dxy               14      0.244057  1 C  dyz        
+    50      0.244057  6 C  dyz               23      0.144841  4 C  py         
+     4      0.053246  1 C  py                40      0.053246  6 C  py         
+    27     -0.051846  4 C  py         
+ 
+ Vector   40  Occ=0.000000D+00  E= 1.707307D+00  Symmetry=a2
+              MO Center=  5.0D-15, -6.0D-17, -2.0D-01, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.972016  1 C  dyz               50     -0.972016  6 C  dyz        
+    11      0.745555  1 C  dxy               47      0.745555  6 C  dxy        
+     8     -0.046443  1 C  py                44      0.046443  6 C  py         
+     4      0.032172  1 C  py                40     -0.032172  6 C  py         
+ 
+ Vector   41  Occ=0.000000D+00  E= 1.748061D+00  Symmetry=b2
+              MO Center= -6.5D-15,  5.2D-17, -1.4D-01, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      1.194517  1 C  dyz               50      1.194517  6 C  dyz        
+    33     -0.417132  4 C  dyz               27     -0.150229  4 C  py         
+     8      0.106413  1 C  py                44      0.106413  6 C  py         
+    23     -0.079890  4 C  py                 4     -0.048399  1 C  py         
+    40     -0.048399  6 C  py         
+ 
+ Vector   42  Occ=0.000000D+00  E= 1.878364D+00  Symmetry=a1
+              MO Center=  1.7D-15,  7.6D-17,  1.4D-01, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.584048  4 C  s                 32     -0.652518  4 C  dyy        
+    34      0.526636  4 C  dzz               13     -0.518691  1 C  dyy        
+    49     -0.518691  6 C  dyy                7      0.502139  1 C  px         
+    43     -0.502139  6 C  px                28     -0.489864  4 C  pz         
+    21     -0.455578  4 C  s                 35     -0.428338  5 H  s          
+ 
+ Vector   43  Occ=0.000000D+00  E= 1.918223D+00  Symmetry=b1
+              MO Center= -9.7D-16,  3.3D-18,  2.7D-03, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    31      1.116981  4 C  dxz               26     -0.531814  4 C  px         
+    15      0.451231  1 C  dzz               51     -0.451231  6 C  dzz        
+    16     -0.406581  2 H  s                 52      0.406581  7 H  s          
+    10     -0.400554  1 C  dxx               46      0.400554  6 C  dxx        
+     3     -0.270794  1 C  px                39     -0.270794  6 C  px         
+ 
+ Vector   44  Occ=0.000000D+00  E= 1.954984D+00  Symmetry=a1
+              MO Center=  1.1D-15, -9.5D-18,  1.5D-01, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      1.205644  4 C  pz                25     -0.818059  4 C  s          
+    12      0.727418  1 C  dxz               48     -0.727418  6 C  dxz        
+    35     -0.566959  5 H  s                 29     -0.535841  4 C  dxx        
+    34      0.486510  4 C  dzz               21      0.461366  4 C  s          
+     6      0.374202  1 C  s                 42      0.374202  6 C  s          
+ 
+ Vector   45  Occ=0.000000D+00  E= 2.140517D+00  Symmetry=b1
+              MO Center=  1.3D-15,  3.4D-17, -1.4D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.269775  1 C  s                 42     -1.269775  6 C  s          
+    26     -0.898428  4 C  px                12      0.762604  1 C  dxz        
+    48      0.762604  6 C  dxz               13     -0.618942  1 C  dyy        
+    49      0.618942  6 C  dyy               18     -0.557648  3 H  s          
+    54      0.557648  8 H  s                 15      0.329000  1 C  dzz        
+ 
+ Vector   46  Occ=0.000000D+00  E= 2.208672D+00  Symmetry=b2
+              MO Center= -1.8D-16, -9.9D-18,  3.6D-02, r^2= 1.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    33      1.288523  4 C  dyz               11     -1.091455  1 C  dxy        
+    47      1.091455  6 C  dxy               27     -0.438209  4 C  py         
+     8      0.248659  1 C  py                44      0.248659  6 C  py         
+    14      0.233511  1 C  dyz               50      0.233511  6 C  dyz        
+    23     -0.100501  4 C  py                 4      0.025523  1 C  py         
+ 
+ Vector   47  Occ=0.000000D+00  E= 2.221835D+00  Symmetry=a1
+              MO Center= -2.0D-15,  1.3D-17, -1.6D-01, r^2= 2.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.663944  1 C  dxz               48     -0.663944  6 C  dxz        
+    15      0.624799  1 C  dzz               51      0.624799  6 C  dzz        
+    21      0.559382  4 C  s                 25     -0.544353  4 C  s          
+    16     -0.466969  2 H  s                 52     -0.466969  7 H  s          
+    32      0.414591  4 C  dyy                6      0.389316  1 C  s          
+ 
+ Vector   48  Occ=0.000000D+00  E= 2.332996D+00  Symmetry=b1
+              MO Center= -5.7D-15, -3.4D-17, -2.0D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      1.123845  1 C  dxz               48      1.123845  6 C  dxz        
+     6     -0.899150  1 C  s                 42      0.899150  6 C  s          
+     7      0.791088  1 C  px                43      0.791088  6 C  px         
+    22      0.594867  4 C  px                13      0.457673  1 C  dyy        
+    49     -0.457673  6 C  dyy               16      0.433024  2 H  s          
+ 
+ Vector   49  Occ=0.000000D+00  E= 2.459175D+00  Symmetry=a2
+              MO Center=  6.4D-16,  2.1D-17,  1.5D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    30      1.629339  4 C  dxy               11      0.878132  1 C  dxy        
+    47      0.878132  6 C  dxy               14     -0.620588  1 C  dyz        
+    50      0.620588  6 C  dyz                8     -0.129188  1 C  py         
+    44      0.129188  6 C  py                 4     -0.086018  1 C  py         
+    40      0.086018  6 C  py         
+ 
+ Vector   50  Occ=0.000000D+00  E= 2.544212D+00  Symmetry=a1
+              MO Center= -1.7D-15,  1.7D-17,  7.4D-02, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      3.129233  4 C  s                  6     -1.842098  1 C  s          
+    42     -1.842098  6 C  s                 28     -0.968728  4 C  pz         
+    32     -0.832374  4 C  dyy                7      0.738536  1 C  px         
+    43     -0.738536  6 C  px                10     -0.679052  1 C  dxx        
+    46     -0.679052  6 C  dxx               13      0.546774  1 C  dyy        
+ 
+ Vector   51  Occ=0.000000D+00  E= 2.781456D+00  Symmetry=b1
+              MO Center=  3.1D-15, -9.2D-19,  1.4D-01, r^2= 1.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    31     -1.986705  4 C  dxz               26      1.837413  4 C  px         
+     6     -1.437737  1 C  s                 42      1.437737  6 C  s          
+     9     -0.774544  1 C  pz                45      0.774544  6 C  pz         
+    10     -0.700884  1 C  dxx               46      0.700884  6 C  dxx        
+    22      0.591318  4 C  px                 7      0.585709  1 C  px         
+ 
+ Vector   52  Occ=0.000000D+00  E= 2.907000D+00  Symmetry=a1
+              MO Center=  3.5D-15,  2.5D-18,  1.4D-01, r^2= 1.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      1.747237  4 C  s                 12      1.134931  1 C  dxz        
+    48     -1.134931  6 C  dxz               29      1.045457  4 C  dxx        
+     6     -0.893102  1 C  s                 42     -0.893102  6 C  s          
+    34     -0.816603  4 C  dzz               28     -0.756706  4 C  pz         
+     7      0.527041  1 C  px                43     -0.527041  6 C  px         
+ 
+ Vector   53  Occ=0.000000D+00  E= 4.080901D+00  Symmetry=a1
+              MO Center= -1.3D-13, -3.4D-19,  6.6D-02, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      1.964956  4 C  s                  2      1.726785  1 C  s          
+    38      1.726785  6 C  s                 32     -1.183113  4 C  dyy        
+    34     -1.133883  4 C  dzz               29     -1.084569  4 C  dxx        
+    15     -0.982425  1 C  dzz               51     -0.982425  6 C  dzz        
+    13     -0.976638  1 C  dyy               49     -0.976638  6 C  dyy        
+ 
+ Vector   54  Occ=0.000000D+00  E= 4.156034D+00  Symmetry=b1
+              MO Center=  1.6D-13, -2.0D-17, -2.1D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      2.112558  1 C  s                 38     -2.112558  6 C  s          
+     6      1.397836  1 C  s                 10     -1.401868  1 C  dxx        
+    42     -1.397836  6 C  s                 46      1.401868  6 C  dxx        
+    13     -1.301436  1 C  dyy               15     -1.305459  1 C  dzz        
+    49      1.301436  6 C  dyy               51      1.305459  6 C  dzz        
+ 
+ Vector   55  Occ=0.000000D+00  E= 4.383931D+00  Symmetry=a1
+              MO Center= -2.4D-14,  1.3D-18,  1.9D-01, r^2= 1.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      2.212183  4 C  s                 25      2.210254  4 C  s          
+    29     -1.932722  4 C  dxx               34     -1.480857  4 C  dzz        
+     6     -1.427963  1 C  s                 42     -1.427963  6 C  s          
+    32     -1.356486  4 C  dyy                2     -1.311905  1 C  s          
+    38     -1.311905  6 C  s                 10      1.087728  1 C  dxx        
+ 
+
+   alpha - beta orbital overlaps 
+   ----------------------------- 
+
+
+   alpha      1      2      3      4      5      6      7      8      9     10
+    beta      1      2      3      4      5      6      7      8      9     10
+ overlap   0.967  1.000  0.967  0.998  0.999  0.998  0.999  1.000  1.000  1.000
+
+
+   alpha     11     12     13     14     15     16     17     18     19     20
+    beta     11     12     13     14     15     16     17     18     19     20
+ overlap   0.985  0.999  0.984  0.987  0.988  0.999  1.000  0.999  1.000  1.000
+
+
+   alpha     21     22     23     24     25     26     27     28     29     30
+    beta     21     22     23     25     24     26     28     27     29     30
+ overlap   1.000  1.000  0.975  0.999  0.992  0.992  0.999  0.976  0.997  1.000
+
+
+   alpha     31     32     33     34     35     36     37     38     39     40
+    beta     31     32     33     34     35     36     37     38     39     40
+ overlap   0.997  0.999  0.999  1.000  1.000  0.999  1.000  1.000  0.998  1.000
+
+
+   alpha     41     42     43     44     45     46     47     48     49     50
+    beta     41     42     43     44     45     46     47     48     49     50
+ overlap   0.999  0.990  0.999  0.992  0.995  0.999  0.999  0.996  1.000  0.999
+
+
+   alpha     51     52     53     54     55
+    beta     51     52     53     54     55
+ overlap   1.000  1.000  0.999  1.000  0.999
+
+     --------------------------
+     Expectation value of S2:  
+     --------------------------
+      <S2> =      0.7823 (Exact =     0.7500)
+ 
+
+ center of mass
+ --------------
+ x =  -0.00000000 y =   0.00000000 z =   0.01402197
+
+ moments of inertia (a.u.)
+ ------------------
+          32.956100368337           0.000000000000           0.000000000000
+           0.000000000000         209.357428735927           0.000000000000
+           0.000000000000           0.000000000000         176.401328367590
+ 
+     Multipole analysis of the density
+     ---------------------------------
+ 
+     L   x y z        total         alpha         beta         nuclear
+     -   - - -        -----         -----         ----         -------
+     0   0 0 0     -0.000000    -12.000000    -11.000000     23.000000
+ 
+     1   1 0 0      0.000000      0.000000      0.000000     -0.000000
+     1   0 1 0      0.000000      0.000000      0.000000      0.000000
+     1   0 0 1      0.029417      0.297778     -0.268360     -0.000000
+ 
+     2   2 0 0    -13.057064    -65.484941    -58.407650    110.835527
+     2   1 1 0      0.000000      0.000000      0.000000      0.000000
+     2   1 0 1     -0.000000     -0.000000     -0.000000     -0.000000
+     2   0 2 0    -16.001954     -9.089789     -6.912165      0.000000
+     2   0 1 1      0.000000      0.000000      0.000000      0.000000
+     2   0 0 2    -12.950424    -20.189863    -19.682288     26.921727
+ 
+
+ Parallel integral file used      10 records with       0 large values
+
+
+
+--------------------------------------------------------------------------------
+
+          ****************************
+          *** ORBITAL LOCALIZATION ***
+          ****************************
+
+                IAO-IBO localization
+                --------------------
+               (occ and virt orbitals)
+
+ UNRESTRICTED calculation
+
+ ======
+ Spin 1
+ ======
+                      Basis "iao basis" -> "iao basis" (cartesian)
+                      -----
+  C (Carbon)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  7.42737049E+02  0.009164
+  1 S  1.36180025E+02  0.049361
+  1 S  3.80982635E+01  0.168538
+  1 S  1.30877818E+01  0.370563
+  1 S  5.08236865E+00  0.416492
+  1 S  2.09320008E+00  0.130334
+ 
+  2 S  3.04972395E+01 -0.013253
+  2 S  6.03619960E+00 -0.046992
+  2 S  1.87604634E+00 -0.033785
+  2 S  7.21782647E-01  0.250242
+  2 S  3.13470695E-01  0.595117
+  2 S  1.43686555E-01  0.240706
+ 
+  3 P  3.04972395E+01  0.003760
+  3 P  6.03619960E+00  0.037679
+  3 P  1.87604634E+00  0.173897
+  3 P  7.21782647E-01  0.418036
+  3 P  3.13470695E-01  0.425860
+  3 P  1.43686555E-01  0.101708
+ 
+  H (Hydrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  3.55232212E+01  0.009164
+  1 S  6.51314373E+00  0.049361
+  1 S  1.82214290E+00  0.168538
+  1 S  6.25955266E-01  0.370563
+  1 S  2.43076747E-01  0.416492
+  1 S  1.00112428E-01  0.130334
+ 
+
+
+ Summary of "iao basis" -> "iao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           STO-6G                  3        5   2s1p
+ H                           STO-6G                  1        1   1s
+
+
+
+ IBO loc: largest element in C(iao,T) S C(iao) -1:          0.00000000
+ Significant deviations from zero may indicate
+ elevated numerical noise in the IAO generation
+
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for CMOs in the IAO basis
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   6.2221048125   3.9203211801    0.00D+00
+              2   2.4899784549   1.8059074592    7.85D-01
+              3   2.0299572022   1.6763621491    3.03D-01
+              4   2.0299157899   1.6758137657    1.97D-02
+              5   2.0299156039   1.6758142444    6.02D-04
+              6   2.0299156263   1.6758142474    6.84D-06
+              7   2.0299156264   1.6758142474    6.10D-08
+              8   2.0299156264   1.6758142474    5.27D-09
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for IBOs in the IAO basis
+
+ IAO-IBO localized orbitals
+
+    1     -10.167032 1.000      1( 1.00)
+    2     -10.167032 1.000      6( 1.00)
+    3     -10.166338 1.000      4( 1.00)
+    4      -0.604638 1.000      6( 0.51)     4( 0.49)
+    5      -0.604638 1.000      1( 0.51)     4( 0.49)
+    6      -0.508921 1.000      1( 0.54)     3( 0.46)
+    7      -0.508921 1.000      6( 0.54)     8( 0.46)
+    8      -0.506698 1.000      6( 0.54)     7( 0.46)
+    9      -0.506698 1.000      1( 0.54)     2( 0.46)
+   10      -0.496862 1.000      4( 0.52)     5( 0.48)
+   11      -0.254260 1.000      1( 0.78)     4( 0.20)     6( 0.01)
+   12      -0.254260 1.000      6( 0.78)     4( 0.20)     1( 0.01)
+ 
+
+ IBO localization (occ): IBOs will be stored
+ in file locorb.movecs, number 
+          1  to         12
+
+
+ IBO loc: largest element in C(iao,T) S C(iao) -1:          0.00000000
+ Significant deviations from zero may indicate
+ elevated numerical noise in the IAO generation
+
+ non-zero singular values:          8
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for CMOs in the IAO basis
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   5.8115812430   4.1708553446    0.00D+00
+              2   3.1080537183   2.4265901890    7.10D-01
+              3   2.2994264172   2.0571669611    5.23D-01
+              4   2.2982620673   2.0448242984    1.07D-01
+              5   2.2982608429   2.0448237952    1.67D-03
+              6   2.2982608423   2.0448237677    5.11D-05
+              7   2.2982608423   2.0448237679    2.11D-06
+              8   2.2982608423   2.0448237679    2.71D-08
+              9   2.2982608423   2.0448237679    0.00D+00
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for IBOs in the IAO basis
+
+ IAO-IBO localized orbitals
+
+    1       0.106693 0.000      4( 0.59)     1( 0.20)     6( 0.20)
+    2       0.440568 0.000      2( 0.53)     1( 0.46)
+    3       0.440568 0.000      7( 0.53)     6( 0.46)
+    4       0.441301 0.000      8( 0.54)     6( 0.46)
+    5       0.441301 0.000      3( 0.54)     1( 0.46)
+    6       0.451580 0.000      5( 0.52)     4( 0.48)
+    7       0.553018 0.000      4( 0.51)     1( 0.49)
+    8       0.553018 0.000      4( 0.51)     6( 0.49)
+ 
+
+ IBO localization (vir): IBOs will be stored
+ in file locorb.movecs, number 
+         13  to         20
+
+ IBO transformation (occ.) written to file 
+ ./testjob.lmotrans_A
+
+ ======
+ Spin 2
+ ======
+
+ IBO loc: largest element in C(iao,T) S C(iao) -1:          0.00000000
+ Significant deviations from zero may indicate
+ elevated numerical noise in the IAO generation
+
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for CMOs in the IAO basis
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   6.4228858636   4.0514866117    0.00D+00
+              2   2.5165640875   1.9026102649    7.85D-01
+              3   2.3650454245   1.7690977529    2.91D-01
+              4   2.3650454245   1.7685445681    3.00D-02
+              5   2.3650454245   1.7685448902    8.83D-04
+              6   2.3650454245   1.7685448943    8.00D-06
+              7   2.3650454245   1.7685448943    4.83D-08
+              8   2.3650454245   1.7685448943    3.73D-09
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for IBOs in the IAO basis
+
+ IAO-IBO localized orbitals
+
+    1     -10.169001 1.000      4( 1.00)
+    2     -10.159296 1.000      6( 1.00)
+    3     -10.159296 1.000      1( 1.00)
+    4      -0.597440 1.000      4( 0.51)     1( 0.49)
+    5      -0.597440 1.000      4( 0.51)     6( 0.49)
+    6      -0.500868 1.000      4( 0.52)     5( 0.47)
+    7      -0.495381 1.000      1( 0.52)     3( 0.48)
+    8      -0.495381 1.000      6( 0.52)     8( 0.48)
+    9      -0.493757 1.000      6( 0.52)     7( 0.48)
+   10      -0.493757 1.000      1( 0.52)     2( 0.48)
+   11      -0.283542 1.000      4( 0.58)     1( 0.21)     6( 0.21)
+ 
+
+ IBO localization (occ): IBOs will be stored
+ in file locorb.movecs, number 
+          1  to         11
+
+
+ IBO loc: largest element in C(iao,T) S C(iao) -1:          0.00000000
+ Significant deviations from zero may indicate
+ elevated numerical noise in the IAO generation
+
+ non-zero singular values:          9
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for CMOs in the IAO basis
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   4.7244222478   3.8860164103    0.00D+00
+              2   2.7123995102   2.3187188707    7.57D-01
+              3   2.0288413207   1.9156381084    7.36D-01
+              4   2.0200410553   1.9103293579    6.91D-02
+              5   2.0200397235   1.9103200006    3.24D-03
+              6   2.0200397660   1.9103199885    1.85D-04
+              7   2.0200397661   1.9103199884    1.11D-05
+              8   2.0200397661   1.9103199884    6.74D-07
+              9   2.0200397661   1.9103199884    4.38D-08
+             10   2.0200397661   1.9103199884    3.73D-09
+
+ IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
+ should be zero, for IBOs in the IAO basis
+
+ IAO-IBO localized orbitals
+
+    1       0.059594 0.000      6( 0.77)     4( 0.21)     1( 0.01)
+    2       0.059594 0.000      1( 0.77)     4( 0.21)     6( 0.01)
+    3       0.446191 0.000      5( 0.52)     4( 0.47)
+    4       0.452446 0.000      7( 0.52)     6( 0.48)
+    5       0.452446 0.000      2( 0.52)     1( 0.48)
+    6       0.453454 0.000      8( 0.52)     6( 0.48)
+    7       0.453454 0.000      3( 0.52)     1( 0.48)
+    8       0.560559 0.000      6( 0.51)     4( 0.49)
+    9       0.560559 0.000      1( 0.51)     4( 0.49)
+ 
+
+ IBO localization (vir): IBOs will be stored
+ in file locorb.movecs, number 
+         12  to         20
+
+ IBO transformation (occ.) written to file 
+ ./testjob.lmotrans_B
+
+ Exiting Localization driver routine
+
+ Task  times  cpu:        0.6s     wall:        0.6s
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+ Summary of allocated global arrays
+-----------------------------------
+  No active global arrays
+
+
+MA_summarize_allocated_blocks: starting scan ...
+MA_summarize_allocated_blocks: scan completed: 0 heap blocks, 0 stack blocks
+MA usage statistics:
+
+	allocation statistics:
+					      heap	     stack
+					      ----	     -----
+	current number of blocks	         0	         0
+	maximum number of blocks	        23	        57
+	current total bytes		         0	         0
+	maximum total bytes		   4124576	  22514760
+	maximum total K-bytes		      4125	     22515
+	maximum total M-bytes		         5	        23
+ 
+ 
+                                     CITATION
+                                     --------
+                Please cite the following reference when publishing
+                           results obtained with NWChem:
+ 
+          E. Apra, E. J. Bylaska, W. A. de Jong, N. Govind, K. Kowalski,
+       T. P. Straatsma, M. Valiev, H. J. J. van Dam, Y. Alexeev, J. Anchell,
+       V. Anisimov, F. W. Aquino, R. Atta-Fynn, J. Autschbach, N. P. Bauman,
+     J. C. Becca, D. E. Bernholdt, K. Bhaskaran-Nair, S. Bogatko, P. Borowski,
+         J. Boschen, J. Brabec, A. Bruner, E. Cauet, Y. Chen, G. N. Chuev,
+      C. J. Cramer, J. Daily, M. J. O. Deegan, T. H. Dunning Jr., M. Dupuis,
+   K. G. Dyall, G. I. Fann, S. A. Fischer, A. Fonari, H. Fruchtl, L. Gagliardi,
+      J. Garza, N. Gawande, S. Ghosh, K. Glaesemann, A. W. Gotz, J. Hammond,
+       V. Helms, E. D. Hermes, K. Hirao, S. Hirata, M. Jacquelin, L. Jensen,
+   B. G. Johnson, H. Jonsson, R. A. Kendall, M. Klemm, R. Kobayashi, V. Konkov,
+      S. Krishnamoorthy, M. Krishnan, Z. Lin, R. D. Lins, R. J. Littlefield,
+      A. J. Logsdail, K. Lopata, W. Ma, A. V. Marenich, J. Martin del Campo,
+   D. Mejia-Rodriguez, J. E. Moore, J. M. Mullin, T. Nakajima, D. R. Nascimento,
+    J. A. Nichols, P. J. Nichols, J. Nieplocha, A. Otero-de-la-Roza, B. Palmer,
+    A. Panyala, T. Pirojsirikul, B. Peng, R. Peverati, J. Pittner, L. Pollack,
+   R. M. Richard, P. Sadayappan, G. C. Schatz, W. A. Shelton, D. W. Silverstein,
+   D. M. A. Smith, T. A. Soares, D. Song, M. Swart, H. L. Taylor, G. S. Thomas,
+            V. Tipparaju, D. G. Truhlar, K. Tsemekhman, T. Van Voorhis,
+      A. Vazquez-Mayagoitia, P. Verma, O. Villa, A. Vishnu, K. D. Vogiatzis,
+        D. Wang, J. H. Weare, M. J. Williamson, T. L. Windus, K. Wolinski,
+        A. T. Wong, Q. Wu, C. Yang, Q. Yu, M. Zacharias, Z. Zhang, Y. Zhao,
+                                and R. J. Harrison
+                        "NWChem: Past, present, and future
+                         J. Chem. Phys. 152, 184102 (2020)
+                               doi:10.1063/5.0004997
+ 
+                                      AUTHORS
+                                      -------
+  E. Apra, E. J. Bylaska, N. Govind, K. Kowalski, M. Valiev, D. Mejia-Rodriguez,
+       A. Kunitsa, N. P. Bauman, A. Panyala, W. A. de Jong, T. P. Straatsma,
+   H. J. J. van Dam, D. Wang, T. L. Windus, J. Hammond, J. Autschbach, A. Woods,
+    K. Bhaskaran-Nair, J. Brabec, K. Lopata, S. A. Fischer, S. Krishnamoorthy,
+     M. Jacquelin, W. Ma, M. Klemm, O. Villa, Y. Chen, V. Anisimov, F. Aquino,
+     S. Hirata, M. T. Hackler, E. Hermes, L. Jensen, J. E. Moore, J. C. Becca,
+      V. Konjkov, T. Risthaus, M. Malagoli, A. Marenich, A. Otero-de-la-Roza,
+        J. Mullin, P. Nichols, R. Peverati, J. Pittner, Y. Zhao, P.-D. Fan,
+        A. Fonari, M. J. Williamson, R. J. Harrison, J. R. Rehr, M. Dupuis,
+     D. Silverstein, D. M. A. Smith, J. Nieplocha, V. Tipparaju, M. Krishnan,
+     B. E. Van Kuiken, A. Vazquez-Mayagoitia, M. Swart, Q. Wu, T. Van Voorhis,
+     A. A. Auer, M. Nooijen, L. D. Crosby, E. Brown, G. Cisneros, G. I. Fann,
+   H. Fruchtl, J. Garza, K. Hirao, R. A. Kendall, J. A. Nichols, K. Tsemekhman,
+    K. Wolinski, J. Anchell, D. E. Bernholdt, P. Borowski, T. Clark, D. Clerc,
+   H. Dachsel, M. J. O. Deegan, K. Dyall, D. Elwood, E. Glendening, M. Gutowski,
+   A. C. Hess, J. Jaffe, B. G. Johnson, J. Ju, R. Kobayashi, R. Kutteh, Z. Lin,
+   R. Littlefield, X. Long, B. Meng, T. Nakajima, S. Niu, L. Pollack, M. Rosing,
+   K. Glaesemann, G. Sandrone, M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe,
+                               A. T. Wong, Z. Zhang.
+
+ Total times  cpu:        0.6s     wall:        0.6s

--- a/QA/tests/localize-ibo-allyl/localize-ibo-allyl.out
+++ b/QA/tests/localize-ibo-allyl/localize-ibo-allyl.out
@@ -1,5 +1,4 @@
-running on 6 processors
- argument  1 = allyl_radical.nw
+ argument  1 = /home/workspace/jochena/nwchem/loc-unr-pr/QA/tests/localize-ibo-allyl/localize-ibo-allyl.nw
                                          
                                          
  
@@ -39,19 +38,19 @@ running on 6 processors
 
     hostname        = ja04
     program         = /home/workspace/jochena/nwchem/loc-unr-pr/bin/LINUX64/nwchem
-    date            = Wed Dec 27 15:42:46 2023
+    date            = Thu Dec 28 11:01:01 2023
 
-    compiled        = Wed_Dec_27_15:35:48_2023
+    compiled        = Thu_Dec_28_11:00:19_2023
     source          = /home/workspace/jochena/nwchem/loc-unr-pr
     nwchem branch   = 7.2.1
     nwchem revision = nwchem_on_git-5262-g4cee1d3a03
     ga revision     = 5.8.0
     use scalapack   = F
-    input           = allyl_radical.nw
+    input           = /home/workspace/jochena/nwchem/loc-unr-pr/QA/tests/localize-ibo-allyl/localize-ibo-allyl.nw
     prefix          = testjob.
     data base       = ./testjob.db
     status          = startup
-    nproc           =        5
+    nproc           =        3
     time left       =     -1s
 
 
@@ -59,8 +58,8 @@ running on 6 processors
            Memory information
            ------------------
 
-    heap     =     26214400 doubles =      200.0 Mbytes
-    stack    =     26214397 doubles =      200.0 Mbytes
+    heap     =     26214396 doubles =      200.0 Mbytes
+    stack    =     26214401 doubles =      200.0 Mbytes
     global   =     52428800 doubles =      400.0 Mbytes (distinct from heap & stack)
     total    =    104857597 doubles =      800.0 Mbytes
     verify   = yes
@@ -71,7 +70,7 @@ running on 6 processors
            ---------------------
  
   0 permanent = .
-  0 scratch   = /tmp
+  0 scratch   = .
  
  
  
@@ -441,12 +440,12 @@ running on 6 processors
     16 b1         17 a1         18 b1         19 a1         20 b1      
     21 b1         22 a1      
  
-   Time after variat. SCF:      0.1
-   Time prior to 1st pass:      0.1
+   Time after variat. SCF:      0.3
+   Time prior to 1st pass:      0.3
 
- Integral file          = /tmp/testjob.aoints.0
+ Integral file          = ./testjob.aoints.0
  Record size in doubles =  65536        No. of integs per rec  =  43688
- Max. records in memory =      5        Max. records in file   =  27610
+ Max. records in memory =      7        Max. records in file   = 866317
  No. of bits per label  =      8        No. of bits per value  =     64
 
 
@@ -456,45 +455,45 @@ running on 6 processors
 File balance: exchanges=     0  moved=     0  time=   0.0
 
 
- Grid_pts file          = /tmp/testjob.gridpts.0
+ Grid_pts file          = ./testjob.gridpts.0
  Record size in doubles =  12289        No. of grid_pts per rec  =   3070
- Max. records in memory =     15        Max. recs in file   =    147215
+ Max. records in memory =     24        Max. recs in file   =   4619938
 
 
            Memory utilization after 1st SCF pass: 
-           Heap Space remaining (MW):       25.70            25698824
-          Stack Space remaining (MW):       26.21            26213652
+           Heap Space remaining (MW):       25.46            25457148
+          Stack Space remaining (MW):       26.21            26213660
 
    convergence    iter        energy       DeltaE   RMS-Dens  Diis-err    time
  ---------------- ----- ----------------- --------- --------- ---------  ------
- d= 0,ls=0.0,diis     1   -117.2264534786 -1.82D+02  4.20D-03  7.87D-02     0.2
+ d= 0,ls=0.0,diis     1   -117.2264534955 -1.82D+02  4.20D-03  7.87D-02     0.4
                                                      4.37D-03  7.80D-02
- d= 0,ls=0.0,diis     2   -117.2587196631 -3.23D-02  7.78D-04  1.26D-03     0.2
+ d= 0,ls=0.0,diis     2   -117.2587196811 -3.23D-02  7.78D-04  1.26D-03     0.4
                                                      1.07D-03  1.84D-03
- d= 0,ls=0.0,diis     3   -117.2598149263 -1.10D-03  4.64D-04  8.89D-04     0.3
+ d= 0,ls=0.0,diis     3   -117.2598149260 -1.10D-03  4.64D-04  8.89D-04     0.5
                                                      2.72D-04  3.90D-04
- d= 0,ls=0.0,diis     4   -117.2602063095 -3.91D-04  8.96D-05  3.18D-05     0.3
+ d= 0,ls=0.0,diis     4   -117.2602063094 -3.91D-04  8.96D-05  3.18D-05     0.6
                                                      2.25D-04  1.42D-04
- d= 0,ls=0.0,diis     5   -117.2602941371 -8.78D-05  1.43D-04  2.90D-05     0.4
+ d= 0,ls=0.0,diis     5   -117.2602941371 -8.78D-05  1.43D-04  2.90D-05     0.6
                                                      7.98D-05  6.96D-06
   Resetting Diis
- d= 0,ls=0.0,diis     6   -117.2603166651 -2.25D-05  3.71D-05  4.15D-06     0.4
+ d= 0,ls=0.0,diis     6   -117.2603166651 -2.25D-05  3.71D-05  4.15D-06     0.7
                                                      6.09D-05  7.84D-06
- d= 0,ls=0.0,diis     7   -117.2603215407 -4.88D-06  1.28D-05  2.23D-07     0.5
+ d= 0,ls=0.0,diis     7   -117.2603215407 -4.88D-06  1.28D-05  2.23D-07     0.7
                                                      8.81D-06  1.11D-07
- d= 0,ls=0.0,diis     8   -117.2603216043 -6.36D-08  4.92D-06  1.14D-07     0.5
+ d= 0,ls=0.0,diis     8   -117.2603216042 -6.36D-08  4.92D-06  1.14D-07     0.8
                                                      6.04D-06  1.72D-07
 
 
-         Total DFT energy =     -117.260321604256
-      One electron energy =     -284.181892325080
-           Coulomb energy =      120.312079357638
-    Exchange-Corr. energy =      -18.079953401880
+         Total DFT energy =     -117.260321604226
+      One electron energy =     -284.181892305191
+           Coulomb energy =      120.312079336051
+    Exchange-Corr. energy =      -18.079953400152
  Nuclear repulsion energy =       64.689444765066
 
- Numeric. integr. density =       23.000000853283
+ Numeric. integr. density =       23.000000853201
 
-     Total iterative time =      0.4s
+     Total iterative time =      0.5s
 
 
  
@@ -513,21 +512,21 @@ File balance: exchanges=     0  moved=     0  time=   0.0
                     ------------------------------------------
  
  Vector    1  Occ=1.000000D+00  E=-1.019144D+01  Symmetry=a1
-              MO Center= -5.4D-18,  0.0D+00,  3.9D-01, r^2= 1.8D-01
+              MO Center= -3.2D-14,  1.0D-27,  3.9D-01, r^2= 1.8D-01
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     20      0.952067  4 C  s                  1      0.198740  1 C  s          
     37      0.198740  6 C  s                 21      0.046701  4 C  s          
  
  Vector    2  Occ=1.000000D+00  E=-1.019007D+01  Symmetry=b1
-              MO Center=  1.6D-10, -5.1D-18, -2.0D-01, r^2= 1.5D+00
+              MO Center=  2.9D-11,  7.8D-19, -2.0D-01, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      1      0.701862  1 C  s                 37     -0.701862  6 C  s          
      2      0.035620  1 C  s                 38     -0.035620  6 C  s          
  
  Vector    3  Occ=1.000000D+00  E=-1.018994D+01  Symmetry=a1
-              MO Center= -1.6D-10,  1.5D-26, -1.4D-01, r^2= 1.5D+00
+              MO Center= -2.9D-11, -1.7D-26, -1.4D-01, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      1      0.673109  1 C  s                 37      0.673109  6 C  s          
@@ -535,7 +534,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     38      0.034080  6 C  s          
  
  Vector    4  Occ=1.000000D+00  E=-7.875894D-01  Symmetry=a1
-              MO Center=  3.4D-17,  2.2D-32,  8.8D-02, r^2= 1.5D+00
+              MO Center=  5.0D-15, -2.5D-17,  8.8D-02, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      0.309509  4 C  s                  2      0.226557  1 C  s          
@@ -545,7 +544,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     37     -0.116999  6 C  s                 35      0.078408  5 H  s          
  
  Vector    5  Occ=1.000000D+00  E=-6.775622D-01  Symmetry=b1
-              MO Center=  4.8D-16,  1.6D-16, -1.1D-01, r^2= 2.6D+00
+              MO Center= -5.4D-15, -2.6D-16, -1.1D-01, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      2      0.291922  1 C  s                 38     -0.291922  6 C  s          
@@ -555,7 +554,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     54     -0.110854  8 H  s                 16      0.097001  2 H  s          
  
  Vector    6  Occ=1.000000D+00  E=-5.546573D-01  Symmetry=a1
-              MO Center= -3.2D-15,  1.4D-17,  4.6D-02, r^2= 2.8D+00
+              MO Center=  1.1D-15,  7.9D-17,  4.6D-02, r^2= 2.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      0.244705  4 C  s                 25      0.225790  4 C  s          
@@ -565,7 +564,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      5      0.138568  1 C  pz                41      0.138568  6 C  pz         
  
  Vector    7  Occ=1.000000D+00  E=-4.739162D-01  Symmetry=a1
-              MO Center=  1.8D-15, -5.4D-32,  1.8D-01, r^2= 2.9D+00
+              MO Center=  2.1D-15,  2.1D-17,  1.8D-01, r^2= 2.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     24      0.272435  4 C  pz                 3      0.258895  1 C  px         
@@ -575,7 +574,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     19      0.110893  3 H  s                 55      0.110893  8 H  s          
  
  Vector    8  Occ=1.000000D+00  E=-4.318944D-01  Symmetry=b1
-              MO Center=  5.9D-16, -8.2D-18, -4.1D-01, r^2= 2.4D+00
+              MO Center= -9.1D-15, -4.1D-18, -4.1D-01, r^2= 2.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      5      0.304576  1 C  pz                41     -0.304576  6 C  pz         
@@ -585,7 +584,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     39     -0.130192  6 C  px                 9      0.126798  1 C  pz         
  
  Vector    9  Occ=1.000000D+00  E=-3.826093D-01  Symmetry=b1
-              MO Center=  9.6D-15, -4.4D-18,  4.8D-03, r^2= 3.3D+00
+              MO Center=  6.4D-15, -1.1D-18,  4.8D-03, r^2= 3.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      3      0.319026  1 C  px                39      0.319026  6 C  px         
@@ -595,7 +594,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     43      0.125357  6 C  px                 5      0.120630  1 C  pz         
  
  Vector   10  Occ=1.000000D+00  E=-3.580975D-01  Symmetry=a1
-              MO Center= -8.6D-15, -1.4D-17,  1.3D-01, r^2= 2.8D+00
+              MO Center= -1.9D-15,  1.4D-17,  1.3D-01, r^2= 2.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     24      0.325098  4 C  pz                 5     -0.253720  1 C  pz         
@@ -605,7 +604,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     52      0.167195  7 H  s                 28      0.095924  4 C  pz         
  
  Vector   11  Occ=1.000000D+00  E=-3.155329D-01  Symmetry=b2
-              MO Center= -7.5D-15, -4.9D-16,  5.4D-02, r^2= 1.9D+00
+              MO Center=  5.3D-15, -1.5D-16,  5.4D-02, r^2= 1.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     23      0.352195  4 C  py                 4      0.315364  1 C  py         
@@ -613,7 +612,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     44      0.215742  6 C  py                27      0.205267  4 C  py         
  
  Vector   12  Occ=1.000000D+00  E=-1.929868D-01  Symmetry=a2
-              MO Center=  5.8D-15, -1.4D-17, -1.9D-01, r^2= 2.6D+00
+              MO Center= -5.9D-15,  2.9D-16, -1.9D-01, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      4      0.435275  1 C  py                40     -0.435275  6 C  py         
@@ -621,7 +620,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     30      0.053428  4 C  dxy        
  
  Vector   13  Occ=0.000000D+00  E= 4.890987D-02  Symmetry=b2
-              MO Center=  1.5D-15, -2.7D-16,  1.8D-01, r^2= 2.3D+00
+              MO Center=  4.0D-16, -4.2D-16,  1.8D-01, r^2= 2.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     27      0.742887  4 C  py                23      0.494038  4 C  py         
@@ -631,7 +630,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     14      0.029054  1 C  dyz               50      0.029054  6 C  dyz        
  
  Vector   14  Occ=0.000000D+00  E= 1.104751D-01  Symmetry=a1
-              MO Center= -1.6D-14,  9.3D-18,  6.1D-01, r^2= 5.6D+00
+              MO Center=  5.4D-16, -3.1D-17,  6.1D-01, r^2= 5.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     19      1.062176  3 H  s                 55      1.062176  8 H  s          
@@ -641,7 +640,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     28     -0.422910  4 C  pz                17      0.361915  2 H  s          
  
  Vector   15  Occ=0.000000D+00  E= 1.344455D-01  Symmetry=a1
-              MO Center=  5.9D-15, -2.9D-17, -7.2D-01, r^2= 4.8D+00
+              MO Center=  3.9D-14, -1.4D-17, -7.2D-01, r^2= 4.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     17      1.251323  2 H  s                 53      1.251323  7 H  s          
@@ -651,7 +650,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     28      0.278675  4 C  pz                 5      0.227735  1 C  pz         
  
  Vector   16  Occ=0.000000D+00  E= 1.506067D-01  Symmetry=b1
-              MO Center=  1.1D-14, -1.0D-16, -4.5D-01, r^2= 6.2D+00
+              MO Center= -4.1D-14,  1.3D-16, -4.5D-01, r^2= 6.2D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      6      1.774875  1 C  s                 42     -1.774875  6 C  s          
@@ -661,7 +660,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     43      0.195376  6 C  px                 2      0.138501  1 C  s          
  
  Vector   17  Occ=0.000000D+00  E= 1.954423D-01  Symmetry=b1
-              MO Center=  1.9D-14,  4.7D-17, -2.9D-01, r^2= 6.4D+00
+              MO Center=  3.8D-16,  2.5D-18, -2.9D-01, r^2= 6.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     19      1.319508  3 H  s                 55     -1.319508  8 H  s          
@@ -671,7 +670,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      5     -0.238701  1 C  pz                41      0.238701  6 C  pz         
  
  Vector   18  Occ=0.000000D+00  E= 1.999659D-01  Symmetry=a1
-              MO Center= -3.5D-14,  4.1D-17,  7.5D-01, r^2= 5.3D+00
+              MO Center=  1.2D-14, -8.2D-18,  7.5D-01, r^2= 5.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      2.196924  4 C  s                 36     -1.558443  5 H  s          
@@ -681,7 +680,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53     -0.703306  7 H  s                  6     -0.649042  1 C  s          
  
  Vector   19  Occ=0.000000D+00  E= 3.087357D-01  Symmetry=a1
-              MO Center=  2.7D-14,  3.6D-17, -2.0D-01, r^2= 4.9D+00
+              MO Center=  1.6D-15, -3.3D-17, -2.0D-01, r^2= 4.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      3.443353  4 C  s                 28     -2.413506  4 C  pz         
@@ -691,7 +690,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     55     -0.863600  8 H  s                 17      0.503457  2 H  s          
  
  Vector   20  Occ=0.000000D+00  E= 3.730297D-01  Symmetry=b1
-              MO Center= -1.8D-14,  7.8D-18, -1.3D-01, r^2= 4.4D+00
+              MO Center= -1.2D-14, -1.5D-17, -1.3D-01, r^2= 4.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      3.400554  4 C  px                 6     -1.984631  1 C  s          
@@ -701,7 +700,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53      1.070686  7 H  s                 22      0.359473  4 C  px         
  
  Vector   21  Occ=0.000000D+00  E= 4.993834D-01  Symmetry=b1
-              MO Center=  5.0D-15,  2.9D-16,  3.5D-01, r^2= 3.5D+00
+              MO Center=  6.5D-16,  3.9D-17,  3.5D-01, r^2= 3.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      1.032454  4 C  px                 7     -0.495359  1 C  px         
@@ -711,7 +710,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      5     -0.338940  1 C  pz                41      0.338940  6 C  pz         
  
  Vector   22  Occ=0.000000D+00  E= 5.173637D-01  Symmetry=a1
-              MO Center= -1.1D-16,  1.9D-16, -2.9D-01, r^2= 2.8D+00
+              MO Center=  7.8D-16,  1.7D-15, -2.9D-01, r^2= 2.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      7      0.582212  1 C  px                43     -0.582212  6 C  px         
@@ -721,7 +720,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      6     -0.245895  1 C  s                 42     -0.245895  6 C  s          
  
  Vector   23  Occ=0.000000D+00  E= 5.255651D-01  Symmetry=b2
-              MO Center=  9.0D-17, -2.6D-16, -1.4D-01, r^2= 3.1D+00
+              MO Center=  1.1D-15, -8.9D-16, -1.4D-01, r^2= 3.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      4      0.678296  1 C  py                40      0.678296  6 C  py         
@@ -731,7 +730,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     47      0.034594  6 C  dxy               14      0.031037  1 C  dyz        
  
  Vector   24  Occ=0.000000D+00  E= 5.897374D-01  Symmetry=a2
-              MO Center= -6.1D-16, -2.6D-15, -2.0D-01, r^2= 3.7D+00
+              MO Center= -6.0D-16, -6.1D-17, -2.0D-01, r^2= 3.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      8      0.872708  1 C  py                44     -0.872708  6 C  py         
@@ -740,7 +739,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     47      0.049938  6 C  dxy        
  
  Vector   25  Occ=0.000000D+00  E= 6.216112D-01  Symmetry=a1
-              MO Center= -1.2D-14,  9.7D-16,  5.9D-01, r^2= 2.4D+00
+              MO Center= -3.8D-15, -8.7D-16,  5.9D-01, r^2= 2.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.160720  4 C  s                 21     -0.593664  4 C  s          
@@ -750,7 +749,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     45      0.427398  6 C  pz                18     -0.301836  3 H  s          
  
  Vector   26  Occ=0.000000D+00  E= 6.440811D-01  Symmetry=a1
-              MO Center= -7.8D-16,  4.3D-17, -3.8D-01, r^2= 3.4D+00
+              MO Center=  4.7D-14,  9.1D-17, -3.8D-01, r^2= 3.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      0.879404  4 C  s                  9     -0.718417  1 C  pz         
@@ -760,7 +759,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     16     -0.419258  2 H  s                 52     -0.419258  7 H  s          
  
  Vector   27  Occ=0.000000D+00  E= 6.575335D-01  Symmetry=b1
-              MO Center=  1.4D-14,  2.2D-15, -1.9D-01, r^2= 3.6D+00
+              MO Center= -3.8D-14, -9.6D-17, -1.9D-01, r^2= 3.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      0.803179  4 C  px                22     -0.674073  4 C  px         
@@ -770,7 +769,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     18     -0.357264  3 H  s                 54      0.357264  8 H  s          
  
  Vector   28  Occ=0.000000D+00  E= 6.633980D-01  Symmetry=b2
-              MO Center=  3.6D-16, -5.2D-16,  4.1D-01, r^2= 2.6D+00
+              MO Center=  5.2D-17,  5.6D-16,  4.1D-01, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     27      1.581315  4 C  py                23     -0.996718  4 C  py         
@@ -780,7 +779,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     33      0.044518  4 C  dyz        
  
  Vector   29  Occ=0.000000D+00  E= 8.464557D-01  Symmetry=a1
-              MO Center=  1.7D-15, -4.0D-18, -5.2D-01, r^2= 4.0D+00
+              MO Center= -3.1D-14,  2.3D-17, -5.2D-01, r^2= 4.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     28      2.301288  4 C  pz                 9     -1.764844  1 C  pz         
@@ -790,7 +789,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     55      1.071625  8 H  s                  7     -1.033651  1 C  px         
  
  Vector   30  Occ=0.000000D+00  E= 8.626675D-01  Symmetry=b1
-              MO Center=  2.2D-15, -1.1D-17, -1.4D-01, r^2= 4.9D+00
+              MO Center=  1.8D-14, -2.6D-18, -1.4D-01, r^2= 4.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      9      1.619782  1 C  pz                45     -1.619782  6 C  pz         
@@ -800,7 +799,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     26     -0.713957  4 C  px                 5     -0.676726  1 C  pz         
  
  Vector   31  Occ=0.000000D+00  E= 8.833233D-01  Symmetry=a1
-              MO Center= -1.7D-16, -1.8D-17,  1.2D+00, r^2= 1.9D+00
+              MO Center= -2.2D-15, -6.2D-18,  1.2D+00, r^2= 1.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     28      2.486162  4 C  pz                36     -2.429060  5 H  s          
@@ -810,7 +809,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      7     -0.481149  1 C  px                43      0.481149  6 C  px         
  
  Vector   32  Occ=0.000000D+00  E= 9.215954D-01  Symmetry=a1
-              MO Center=  2.8D-16,  9.9D-17, -1.5D-01, r^2= 5.0D+00
+              MO Center=  1.8D-14, -6.1D-17, -1.5D-01, r^2= 5.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.242249  4 C  s                 19     -1.175595  3 H  s          
@@ -820,7 +819,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     38     -0.718653  6 C  s                 17     -0.588252  2 H  s          
  
  Vector   33  Occ=0.000000D+00  E= 9.405175D-01  Symmetry=b1
-              MO Center= -3.4D-15, -4.5D-17, -4.0D-01, r^2= 4.1D+00
+              MO Center= -2.1D-15,  1.5D-17, -4.0D-01, r^2= 4.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      2.588414  4 C  px                 7      1.422824  1 C  px         
@@ -830,7 +829,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     42      1.014710  6 C  s                 19     -0.679485  3 H  s          
  
  Vector   34  Occ=0.000000D+00  E= 9.945514D-01  Symmetry=b1
-              MO Center= -5.0D-15,  1.1D-16, -1.8D-01, r^2= 3.7D+00
+              MO Center=  5.5D-14, -7.7D-17, -1.8D-01, r^2= 3.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      6      4.130016  1 C  s                 42     -4.130016  6 C  s          
@@ -840,7 +839,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53      0.677197  7 H  s                 19     -0.563915  3 H  s          
  
  Vector   35  Occ=0.000000D+00  E= 1.116321D+00  Symmetry=b1
-              MO Center=  1.8D-13,  2.9D-18, -2.4D-02, r^2= 3.7D+00
+              MO Center= -5.3D-15, -1.0D-17, -2.4D-02, r^2= 3.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      3.458815  4 C  px                 9     -2.391694  1 C  pz         
@@ -850,7 +849,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53      0.653128  7 H  s                 18      0.570703  3 H  s          
  
  Vector   36  Occ=0.000000D+00  E= 1.136036D+00  Symmetry=a1
-              MO Center= -1.9D-13,  1.3D-16,  3.7D-01, r^2= 3.1D+00
+              MO Center= -7.3D-14, -2.4D-17,  3.7D-01, r^2= 3.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      6.019867  4 C  s                  6     -3.465096  1 C  s          
@@ -860,7 +859,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      7      0.707987  1 C  px                43     -0.707987  6 C  px         
  
  Vector   37  Occ=0.000000D+00  E= 1.324032D+00  Symmetry=a1
-              MO Center=  1.7D-14, -2.4D-17,  3.3D-02, r^2= 3.3D+00
+              MO Center=  4.0D-15, -8.2D-17,  3.3D-02, r^2= 3.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     28      4.802933  4 C  pz                25     -3.657206  4 C  s          
@@ -870,7 +869,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     45     -1.452212  6 C  pz                21      0.836613  4 C  s          
  
  Vector   38  Occ=0.000000D+00  E= 1.363767D+00  Symmetry=a2
-              MO Center=  9.5D-17, -1.9D-18,  6.6D-02, r^2= 1.6D+00
+              MO Center= -3.4D-15, -6.1D-18,  6.6D-02, r^2= 1.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     30      0.977038  4 C  dxy               11     -0.612249  1 C  dxy        
@@ -879,7 +878,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     40      0.125983  6 C  py         
  
  Vector   39  Occ=0.000000D+00  E= 1.464994D+00  Symmetry=b2
-              MO Center=  1.9D-15, -1.1D-18,  1.4D-01, r^2= 1.5D+00
+              MO Center= -1.1D-15, -3.1D-17,  1.4D-01, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     33      1.122325  4 C  dyz               11      0.751855  1 C  dxy        
@@ -889,7 +888,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     27     -0.039799  4 C  py         
  
  Vector   40  Occ=0.000000D+00  E= 1.662901D+00  Symmetry=a2
-              MO Center= -3.1D-15, -6.8D-17, -2.0D-01, r^2= 2.1D+00
+              MO Center= -3.5D-15, -2.6D-17, -2.0D-01, r^2= 2.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     14      0.969638  1 C  dyz               50     -0.969638  6 C  dyz        
@@ -899,7 +898,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     30     -0.026174  4 C  dxy        
  
  Vector   41  Occ=0.000000D+00  E= 1.708594D+00  Symmetry=b2
-              MO Center=  1.0D-15,  3.2D-19, -1.3D-01, r^2= 2.1D+00
+              MO Center=  7.3D-15,  1.3D-19, -1.3D-01, r^2= 2.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     14      1.186376  1 C  dyz               50      1.186376  6 C  dyz        
@@ -909,7 +908,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     47      0.053411  6 C  dxy                4     -0.049333  1 C  py         
  
  Vector   42  Occ=0.000000D+00  E= 1.855904D+00  Symmetry=a1
-              MO Center=  1.4D-16,  2.2D-17,  7.4D-02, r^2= 2.0D+00
+              MO Center= -3.1D-15, -7.5D-18,  7.4D-02, r^2= 2.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.528929  4 C  s                 32     -0.617958  4 C  dyy        
@@ -919,7 +918,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     34      0.435676  4 C  dzz               18     -0.328060  3 H  s          
  
  Vector   43  Occ=0.000000D+00  E= 1.913622D+00  Symmetry=b1
-              MO Center= -1.5D-15, -8.9D-18,  7.1D-03, r^2= 1.9D+00
+              MO Center= -1.6D-15,  5.6D-19,  7.1D-03, r^2= 1.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     31      1.107155  4 C  dxz               26     -0.487225  4 C  px         
@@ -929,7 +928,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      2      0.273865  1 C  s                 38     -0.273865  6 C  s          
  
  Vector   44  Occ=0.000000D+00  E= 1.947782D+00  Symmetry=a1
-              MO Center=  2.4D-15, -6.9D-18,  1.8D-01, r^2= 2.0D+00
+              MO Center= -7.8D-16,  1.9D-17,  1.8D-01, r^2= 2.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     28      1.127875  4 C  pz                12      0.756990  1 C  dxz        
@@ -939,7 +938,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      6      0.312872  1 C  s                 42      0.312872  6 C  s          
  
  Vector   45  Occ=0.000000D+00  E= 2.101913D+00  Symmetry=b1
-              MO Center=  4.0D-15,  5.3D-17, -1.6D-01, r^2= 2.6D+00
+              MO Center=  5.5D-15,  9.5D-18, -1.6D-01, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      6      1.367107  1 C  s                 42     -1.367107  6 C  s          
@@ -949,7 +948,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     54      0.535185  8 H  s                 15      0.372899  1 C  dzz        
  
  Vector   46  Occ=0.000000D+00  E= 2.189658D+00  Symmetry=b2
-              MO Center= -2.6D-16,  7.0D-17,  5.8D-02, r^2= 1.7D+00
+              MO Center=  1.1D-15,  1.3D-16,  5.8D-02, r^2= 1.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     33      1.336057  4 C  dyz               11     -1.065414  1 C  dxy        
@@ -959,7 +958,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     23     -0.096204  4 C  py                 4      0.026693  1 C  py         
  
  Vector   47  Occ=0.000000D+00  E= 2.216936D+00  Symmetry=a1
-              MO Center=  3.2D-17,  8.4D-18, -1.4D-01, r^2= 2.2D+00
+              MO Center= -2.7D-15,  5.0D-18, -1.4D-01, r^2= 2.2D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     12      0.667641  1 C  dxz               48     -0.667641  6 C  dxz        
@@ -969,7 +968,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     32      0.444709  4 C  dyy                6      0.390761  1 C  s          
  
  Vector   48  Occ=0.000000D+00  E= 2.314741D+00  Symmetry=b1
-              MO Center= -5.0D-15,  4.4D-18, -1.9D-01, r^2= 2.5D+00
+              MO Center=  2.2D-15,  4.6D-18, -1.9D-01, r^2= 2.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     12      1.192320  1 C  dxz               48      1.192320  6 C  dxz        
@@ -979,7 +978,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     52     -0.415523  7 H  s                 13      0.399540  1 C  dyy        
  
  Vector   49  Occ=0.000000D+00  E= 2.443102D+00  Symmetry=a2
-              MO Center=  2.9D-16,  1.6D-17,  1.7D-01, r^2= 1.6D+00
+              MO Center= -5.6D-16,  6.7D-17,  1.7D-01, r^2= 1.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     30      1.654040  4 C  dxy               11      0.862748  1 C  dxy        
@@ -989,7 +988,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     40      0.085619  6 C  py         
  
  Vector   50  Occ=0.000000D+00  E= 2.533427D+00  Symmetry=a1
-              MO Center=  1.5D-14, -1.1D-17,  9.2D-02, r^2= 2.0D+00
+              MO Center= -1.8D-15,  5.8D-18,  9.2D-02, r^2= 2.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      3.191104  4 C  s                  6     -1.848199  1 C  s          
@@ -999,7 +998,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     46     -0.669902  6 C  dxx               13      0.523227  1 C  dyy        
  
  Vector   51  Occ=0.000000D+00  E= 2.778110D+00  Symmetry=b1
-              MO Center= -1.7D-14,  1.1D-18,  1.4D-01, r^2= 1.8D+00
+              MO Center=  4.2D-15,  9.3D-19,  1.4D-01, r^2= 1.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     31     -1.994653  4 C  dxz               26      1.832278  4 C  px         
@@ -1009,7 +1008,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     22      0.587356  4 C  px                 7      0.580886  1 C  px         
  
  Vector   52  Occ=0.000000D+00  E= 2.904610D+00  Symmetry=a1
-              MO Center=  1.6D-15,  6.5D-18,  1.5D-01, r^2= 1.7D+00
+              MO Center=  1.1D-15,  1.2D-17,  1.5D-01, r^2= 1.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.749688  4 C  s                 12      1.130343  1 C  dxz        
@@ -1019,7 +1018,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      7      0.527528  1 C  px                43     -0.527528  6 C  px         
  
  Vector   53  Occ=0.000000D+00  E= 4.069168D+00  Symmetry=a1
-              MO Center= -1.5D-13,  3.4D-18,  3.3D-02, r^2= 1.7D+00
+              MO Center=  1.5D-14,  1.6D-18,  3.3D-02, r^2= 1.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      1.860006  4 C  s                  2      1.783752  1 C  s          
@@ -1029,7 +1028,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     49     -1.011424  6 C  dyy               10     -1.005816  1 C  dxx        
  
  Vector   54  Occ=0.000000D+00  E= 4.132941D+00  Symmetry=b1
-              MO Center=  1.3D-13, -3.6D-17, -2.1D-01, r^2= 2.3D+00
+              MO Center= -1.6D-14,  3.2D-18, -2.1D-01, r^2= 2.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      2      2.109301  1 C  s                 38     -2.109301  6 C  s          
@@ -1039,7 +1038,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     49      1.300055  6 C  dyy               51      1.305840  6 C  dzz        
  
  Vector   55  Occ=0.000000D+00  E= 4.378798D+00  Symmetry=a1
-              MO Center=  2.2D-14,  6.3D-18,  2.2D-01, r^2= 1.6D+00
+              MO Center=  7.8D-18, -6.2D-19,  2.2D-01, r^2= 1.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      2.305576  4 C  s                 25      2.249791  4 C  s          
@@ -1053,20 +1052,20 @@ File balance: exchanges=     0  moved=     0  time=   0.0
                      -----------------------------------------
  
  Vector    1  Occ=1.000000D+00  E=-1.019474D+01  Symmetry=a1
-              MO Center= -3.1D-16, -5.6D-29,  4.4D-01, r^2= 3.0D-02
+              MO Center= -8.8D-17, -4.6D-30,  4.4D-01, r^2= 3.0D-02
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     20      0.992296  4 C  s                 21      0.049641  4 C  s          
  
  Vector    2  Occ=1.000000D+00  E=-1.018112D+01  Symmetry=b1
-              MO Center= -6.3D-10, -3.2D-18, -2.0D-01, r^2= 1.5D+00
+              MO Center=  5.0D-10, -3.5D-17, -2.0D-01, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      1      0.702106  1 C  s                 37     -0.702106  6 C  s          
      2      0.033995  1 C  s                 38     -0.033995  6 C  s          
  
  Vector    3  Occ=1.000000D+00  E=-1.018110D+01  Symmetry=a1
-              MO Center=  6.3D-10,  8.6D-26, -2.0D-01, r^2= 1.5D+00
+              MO Center= -5.0D-10, -4.4D-27, -2.0D-01, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      1      0.701782  1 C  s                 37      0.701782  6 C  s          
@@ -1074,7 +1073,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     20     -0.029557  4 C  s          
  
  Vector    4  Occ=1.000000D+00  E=-7.769008D-01  Symmetry=a1
-              MO Center= -9.4D-15, -1.9D-17,  1.4D-01, r^2= 1.4D+00
+              MO Center= -3.0D-15, -3.4D-17,  1.4D-01, r^2= 1.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      0.331598  4 C  s                 25      0.223429  4 C  s          
@@ -1084,7 +1083,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     37     -0.109586  6 C  s                 35      0.085654  5 H  s          
  
  Vector    5  Occ=1.000000D+00  E=-6.523638D-01  Symmetry=b1
-              MO Center=  8.0D-16, -2.0D-16, -1.0D-01, r^2= 2.6D+00
+              MO Center=  1.5D-16,  7.0D-17, -1.0D-01, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      2      0.283500  1 C  s                 38     -0.283500  6 C  s          
@@ -1094,7 +1093,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     54     -0.118511  8 H  s                 16      0.101912  2 H  s          
  
  Vector    6  Occ=1.000000D+00  E=-5.479289D-01  Symmetry=a1
-              MO Center=  8.5D-15, -1.2D-16,  7.0D-03, r^2= 2.9D+00
+              MO Center=  6.0D-15,  3.5D-31,  7.0D-03, r^2= 2.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      0.227759  4 C  s                 25      0.206542  4 C  s          
@@ -1104,7 +1103,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     16     -0.142813  2 H  s                 52     -0.142813  7 H  s          
  
  Vector    7  Occ=1.000000D+00  E=-4.691647D-01  Symmetry=a1
-              MO Center= -1.9D-15, -6.5D-32,  2.0D-01, r^2= 3.0D+00
+              MO Center= -1.8D-14,  7.2D-17,  2.0D-01, r^2= 3.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     24      0.277367  4 C  pz                 3      0.256734  1 C  px         
@@ -1114,7 +1113,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     41      0.122014  6 C  pz                55      0.122187  8 H  s          
  
  Vector    8  Occ=1.000000D+00  E=-4.259626D-01  Symmetry=b1
-              MO Center= -2.0D-15, -1.3D-18, -4.2D-01, r^2= 2.4D+00
+              MO Center=  2.3D-15,  1.8D-17, -4.2D-01, r^2= 2.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     22      0.310586  4 C  px                 5      0.296500  1 C  pz         
@@ -1124,7 +1123,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     39     -0.129585  6 C  px                 9      0.116956  1 C  pz         
  
  Vector    9  Occ=1.000000D+00  E=-3.768311D-01  Symmetry=b1
-              MO Center=  7.8D-16,  5.4D-33,  5.9D-03, r^2= 3.3D+00
+              MO Center= -7.0D-15,  1.2D-17,  5.9D-03, r^2= 3.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      3      0.310358  1 C  px                39      0.310358  6 C  px         
@@ -1134,7 +1133,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     41     -0.120007  6 C  pz                 7      0.115093  1 C  px         
  
  Vector   10  Occ=1.000000D+00  E=-3.555026D-01  Symmetry=a1
-              MO Center=  3.1D-15,  2.0D-17,  9.0D-02, r^2= 2.9D+00
+              MO Center=  2.1D-14, -1.7D-17,  9.0D-02, r^2= 2.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     24      0.323425  4 C  pz                 5     -0.251006  1 C  pz         
@@ -1144,7 +1143,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     52      0.172854  7 H  s                 18     -0.097878  3 H  s          
  
  Vector   11  Occ=1.000000D+00  E=-2.835423D-01  Symmetry=b2
-              MO Center=  5.4D-16, -1.5D-16,  1.8D-01, r^2= 1.6D+00
+              MO Center= -2.2D-15, -4.1D-16,  1.8D-01, r^2= 1.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     23      0.442357  4 C  py                27      0.298528  4 C  py         
@@ -1152,7 +1151,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      8      0.163551  1 C  py                44      0.163551  6 C  py         
  
  Vector   12  Occ=0.000000D+00  E=-6.761653D-02  Symmetry=a2
-              MO Center= -3.0D-15,  1.5D-16, -1.9D-01, r^2= 2.7D+00
+              MO Center=  2.3D-15, -7.4D-17, -1.9D-01, r^2= 2.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      8      0.428097  1 C  py                44     -0.428097  6 C  py         
@@ -1160,7 +1159,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     30      0.060469  4 C  dxy        
  
  Vector   13  Occ=0.000000D+00  E= 7.656088D-02  Symmetry=b2
-              MO Center=  2.7D-15, -1.8D-17,  4.4D-02, r^2= 2.6D+00
+              MO Center= -1.8D-16,  4.4D-16,  4.4D-02, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     27      0.697685  4 C  py                 8     -0.549964  1 C  py         
@@ -1170,7 +1169,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     47      0.034002  6 C  dxy               14      0.025565  1 C  dyz        
  
  Vector   14  Occ=0.000000D+00  E= 1.140651D-01  Symmetry=a1
-              MO Center=  9.5D-17,  1.1D-17,  8.4D-01, r^2= 5.0D+00
+              MO Center= -2.7D-15, -4.8D-17,  8.4D-01, r^2= 5.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     36     -1.200264  5 H  s                 25      1.141660  4 C  s          
@@ -1180,7 +1179,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     28      0.470279  4 C  pz                24      0.240722  4 C  pz         
  
  Vector   15  Occ=0.000000D+00  E= 1.390082D-01  Symmetry=a1
-              MO Center=  3.3D-14,  2.0D-18, -9.1D-01, r^2= 4.6D+00
+              MO Center= -3.4D-16,  1.3D-16, -9.1D-01, r^2= 4.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     17      1.297363  2 H  s                 53      1.297363  7 H  s          
@@ -1190,7 +1189,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     28      0.229626  4 C  pz                 5      0.220610  1 C  pz         
  
  Vector   16  Occ=0.000000D+00  E= 1.597482D-01  Symmetry=b1
-              MO Center= -2.8D-14,  4.2D-17, -4.3D-01, r^2= 6.3D+00
+              MO Center= -7.3D-15, -7.1D-17, -4.3D-01, r^2= 6.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      6      1.773036  1 C  s                 42     -1.773036  6 C  s          
@@ -1200,7 +1199,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     43      0.227097  6 C  px                 2      0.138620  1 C  s          
  
  Vector   17  Occ=0.000000D+00  E= 1.995138D-01  Symmetry=b1
-              MO Center=  1.2D-13,  6.8D-17, -3.2D-01, r^2= 6.4D+00
+              MO Center=  1.4D-13, -5.2D-18, -3.2D-01, r^2= 6.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     19      1.311277  3 H  s                 55     -1.311277  8 H  s          
@@ -1210,7 +1209,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      5     -0.239504  1 C  pz                41      0.239504  6 C  pz         
  
  Vector   18  Occ=0.000000D+00  E= 2.028556D-01  Symmetry=a1
-              MO Center= -1.3D-13,  2.0D-16,  7.3D-01, r^2= 5.4D+00
+              MO Center= -1.3D-13, -4.3D-16,  7.3D-01, r^2= 5.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      2.099978  4 C  s                 36     -1.526444  5 H  s          
@@ -1220,7 +1219,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53     -0.696301  7 H  s                  6     -0.667051  1 C  s          
  
  Vector   19  Occ=0.000000D+00  E= 3.114851D-01  Symmetry=a1
-              MO Center=  7.9D-15,  3.5D-17, -2.3D-01, r^2= 4.9D+00
+              MO Center= -2.5D-15, -1.4D-16, -2.3D-01, r^2= 4.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      3.500319  4 C  s                 28     -2.411788  4 C  pz         
@@ -1230,7 +1229,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     55     -0.834764  8 H  s                 17      0.516670  2 H  s          
  
  Vector   20  Occ=0.000000D+00  E= 3.768865D-01  Symmetry=b1
-              MO Center= -4.8D-15,  9.6D-18, -1.2D-01, r^2= 4.4D+00
+              MO Center= -3.2D-15, -2.9D-31, -1.2D-01, r^2= 4.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      3.437614  4 C  px                 6     -2.016033  1 C  s          
@@ -1240,7 +1239,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53      1.059208  7 H  s                 22      0.341559  4 C  px         
  
  Vector   21  Occ=0.000000D+00  E= 5.028433D-01  Symmetry=b1
-              MO Center= -1.9D-15, -1.3D-16,  3.3D-01, r^2= 3.6D+00
+              MO Center=  1.9D-15,  1.4D-16,  3.3D-01, r^2= 3.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      1.021134  4 C  px                 7     -0.505202  1 C  px         
@@ -1250,7 +1249,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      5     -0.332847  1 C  pz                41      0.332847  6 C  pz         
  
  Vector   22  Occ=0.000000D+00  E= 5.202561D-01  Symmetry=a1
-              MO Center=  2.0D-15,  5.0D-17, -2.9D-01, r^2= 2.8D+00
+              MO Center= -7.1D-16, -1.1D-15, -2.9D-01, r^2= 2.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      7      0.555773  1 C  px                43     -0.555773  6 C  px         
@@ -1260,7 +1259,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      2      0.246382  1 C  s                 38      0.246382  6 C  s          
  
  Vector   23  Occ=0.000000D+00  E= 5.571645D-01  Symmetry=b2
-              MO Center=  5.5D-15,  4.7D-16,  4.1D-02, r^2= 2.7D+00
+              MO Center=  1.5D-17,  1.2D-15,  4.1D-02, r^2= 2.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      4      0.614597  1 C  py                40      0.614597  6 C  py         
@@ -1270,7 +1269,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     47      0.042663  6 C  dxy               14      0.028284  1 C  dyz        
  
  Vector   24  Occ=0.000000D+00  E= 6.241132D-01  Symmetry=a1
-              MO Center=  3.8D-15, -1.8D-16,  6.5D-01, r^2= 2.2D+00
+              MO Center=  4.1D-17,  2.9D-16,  6.5D-01, r^2= 2.2D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.099269  4 C  s                 35     -0.574098  5 H  s          
@@ -1280,7 +1279,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     42      0.375126  6 C  s                  5     -0.304644  1 C  pz         
  
  Vector   25  Occ=0.000000D+00  E= 6.352573D-01  Symmetry=a2
-              MO Center=  1.4D-14, -4.4D-16, -2.0D-01, r^2= 3.6D+00
+              MO Center=  8.4D-15, -1.9D-15, -2.0D-01, r^2= 3.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      8      0.851980  1 C  py                44     -0.851980  6 C  py         
@@ -1289,7 +1288,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     47      0.050706  6 C  dxy        
  
  Vector   26  Occ=0.000000D+00  E= 6.548109D-01  Symmetry=a1
-              MO Center=  2.5D-14, -1.4D-15, -4.2D-01, r^2= 3.5D+00
+              MO Center=  1.9D-16,  1.3D-16, -4.2D-01, r^2= 3.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.052954  4 C  s                  9     -0.661538  1 C  pz         
@@ -1299,7 +1298,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     16     -0.419259  2 H  s                 52     -0.419259  7 H  s          
  
  Vector   27  Occ=0.000000D+00  E= 6.662205D-01  Symmetry=b2
-              MO Center= -2.0D-14,  1.2D-15,  2.4D-01, r^2= 3.0D+00
+              MO Center= -8.3D-15,  1.7D-17,  2.4D-01, r^2= 3.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     27      1.506410  4 C  py                23     -0.881895  4 C  py         
@@ -1309,7 +1308,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     33      0.027194  4 C  dyz        
  
  Vector   28  Occ=0.000000D+00  E= 6.717053D-01  Symmetry=b1
-              MO Center= -2.2D-14,  6.8D-16, -1.7D-01, r^2= 3.6D+00
+              MO Center=  6.7D-18,  1.7D-15, -1.7D-01, r^2= 3.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      0.837672  4 C  px                22     -0.700328  4 C  px         
@@ -1319,7 +1318,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     18     -0.348244  3 H  s                 54      0.348244  8 H  s          
  
  Vector   29  Occ=0.000000D+00  E= 8.520725D-01  Symmetry=a1
-              MO Center= -3.7D-15, -4.9D-17, -4.2D-01, r^2= 4.0D+00
+              MO Center=  1.0D-15, -1.6D-17, -4.2D-01, r^2= 4.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     28      2.457751  4 C  pz                 9     -1.758125  1 C  pz         
@@ -1329,7 +1328,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      7     -1.077018  1 C  px                43      1.077018  6 C  px         
  
  Vector   30  Occ=0.000000D+00  E= 8.688124D-01  Symmetry=b1
-              MO Center=  4.3D-15, -8.1D-18, -1.6D-01, r^2= 4.8D+00
+              MO Center=  1.3D-15, -5.8D-18, -1.6D-01, r^2= 4.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      9      1.597590  1 C  pz                45     -1.597590  6 C  pz         
@@ -1339,7 +1338,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      5     -0.687320  1 C  pz                26     -0.684001  4 C  px         
  
  Vector   31  Occ=0.000000D+00  E= 8.814865D-01  Symmetry=a1
-              MO Center= -1.2D-15,  3.0D-17,  1.2D+00, r^2= 2.1D+00
+              MO Center= -2.6D-16,  5.4D-17,  1.2D+00, r^2= 2.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     36     -2.366623  5 H  s                 28      2.321887  4 C  pz         
@@ -1349,7 +1348,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      7     -0.391498  1 C  px                43      0.391498  6 C  px         
  
  Vector   32  Occ=0.000000D+00  E= 9.300733D-01  Symmetry=a1
-              MO Center=  5.2D-16, -2.1D-16, -1.7D-01, r^2= 4.9D+00
+              MO Center=  1.1D-13, -1.5D-17, -1.7D-01, r^2= 4.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.450458  4 C  s                 19     -1.125088  3 H  s          
@@ -1359,7 +1358,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     38     -0.691022  6 C  s                 17     -0.606399  2 H  s          
  
  Vector   33  Occ=0.000000D+00  E= 9.475574D-01  Symmetry=b1
-              MO Center= -3.5D-15, -5.0D-17, -3.9D-01, r^2= 4.1D+00
+              MO Center= -1.3D-13, -3.0D-18, -3.9D-01, r^2= 4.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      2.582639  4 C  px                 7      1.434236  1 C  px         
@@ -1369,7 +1368,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     42      1.047775  6 C  s                 19     -0.696168  3 H  s          
  
  Vector   34  Occ=0.000000D+00  E= 1.012077D+00  Symmetry=b1
-              MO Center=  6.2D-15, -6.9D-17, -1.7D-01, r^2= 3.7D+00
+              MO Center=  1.3D-13,  5.1D-17, -1.7D-01, r^2= 3.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      6      4.147133  1 C  s                 42     -4.147133  6 C  s          
@@ -1379,7 +1378,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53      0.655361  7 H  s                 19     -0.582730  3 H  s          
  
  Vector   35  Occ=0.000000D+00  E= 1.121951D+00  Symmetry=b1
-              MO Center= -8.1D-16,  1.4D-17, -3.3D-02, r^2= 3.7D+00
+              MO Center=  3.4D-13, -2.1D-17, -3.3D-02, r^2= 3.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     26      3.426464  4 C  px                 9     -2.401597  1 C  pz         
@@ -1389,7 +1388,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     53      0.668465  7 H  s                 18      0.566084  3 H  s          
  
  Vector   36  Occ=0.000000D+00  E= 1.142663D+00  Symmetry=a1
-              MO Center= -1.3D-14, -1.2D-17,  3.5D-01, r^2= 3.2D+00
+              MO Center= -4.8D-13,  3.2D-17,  3.5D-01, r^2= 3.2D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      5.900483  4 C  s                  6     -3.482659  1 C  s          
@@ -1399,7 +1398,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      7      0.666599  1 C  px                43     -0.666599  6 C  px         
  
  Vector   37  Occ=0.000000D+00  E= 1.325929D+00  Symmetry=a1
-              MO Center=  1.7D-15, -6.2D-18,  3.0D-02, r^2= 3.3D+00
+              MO Center=  1.8D-14,  3.0D-18,  3.0D-02, r^2= 3.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     28      4.804745  4 C  pz                25     -3.700914  4 C  s          
@@ -1409,7 +1408,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     45     -1.452669  6 C  pz                21      0.853267  4 C  s          
  
  Vector   38  Occ=0.000000D+00  E= 1.385096D+00  Symmetry=a2
-              MO Center= -3.8D-17,  3.9D-18,  7.9D-02, r^2= 1.5D+00
+              MO Center=  2.7D-17, -3.7D-18,  7.9D-02, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     30      1.015955  4 C  dxy               11     -0.593627  1 C  dxy        
@@ -1418,7 +1417,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     40      0.135300  6 C  py         
  
  Vector   39  Occ=0.000000D+00  E= 1.478302D+00  Symmetry=b2
-              MO Center=  1.2D-15,  5.3D-18,  1.7D-01, r^2= 1.4D+00
+              MO Center= -6.6D-18, -5.4D-19,  1.7D-01, r^2= 1.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     33      1.186783  4 C  dyz               11      0.716035  1 C  dxy        
@@ -1428,7 +1427,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     27     -0.051846  4 C  py         
  
  Vector   40  Occ=0.000000D+00  E= 1.707307D+00  Symmetry=a2
-              MO Center=  5.0D-15, -6.0D-17, -2.0D-01, r^2= 2.1D+00
+              MO Center=  7.1D-15,  2.5D-17, -2.0D-01, r^2= 2.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     14      0.972016  1 C  dyz               50     -0.972016  6 C  dyz        
@@ -1437,7 +1436,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      4      0.032172  1 C  py                40     -0.032172  6 C  py         
  
  Vector   41  Occ=0.000000D+00  E= 1.748061D+00  Symmetry=b2
-              MO Center= -6.5D-15,  5.2D-17, -1.4D-01, r^2= 2.1D+00
+              MO Center= -6.7D-15, -2.1D-18, -1.4D-01, r^2= 2.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     14      1.194517  1 C  dyz               50      1.194517  6 C  dyz        
@@ -1447,7 +1446,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     40     -0.048399  6 C  py         
  
  Vector   42  Occ=0.000000D+00  E= 1.878364D+00  Symmetry=a1
-              MO Center=  1.7D-15,  7.6D-17,  1.4D-01, r^2= 1.9D+00
+              MO Center= -5.4D-16, -2.2D-17,  1.4D-01, r^2= 1.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.584048  4 C  s                 32     -0.652518  4 C  dyy        
@@ -1457,7 +1456,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     21     -0.455578  4 C  s                 35     -0.428338  5 H  s          
  
  Vector   43  Occ=0.000000D+00  E= 1.918223D+00  Symmetry=b1
-              MO Center= -9.7D-16,  3.3D-18,  2.7D-03, r^2= 1.9D+00
+              MO Center=  3.6D-15,  9.0D-18,  2.7D-03, r^2= 1.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     31      1.116981  4 C  dxz               26     -0.531814  4 C  px         
@@ -1467,7 +1466,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      3     -0.270794  1 C  px                39     -0.270794  6 C  px         
  
  Vector   44  Occ=0.000000D+00  E= 1.954984D+00  Symmetry=a1
-              MO Center=  1.1D-15, -9.5D-18,  1.5D-01, r^2= 1.9D+00
+              MO Center= -2.9D-15,  2.7D-18,  1.5D-01, r^2= 1.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     28      1.205644  4 C  pz                25     -0.818059  4 C  s          
@@ -1477,7 +1476,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      6      0.374202  1 C  s                 42      0.374202  6 C  s          
  
  Vector   45  Occ=0.000000D+00  E= 2.140517D+00  Symmetry=b1
-              MO Center=  1.3D-15,  3.4D-17, -1.4D-01, r^2= 2.6D+00
+              MO Center=  5.0D-16,  3.1D-17, -1.4D-01, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      6      1.269775  1 C  s                 42     -1.269775  6 C  s          
@@ -1487,7 +1486,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     54      0.557648  8 H  s                 15      0.329000  1 C  dzz        
  
  Vector   46  Occ=0.000000D+00  E= 2.208672D+00  Symmetry=b2
-              MO Center= -1.8D-16, -9.9D-18,  3.6D-02, r^2= 1.8D+00
+              MO Center=  3.8D-16, -1.2D-16,  3.6D-02, r^2= 1.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     33      1.288523  4 C  dyz               11     -1.091455  1 C  dxy        
@@ -1497,7 +1496,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     23     -0.100501  4 C  py                 4      0.025523  1 C  py         
  
  Vector   47  Occ=0.000000D+00  E= 2.221835D+00  Symmetry=a1
-              MO Center= -2.0D-15,  1.3D-17, -1.6D-01, r^2= 2.2D+00
+              MO Center=  2.2D-15, -1.7D-18, -1.6D-01, r^2= 2.2D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     12      0.663944  1 C  dxz               48     -0.663944  6 C  dxz        
@@ -1507,7 +1506,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     32      0.414591  4 C  dyy                6      0.389316  1 C  s          
  
  Vector   48  Occ=0.000000D+00  E= 2.332996D+00  Symmetry=b1
-              MO Center= -5.7D-15, -3.4D-17, -2.0D-01, r^2= 2.4D+00
+              MO Center= -9.4D-17,  7.6D-17, -2.0D-01, r^2= 2.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     12      1.123845  1 C  dxz               48      1.123845  6 C  dxz        
@@ -1517,7 +1516,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     49     -0.457673  6 C  dyy               16      0.433024  2 H  s          
  
  Vector   49  Occ=0.000000D+00  E= 2.459175D+00  Symmetry=a2
-              MO Center=  6.4D-16,  2.1D-17,  1.5D-01, r^2= 1.6D+00
+              MO Center= -1.2D-15, -3.2D-17,  1.5D-01, r^2= 1.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     30      1.629339  4 C  dxy               11      0.878132  1 C  dxy        
@@ -1527,7 +1526,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     40      0.086018  6 C  py         
  
  Vector   50  Occ=0.000000D+00  E= 2.544212D+00  Symmetry=a1
-              MO Center= -1.7D-15,  1.7D-17,  7.4D-02, r^2= 2.0D+00
+              MO Center= -8.1D-16, -3.0D-17,  7.4D-02, r^2= 2.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      3.129233  4 C  s                  6     -1.842098  1 C  s          
@@ -1537,7 +1536,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     46     -0.679052  6 C  dxx               13      0.546774  1 C  dyy        
  
  Vector   51  Occ=0.000000D+00  E= 2.781456D+00  Symmetry=b1
-              MO Center=  3.1D-15, -9.2D-19,  1.4D-01, r^2= 1.8D+00
+              MO Center= -4.7D-15, -4.8D-19,  1.4D-01, r^2= 1.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     31     -1.986705  4 C  dxz               26      1.837413  4 C  px         
@@ -1547,7 +1546,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     22      0.591318  4 C  px                 7      0.585709  1 C  px         
  
  Vector   52  Occ=0.000000D+00  E= 2.907000D+00  Symmetry=a1
-              MO Center=  3.5D-15,  2.5D-18,  1.4D-01, r^2= 1.8D+00
+              MO Center= -2.4D-16,  1.2D-17,  1.4D-01, r^2= 1.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     25      1.747237  4 C  s                 12      1.134931  1 C  dxz        
@@ -1557,7 +1556,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      7      0.527041  1 C  px                43     -0.527041  6 C  px         
  
  Vector   53  Occ=0.000000D+00  E= 4.080901D+00  Symmetry=a1
-              MO Center= -1.3D-13, -3.4D-19,  6.6D-02, r^2= 1.6D+00
+              MO Center=  9.1D-16, -1.7D-18,  6.6D-02, r^2= 1.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      1.964956  4 C  s                  2      1.726785  1 C  s          
@@ -1567,7 +1566,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     13     -0.976638  1 C  dyy               49     -0.976638  6 C  dyy        
  
  Vector   54  Occ=0.000000D+00  E= 4.156034D+00  Symmetry=b1
-              MO Center=  1.6D-13, -2.0D-17, -2.1D-01, r^2= 2.3D+00
+              MO Center= -3.6D-14, -8.2D-19, -2.1D-01, r^2= 2.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      2      2.112558  1 C  s                 38     -2.112558  6 C  s          
@@ -1577,7 +1576,7 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     49      1.301436  6 C  dyy               51      1.305459  6 C  dzz        
  
  Vector   55  Occ=0.000000D+00  E= 4.383931D+00  Symmetry=a1
-              MO Center= -2.4D-14,  1.3D-18,  1.9D-01, r^2= 1.7D+00
+              MO Center=  3.9D-14,  1.2D-18,  1.9D-01, r^2= 1.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      2.212183  4 C  s                 25      2.210254  4 C  s          
@@ -1643,19 +1642,19 @@ File balance: exchanges=     0  moved=     0  time=   0.0
      -   - - -        -----         -----         ----         -------
      0   0 0 0     -0.000000    -12.000000    -11.000000     23.000000
  
-     1   1 0 0      0.000000      0.000000      0.000000     -0.000000
+     1   1 0 0      0.000000     -0.000000      0.000000     -0.000000
      1   0 1 0      0.000000      0.000000      0.000000      0.000000
      1   0 0 1      0.029417      0.297778     -0.268360     -0.000000
  
      2   2 0 0    -13.057064    -65.484941    -58.407650    110.835527
      2   1 1 0      0.000000      0.000000      0.000000      0.000000
-     2   1 0 1     -0.000000     -0.000000     -0.000000     -0.000000
+     2   1 0 1     -0.000000     -0.000000      0.000000     -0.000000
      2   0 2 0    -16.001954     -9.089789     -6.912165      0.000000
      2   0 1 1      0.000000      0.000000      0.000000      0.000000
      2   0 0 2    -12.950424    -20.189863    -19.682288     26.921727
  
 
- Parallel integral file used      10 records with       0 large values
+ Parallel integral file used       9 records with       0 large values
 
 
 
@@ -1733,14 +1732,14 @@ File balance: exchanges=     0  moved=     0  time=   0.0
 
            iter   Max. delocal   Mean delocal    Converge
            ----   ------------   ------------    --------
-              1   6.2221048125   3.9203211801    0.00D+00
-              2   2.4899784549   1.8059074592    7.85D-01
-              3   2.0299572022   1.6763621491    3.03D-01
-              4   2.0299157899   1.6758137657    1.97D-02
-              5   2.0299156039   1.6758142444    6.02D-04
-              6   2.0299156263   1.6758142474    6.84D-06
-              7   2.0299156264   1.6758142474    6.10D-08
-              8   2.0299156264   1.6758142474    5.27D-09
+              1   6.2221048180   3.9203211597    0.00D+00
+              2   2.5158058741   1.8009209511    7.85D-01
+              3   2.0298484265   1.6763692530    3.01D-01
+              4   2.0299137638   1.6758126183    3.28D-02
+              5   2.0299156297   1.6758142466    7.96D-04
+              6   2.0299156265   1.6758142475    8.28D-06
+              7   2.0299156263   1.6758142474    6.32D-08
+              8   2.0299156263   1.6758142474    0.00D+00
 
  IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
  should be zero, for IBOs in the IAO basis
@@ -1750,15 +1749,15 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     1     -10.167032 1.000      1( 1.00)
     2     -10.167032 1.000      6( 1.00)
     3     -10.166338 1.000      4( 1.00)
-    4      -0.604638 1.000      6( 0.51)     4( 0.49)
-    5      -0.604638 1.000      1( 0.51)     4( 0.49)
-    6      -0.508921 1.000      1( 0.54)     3( 0.46)
-    7      -0.508921 1.000      6( 0.54)     8( 0.46)
-    8      -0.506698 1.000      6( 0.54)     7( 0.46)
-    9      -0.506698 1.000      1( 0.54)     2( 0.46)
+    4      -0.604638 1.000      1( 0.51)     4( 0.49)
+    5      -0.604638 1.000      6( 0.51)     4( 0.49)
+    6      -0.508921 1.000      6( 0.54)     8( 0.46)
+    7      -0.508921 1.000      1( 0.54)     3( 0.46)
+    8      -0.506698 1.000      1( 0.54)     2( 0.46)
+    9      -0.506698 1.000      6( 0.54)     7( 0.46)
    10      -0.496862 1.000      4( 0.52)     5( 0.48)
-   11      -0.254260 1.000      1( 0.78)     4( 0.20)     6( 0.01)
-   12      -0.254260 1.000      6( 0.78)     4( 0.20)     1( 0.01)
+   11      -0.254260 1.000      6( 0.78)     4( 0.20)     1( 0.01)
+   12      -0.254260 1.000      1( 0.78)     4( 0.20)     6( 0.01)
  
 
  IBO localization (occ): IBOs will be stored
@@ -1777,15 +1776,14 @@ File balance: exchanges=     0  moved=     0  time=   0.0
 
            iter   Max. delocal   Mean delocal    Converge
            ----   ------------   ------------    --------
-              1   5.8115812430   4.1708553446    0.00D+00
-              2   3.1080537183   2.4265901890    7.10D-01
-              3   2.2994264172   2.0571669611    5.23D-01
-              4   2.2982620673   2.0448242984    1.07D-01
-              5   2.2982608429   2.0448237952    1.67D-03
-              6   2.2982608423   2.0448237677    5.11D-05
-              7   2.2982608423   2.0448237679    2.11D-06
-              8   2.2982608423   2.0448237679    2.71D-08
-              9   2.2982608423   2.0448237679    0.00D+00
+              1   4.7031131004   3.3016795118    0.00D+00
+              2   2.3150314351   2.0735786161    6.78D-01
+              3   2.2982830800   2.0448341721    1.35D-01
+              4   2.2982608689   2.0448239504    5.31D-03
+              5   2.2982608435   2.0448237682    8.38D-05
+              6   2.2982608435   2.0448237682    5.35D-06
+              7   2.2982608435   2.0448237681    1.44D-08
+              8   2.2982608435   2.0448237680    3.73D-09
 
  IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
  should be zero, for IBOs in the IAO basis
@@ -1793,8 +1791,8 @@ File balance: exchanges=     0  moved=     0  time=   0.0
  IAO-IBO localized orbitals
 
     1       0.106693 0.000      4( 0.59)     1( 0.20)     6( 0.20)
-    2       0.440568 0.000      2( 0.53)     1( 0.46)
-    3       0.440568 0.000      7( 0.53)     6( 0.46)
+    2       0.440568 0.000      7( 0.53)     6( 0.46)
+    3       0.440568 0.000      2( 0.53)     1( 0.46)
     4       0.441301 0.000      8( 0.54)     6( 0.46)
     5       0.441301 0.000      3( 0.54)     1( 0.46)
     6       0.451580 0.000      5( 0.52)     4( 0.48)
@@ -1823,14 +1821,14 @@ File balance: exchanges=     0  moved=     0  time=   0.0
 
            iter   Max. delocal   Mean delocal    Converge
            ----   ------------   ------------    --------
-              1   6.4228858636   4.0514866117    0.00D+00
-              2   2.5165640875   1.9026102649    7.85D-01
-              3   2.3650454245   1.7690977529    2.91D-01
-              4   2.3650454245   1.7685445681    3.00D-02
-              5   2.3650454245   1.7685448902    8.83D-04
-              6   2.3650454245   1.7685448943    8.00D-06
-              7   2.3650454245   1.7685448943    4.83D-08
-              8   2.3650454245   1.7685448943    3.73D-09
+              1   6.4228858707   4.0514866125    0.00D+00
+              2   2.4932638396   1.9087989589    7.85D-01
+              3   2.3650454255   1.7690811136    3.00D-01
+              4   2.3650454255   1.7685447145    1.97D-02
+              5   2.3650454255   1.7685448937    4.84D-04
+              6   2.3650454255   1.7685448944    4.65D-06
+              7   2.3650454255   1.7685448944    3.73D-08
+              8   2.3650454255   1.7685448944    3.73D-09
 
  IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
  should be zero, for IBOs in the IAO basis
@@ -1845,9 +1843,9 @@ File balance: exchanges=     0  moved=     0  time=   0.0
     6      -0.500868 1.000      4( 0.52)     5( 0.47)
     7      -0.495381 1.000      1( 0.52)     3( 0.48)
     8      -0.495381 1.000      6( 0.52)     8( 0.48)
-    9      -0.493757 1.000      6( 0.52)     7( 0.48)
-   10      -0.493757 1.000      1( 0.52)     2( 0.48)
-   11      -0.283542 1.000      4( 0.58)     1( 0.21)     6( 0.21)
+    9      -0.493757 1.000      1( 0.52)     2( 0.48)
+   10      -0.493757 1.000      6( 0.52)     7( 0.48)
+   11      -0.283542 1.000      4( 0.58)     6( 0.21)     1( 0.21)
  
 
  IBO localization (occ): IBOs will be stored
@@ -1866,31 +1864,31 @@ File balance: exchanges=     0  moved=     0  time=   0.0
 
            iter   Max. delocal   Mean delocal    Converge
            ----   ------------   ------------    --------
-              1   4.7244222478   3.8860164103    0.00D+00
-              2   2.7123995102   2.3187188707    7.57D-01
-              3   2.0288413207   1.9156381084    7.36D-01
-              4   2.0200410553   1.9103293579    6.91D-02
-              5   2.0200397235   1.9103200006    3.24D-03
-              6   2.0200397660   1.9103199885    1.85D-04
-              7   2.0200397661   1.9103199884    1.11D-05
-              8   2.0200397661   1.9103199884    6.74D-07
-              9   2.0200397661   1.9103199884    4.38D-08
-             10   2.0200397661   1.9103199884    3.73D-09
+              1   6.1106104110   4.2529669264    0.00D+00
+              2   3.1146608386   2.2563977151    7.53D-01
+              3   2.0217711710   1.9109971975    6.32D-01
+              4   2.0200416670   1.9103211873    2.09D-02
+              5   2.0200397583   1.9103199895    8.22D-04
+              6   2.0200397661   1.9103199885    4.26D-05
+              7   2.0200397661   1.9103199885    2.90D-06
+              8   2.0200397661   1.9103199885    2.06D-07
+              9   2.0200397661   1.9103199885    1.44D-08
+             10   2.0200397661   1.9103199885    0.00D+00
 
  IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
  should be zero, for IBOs in the IAO basis
 
  IAO-IBO localized orbitals
 
-    1       0.059594 0.000      6( 0.77)     4( 0.21)     1( 0.01)
-    2       0.059594 0.000      1( 0.77)     4( 0.21)     6( 0.01)
+    1       0.059594 0.000      1( 0.77)     4( 0.21)     6( 0.01)
+    2       0.059594 0.000      6( 0.77)     4( 0.21)     1( 0.01)
     3       0.446191 0.000      5( 0.52)     4( 0.47)
     4       0.452446 0.000      7( 0.52)     6( 0.48)
     5       0.452446 0.000      2( 0.52)     1( 0.48)
-    6       0.453454 0.000      8( 0.52)     6( 0.48)
-    7       0.453454 0.000      3( 0.52)     1( 0.48)
-    8       0.560559 0.000      6( 0.51)     4( 0.49)
-    9       0.560559 0.000      1( 0.51)     4( 0.49)
+    6       0.453454 0.000      3( 0.52)     1( 0.48)
+    7       0.453454 0.000      8( 0.52)     6( 0.48)
+    8       0.560559 0.000      1( 0.51)     4( 0.49)
+    9       0.560559 0.000      6( 0.51)     4( 0.49)
  
 
  IBO localization (vir): IBOs will be stored
@@ -1902,7 +1900,30 @@ File balance: exchanges=     0  moved=     0  time=   0.0
 
  Exiting Localization driver routine
 
- Task  times  cpu:        0.6s     wall:        0.6s
+          -------------
+          Dipole Moment
+          -------------
+
+ Center of charge (in au) is the expansion point
+         X =      -0.0000000 Y =       0.0000000 Z =      -0.0000000
+
+   Dipole moment        0.0294172911 A.U.
+             DMX        0.0000000000 DMXEFC        0.0000000000
+             DMY        0.0000000000 DMYEFC        0.0000000000
+             DMZ        0.0294172911 DMZEFC        0.0000000000
+   -EFC- dipole         0.0000000000 A.U.
+   Total dipole         0.0294172911 A.U.
+
+   Dipole moment        0.0747718610 Debye(s)
+             DMX        0.0000000000 DMXEFC        0.0000000000
+             DMY        0.0000000000 DMYEFC        0.0000000000
+             DMZ        0.0747718610 DMZEFC        0.0000000000
+   -EFC- dipole         0.0000000000 DEBYE(S)
+   Total dipole         0.0747718610 DEBYE(S)
+
+ 1 a.u. = 2.541766 Debyes 
+
+ Task  times  cpu:        0.7s     wall:        0.7s
  
  
                                 NWChem Input Module
@@ -1924,9 +1945,9 @@ MA usage statistics:
 	current number of blocks	         0	         0
 	maximum number of blocks	        23	        57
 	current total bytes		         0	         0
-	maximum total bytes		   4124576	  22514760
-	maximum total K-bytes		      4125	     22515
-	maximum total M-bytes		         5	        23
+	maximum total bytes		   6057992	  22514728
+	maximum total K-bytes		      6058	     22515
+	maximum total M-bytes		         7	        23
  
  
                                      CITATION
@@ -1982,4 +2003,4 @@ MA usage statistics:
    K. Glaesemann, G. Sandrone, M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe,
                                A. T. Wong, Z. Zhang.
 
- Total times  cpu:        0.6s     wall:        0.6s
+ Total times  cpu:        1.0s     wall:        1.0s

--- a/QA/tests/localize-pm-allyl/localize-pm-allyl.nw
+++ b/QA/tests/localize-pm-allyl/localize-pm-allyl.nw
@@ -1,0 +1,29 @@
+start testjob
+
+title "allylic_radical IBO localization"
+
+geometry units angstrom
+C         -0.25784636     1.21851111     0.00000000
+H         -1.34417006     1.24248062     0.00000000
+H          0.25678777     2.17304362     0.00000000
+C          0.43614025     0.01428420     0.00000000
+H          1.52527261     0.06222464     0.00000000
+C         -0.14953749    -1.24624893     0.00000000
+H         -1.22943924    -1.36577805     0.00000000
+H          0.44767502    -2.15141880     0.00000000
+end
+
+basis "ao basis"
+  * library 6-31G
+end
+
+dft
+  xc b3lyp
+  mult 2
+end
+
+property
+localization pm 2
+end
+
+task dft property

--- a/QA/tests/localize-pm-allyl/localize-pm-allyl.out
+++ b/QA/tests/localize-pm-allyl/localize-pm-allyl.out
@@ -1,0 +1,1531 @@
+running on 6 processors
+ argument  1 = allyl_radical.nw
+                                         
+                                         
+ 
+ 
+             Northwest Computational Chemistry Package (NWChem) 7.2.1
+             --------------------------------------------------------
+ 
+ 
+                    Environmental Molecular Sciences Laboratory
+                       Pacific Northwest National Laboratory
+                                Richland, WA 99352
+ 
+                              Copyright (c) 1994-2022
+                       Pacific Northwest National Laboratory
+                            Battelle Memorial Institute
+ 
+             NWChem is an open-source computational chemistry package
+                        distributed under the terms of the
+                      Educational Community License (ECL) 2.0
+             A copy of the license is included with this distribution
+                              in the LICENSE.TXT file
+ 
+                                  ACKNOWLEDGMENT
+                                  --------------
+
+            This software and its documentation were developed at the
+            EMSL at Pacific Northwest National Laboratory, a multiprogram
+            national laboratory, operated for the U.S. Department of Energy
+            by Battelle under Contract Number DE-AC05-76RL01830. Support
+            for this work was provided by the Department of Energy Office
+            of Biological and Environmental Research, Office of Basic
+            Energy Sciences, and the Office of Advanced Scientific Computing.
+
+
+           Job information
+           ---------------
+
+    hostname        = ja04
+    program         = /home/workspace/jochena/nwchem/loc-unr-pr/bin/LINUX64/nwchem
+    date            = Thu Dec 28 09:45:11 2023
+
+    compiled        = Wed_Dec_27_15:35:48_2023
+    source          = /home/workspace/jochena/nwchem/loc-unr-pr
+    nwchem branch   = 7.2.1
+    nwchem revision = nwchem_on_git-5262-g4cee1d3a03
+    ga revision     = 5.8.0
+    use scalapack   = F
+    input           = allyl_radical.nw
+    prefix          = testjob.
+    data base       = ./testjob.db
+    status          = startup
+    nproc           =        5
+    time left       =     -1s
+
+
+
+           Memory information
+           ------------------
+
+    heap     =     26214400 doubles =      200.0 Mbytes
+    stack    =     26214397 doubles =      200.0 Mbytes
+    global   =     52428800 doubles =      400.0 Mbytes (distinct from heap & stack)
+    total    =    104857597 doubles =      800.0 Mbytes
+    verify   = yes
+    hardfail = no 
+
+
+           Directory information
+           ---------------------
+ 
+  0 permanent = .
+  0 scratch   = /tmp
+ 
+ 
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+                         allylic_radical IBO localization
+                         --------------------------------
+
+ Scaling coordinates for geometry "geometry" by  1.889725989
+ (inverse scale =  0.529177249)
+
+ C2V symmetry detected
+
+          ------
+          auto-z
+          ------
+  no constraints, skipping   0.000000000000000E+000
+  no constraints, skipping   0.000000000000000E+000
+ 
+ 
+                             Geometry "geometry" -> ""
+                             -------------------------
+ 
+ Output coordinates in angstroms (scale by  1.889725989 to convert to a.u.)
+ 
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 C                    6.0000     1.23356930     0.00000000    -0.19643284
+    2 H                    1.0000     1.30539041     0.00000000    -1.28059891
+    3 H                    1.0000     2.16433665     0.00000000     0.36003805
+    4 C                    6.0000     0.00000000     0.00000000     0.44401841
+    5 H                    1.0000     0.00000000     0.00000000     1.53420536
+    6 C                    6.0000    -1.23356930     0.00000000    -0.19643284
+    7 H                    1.0000    -1.30539041     0.00000000    -1.28059891
+    8 H                    1.0000    -2.16433665     0.00000000     0.36003805
+ 
+      Atomic Mass 
+      ----------- 
+ 
+      C                 12.000000
+      H                  1.007825
+ 
+
+ Effective nuclear repulsion energy (a.u.)      64.6894447651
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+    -0.0000000000     0.0000000000    -0.0000000000
+ 
+      Symmetry information
+      --------------------
+ 
+ Group name             C2v       
+ Group number             16
+ Group order               4
+ No. of unique centers     5
+ 
+      Symmetry unique atoms
+ 
+     1    2    3    4    5
+ 
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+ 
+      Type          Name      I     J     K     L     M      Value
+      ----------- --------  ----- ----- ----- ----- ----- ----------
+    1 Stretch                  1     2                       1.08654
+    2 Stretch                  1     3                       1.08443
+    3 Stretch                  1     4                       1.38992
+    4 Stretch                  4     5                       1.09019
+    5 Stretch                  4     6                       1.38992
+    6 Stretch                  6     7                       1.08654
+    7 Stretch                  6     8                       1.08443
+    8 Bend                     1     4     5               117.43768
+    9 Bend                     1     4     6               125.12463
+   10 Bend                     2     1     3               117.08357
+   11 Bend                     2     1     4               121.22773
+   12 Bend                     3     1     4               121.68870
+   13 Bend                     4     6     7               121.22773
+   14 Bend                     4     6     8               121.68870
+   15 Bend                     5     4     6               117.43768
+   16 Bend                     7     6     8               117.08357
+   17 Torsion                  1     4     6     7           0.00000
+   18 Torsion                  1     4     6     8         180.00000
+   19 Torsion                  2     1     4     5         180.00000
+   20 Torsion                  2     1     4     6           0.00000
+   21 Torsion                  3     1     4     5           0.00000
+   22 Torsion                  3     1     4     6         180.00000
+   23 Torsion                  5     4     6     7         180.00000
+   24 Torsion                  5     4     6     8           0.00000
+ 
+ 
+            XYZ format geometry
+            -------------------
+     8
+ geometry
+ C                     1.23356930     0.00000000    -0.19643284
+ H                     1.30539041     0.00000000    -1.28059891
+ H                     2.16433665     0.00000000     0.36003805
+ C                     0.00000000     0.00000000     0.44401841
+ H                     0.00000000     0.00000000     1.53420536
+ C                    -1.23356930     0.00000000    -0.19643284
+ H                    -1.30539041     0.00000000    -1.28059891
+ H                    -2.16433665     0.00000000     0.36003805
+ 
+ ==============================================================================
+                                internuclear distances
+ ------------------------------------------------------------------------------
+       center one      |      center two      | atomic units |  angstroms
+ ------------------------------------------------------------------------------
+    2 H                |   1 C                |     2.05327  |     1.08654
+    3 H                |   1 C                |     2.04927  |     1.08443
+    4 C                |   1 C                |     2.62656  |     1.38992
+    5 H                |   4 C                |     2.06015  |     1.09019
+    6 C                |   4 C                |     2.62656  |     1.38992
+    7 H                |   6 C                |     2.05327  |     1.08654
+    8 H                |   6 C                |     2.04927  |     1.08443
+ ------------------------------------------------------------------------------
+                         number of included internuclear distances:          7
+ ==============================================================================
+
+
+
+ ==============================================================================
+                                 internuclear angles
+ ------------------------------------------------------------------------------
+        center 1       |       center 2       |       center 3       |  degrees
+ ------------------------------------------------------------------------------
+    2 H                |   1 C                |   3 H                |   117.08
+    2 H                |   1 C                |   4 C                |   121.23
+    3 H                |   1 C                |   4 C                |   121.69
+    1 C                |   4 C                |   5 H                |   117.44
+    1 C                |   4 C                |   6 C                |   125.12
+    5 H                |   4 C                |   6 C                |   117.44
+    4 C                |   6 C                |   7 H                |   121.23
+    4 C                |   6 C                |   8 H                |   121.69
+    7 H                |   6 C                |   8 H                |   117.08
+ ------------------------------------------------------------------------------
+                            number of included internuclear angles:          9
+ ==============================================================================
+
+
+
+  library name resolved from: environment
+  library file name is: <
+ /home/workspace/jochena/nwchem/loc-unr-pr/src/basis/libraries/>
+  
+
+
+ Summary of "ao basis" -> "" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ *                           6-31G                    on all atoms 
+
+
+                              NWChem Property Module
+                              ----------------------
+ 
+ 
+                         allylic_radical IBO localization
+ 
+ 
+                                 NWChem DFT Module
+                                 -----------------
+ 
+ 
+                         allylic_radical IBO localization
+ 
+ 
+                      Basis "ao basis" -> "ao basis" (cartesian)
+                      -----
+  C (Carbon)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  3.04752490E+03  0.001835
+  1 S  4.57369510E+02  0.014037
+  1 S  1.03948690E+02  0.068843
+  1 S  2.92101550E+01  0.232184
+  1 S  9.28666300E+00  0.467941
+  1 S  3.16392700E+00  0.362312
+ 
+  2 S  7.86827240E+00 -0.119332
+  2 S  1.88128850E+00 -0.160854
+  2 S  5.44249300E-01  1.143456
+ 
+  3 P  7.86827240E+00  0.068999
+  3 P  1.88128850E+00  0.316424
+  3 P  5.44249300E-01  0.744308
+ 
+  4 S  1.68714400E-01  1.000000
+ 
+  5 P  1.68714400E-01  1.000000
+ 
+  H (Hydrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  1.87311370E+01  0.033495
+  1 S  2.82539370E+00  0.234727
+  1 S  6.40121700E-01  0.813757
+ 
+  2 S  1.61277800E-01  1.000000
+ 
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           6-31G                   5        9   3s2p
+ H                           6-31G                   2        2   2s
+
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           6-31G                   5        9   3s2p
+ H                           6-31G                   2        2   2s
+
+
+      Symmetry analysis of basis
+      --------------------------
+ 
+        a1         18
+        a2          2
+        b1         13
+        b2          4
+ 
+  Caching 1-el integrals 
+ 
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  spin polarized.
+          No. of atoms     :     8
+          No. of electrons :    23
+           Alpha electrons :    12
+            Beta electrons :    11
+          Charge           :     0
+          Spin multiplicity:     2
+          Use of symmetry is: on ; symmetry adaption is: on 
+          Maximum number of iterations:  50
+          AO basis - number of functions:    37
+                     number of shells:    25
+          Convergence on energy requested:  1.00D-07
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  5.00D-04
+ 
+              XC Information
+              --------------
+                         B3LYP Method XC Potential
+                     Hartree-Fock (Exact) Exchange  0.200          
+                        Slater Exchange Functional  0.800 local    
+                    Becke 1988 Exchange Functional  0.720 non-local
+              Lee-Yang-Parr Correlation Functional  0.810          
+                  VWN I RPA Correlation Functional  0.190 local    
+ 
+             Grid Information
+             ----------------
+          Grid used for XC integration:  fine      
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          C                   0.70       70          10.0       590
+          H                   0.35       60          11.0       590
+          Grid pruning is: on 
+          Number of quadrature shells:   320
+          Spatial weights used:  Erf1
+ 
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters         50 iters            50 iters 
+
+ 
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-11
+          AO Gaussian exp screening on grid/accAOfunc:  16
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-08
+
+ 
+      Superposition of Atomic Density Guess
+      -------------------------------------
+ 
+ Sum of atomic energies:        -115.47192514
+ 
+      Non-variational initial energy
+      ------------------------------
+
+ Total energy =    -117.175105
+ 1-e energy   =    -281.394383
+ 2-e energy   =      99.529834
+ HOMO         =      -0.144674
+ LUMO         =       0.085646
+ 
+ 
+   Symmetry analysis of molecular orbitals - initial alpha
+   -------------------------------------------------------
+ 
+  Numbering of irreducible representations: 
+ 
+     1 a1          2 a2          3 b1          4 b2      
+ 
+  Orbital symmetries:
+ 
+     1 a1          2 b1          3 a1          4 a1          5 b1      
+     6 a1          7 a1          8 b1          9 b1         10 a1      
+    11 b2         12 a2         13 b2         14 a1         15 a1      
+    16 b1         17 a1         18 b1         19 a1         20 b1      
+    21 b1         22 a1      
+ 
+ 
+   Symmetry analysis of molecular orbitals - initial beta
+   ------------------------------------------------------
+ 
+  Numbering of irreducible representations: 
+ 
+     1 a1          2 a2          3 b1          4 b2      
+ 
+  Orbital symmetries:
+ 
+     1 a1          2 b1          3 a1          4 a1          5 b1      
+     6 a1          7 a1          8 b1          9 b1         10 a1      
+    11 b2         12 a2         13 b2         14 a1         15 a1      
+    16 b1         17 a1         18 b1         19 a1         20 b1      
+    21 b1         22 a1      
+ 
+   Time after variat. SCF:      0.1
+   Time prior to 1st pass:      0.1
+
+ #quartets = 2.710D+04 #integrals = 7.890D+04 #direct =  0.0% #cached =100.0%
+
+
+ Integral file          = /tmp/testjob.aoints.0
+ Record size in doubles =  65536        No. of integs per rec  =  43688
+ Max. records in memory =      3        Max. records in file   =  27633
+ No. of bits per label  =      8        No. of bits per value  =     64
+
+
+File balance: exchanges=     0  moved=     0  time=   0.0
+
+
+ Grid_pts file          = /tmp/testjob.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =     15        Max. recs in file   =    147327
+
+
+           Memory utilization after 1st SCF pass: 
+           Heap Space remaining (MW):       25.83            25830616
+          Stack Space remaining (MW):       26.21            26213804
+
+   convergence    iter        energy       DeltaE   RMS-Dens  Diis-err    time
+ ---------------- ----- ----------------- --------- --------- ---------  ------
+ d= 0,ls=0.0,diis     1   -117.2043520728 -1.82D+02  6.04D-03  5.34D-02     0.2
+                                                     6.35D-03  5.56D-02
+ d= 0,ls=0.0,diis     2   -117.2344640777 -3.01D-02  1.65D-03  1.92D-03     0.2
+                                                     1.73D-03  2.21D-03
+ d= 0,ls=0.0,diis     3   -117.2355170466 -1.05D-03  8.35D-04  1.28D-03     0.2
+                                                     8.19D-04  1.11D-03
+ d= 0,ls=0.0,diis     4   -117.2362786507 -7.62D-04  3.90D-04  7.14D-05     0.3
+                                                     2.22D-04  3.22D-05
+ d= 0,ls=0.0,diis     5   -117.2363574889 -7.88D-05  5.71D-05  7.64D-06     0.3
+                                                     1.82D-04  3.85D-05
+  Resetting Diis
+ d= 0,ls=0.0,diis     6   -117.2363785636 -2.11D-05  9.71D-05  5.68D-06     0.3
+                                                     6.74D-05  6.46D-07
+ d= 0,ls=0.0,diis     7   -117.2363826777 -4.11D-06  5.89D-06  1.48D-08     0.4
+                                                     5.29D-06  1.52D-08
+ d= 0,ls=0.0,diis     8   -117.2363826954 -1.77D-08  1.90D-06  2.21D-09     0.4
+                                                     2.26D-06  2.66D-09
+
+
+         Total DFT energy =     -117.236382695362
+      One electron energy =     -284.107509136771
+           Coulomb energy =      120.273802621779
+    Exchange-Corr. energy =      -18.092120945436
+ Nuclear repulsion energy =       64.689444765066
+
+ Numeric. integr. density =       23.000000851568
+
+     Total iterative time =      0.3s
+
+
+ 
+                  Occupations of the irreducible representations
+                  ----------------------------------------------
+ 
+                     irrep           alpha         beta
+                     --------     --------     --------
+                     a1                6.0          6.0
+                     a2                1.0          0.0
+                     b1                4.0          4.0
+                     b2                1.0          1.0
+ 
+ 
+                    DFT Final Alpha Molecular Orbital Analysis
+                    ------------------------------------------
+ 
+ Vector    1  Occ=1.000000D+00  E=-1.018863D+01  Symmetry=a1
+              MO Center= -1.3D-15,  1.3D-31,  4.4D-01, r^2= 5.1D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.989195  4 C  s                  1      0.077157  1 C  s          
+    25      0.077157  6 C  s                 15      0.035072  4 C  s          
+    19     -0.030869  4 C  s          
+ 
+ Vector    2  Occ=1.000000D+00  E=-1.018556D+01  Symmetry=b1
+              MO Center=  1.4D-10, -4.3D-18, -2.0D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.703625  1 C  s                 25     -0.703625  6 C  s          
+     2      0.025292  1 C  s                 26     -0.025292  6 C  s          
+ 
+ Vector    3  Occ=1.000000D+00  E=-1.018550D+01  Symmetry=a1
+              MO Center= -1.4D-10,  2.6D-28, -1.9D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.699332  1 C  s                 25      0.699332  6 C  s          
+    14     -0.109414  4 C  s          
+ 
+ Vector    4  Occ=1.000000D+00  E=-7.923042D-01  Symmetry=a1
+              MO Center=  2.0D-15,  1.1D-18,  8.7D-02, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.311971  4 C  s                  2      0.228055  1 C  s          
+    26      0.228055  6 C  s                  6      0.185524  1 C  s          
+    30      0.185524  6 C  s                 19      0.170879  4 C  s          
+    14     -0.157014  4 C  s                  1     -0.116502  1 C  s          
+    25     -0.116502  6 C  s                  3     -0.080682  1 C  px         
+ 
+ Vector    5  Occ=1.000000D+00  E=-6.811422D-01  Symmetry=b1
+              MO Center=  1.4D-18,  6.6D-17, -1.1D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.291768  1 C  s                 26     -0.291768  6 C  s          
+     6      0.264563  1 C  s                 30     -0.264563  6 C  s          
+    16      0.216367  4 C  px                 1     -0.146330  1 C  s          
+    25      0.146330  6 C  s                 12      0.111269  3 H  s          
+    36     -0.111269  8 H  s                 10      0.097830  2 H  s          
+ 
+ Vector    6  Occ=1.000000D+00  E=-5.566868D-01  Symmetry=a1
+              MO Center=  4.3D-16, -1.0D-17,  4.2D-02, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.242483  4 C  s                 19      0.232054  4 C  s          
+    23      0.180814  5 H  s                  6     -0.164349  1 C  s          
+    30     -0.164349  6 C  s                 18      0.152139  4 C  pz         
+     2     -0.149518  1 C  s                 26     -0.149518  6 C  s          
+     5      0.139435  1 C  pz                29      0.139435  6 C  pz         
+ 
+ Vector    7  Occ=1.000000D+00  E=-4.777968D-01  Symmetry=a1
+              MO Center= -3.7D-15,  7.8D-18,  1.8D-01, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    18      0.276864  4 C  pz                 3      0.259085  1 C  px         
+    27     -0.259085  6 C  px                12      0.174037  3 H  s          
+    36      0.174037  8 H  s                  5      0.133800  1 C  pz         
+    29      0.133800  6 C  pz                23      0.123991  5 H  s          
+    13      0.109836  3 H  s                 37      0.109836  8 H  s          
+ 
+ Vector    8  Occ=1.000000D+00  E=-4.357457D-01  Symmetry=b1
+              MO Center= -2.5D-15,  9.0D-18, -4.0D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.311509  4 C  px                 5      0.302460  1 C  pz         
+    29     -0.302460  6 C  pz                10     -0.187507  2 H  s          
+    34      0.187507  7 H  s                  3     -0.137896  1 C  px         
+    27     -0.137896  6 C  px                11     -0.131249  2 H  s          
+    35      0.131249  7 H  s                  9      0.119677  1 C  pz         
+ 
+ Vector    9  Occ=1.000000D+00  E=-3.847617D-01  Symmetry=b1
+              MO Center=  5.4D-16, -4.7D-34, -9.0D-03, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.320549  1 C  px                27      0.320549  6 C  px         
+    16     -0.249432  4 C  px                12      0.211176  3 H  s          
+    36     -0.211176  8 H  s                 13      0.196892  3 H  s          
+    37     -0.196892  8 H  s                  5      0.127600  1 C  pz         
+    29     -0.127600  6 C  pz                 7      0.120127  1 C  px         
+ 
+ Vector   10  Occ=1.000000D+00  E=-3.585917D-01  Symmetry=a1
+              MO Center=  2.6D-15, -1.2D-17,  1.3D-01, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    18      0.325266  4 C  pz                 5     -0.256707  1 C  pz         
+    29     -0.256707  6 C  pz                23      0.246429  5 H  s          
+    24      0.235425  5 H  s                 11      0.178591  2 H  s          
+    35      0.178591  7 H  s                 10      0.172540  2 H  s          
+    34      0.172540  7 H  s                 22      0.114703  4 C  pz         
+ 
+ Vector   11  Occ=1.000000D+00  E=-3.175397D-01  Symmetry=b2
+              MO Center=  7.3D-16,  3.3D-17,  5.7D-02, r^2= 1.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      0.354758  4 C  py                 4      0.316187  1 C  py         
+    28      0.316187  6 C  py                 8      0.213395  1 C  py         
+    32      0.213395  6 C  py                21      0.210351  4 C  py         
+ 
+ Vector   12  Occ=1.000000D+00  E=-1.933727D-01  Symmetry=a2
+              MO Center= -4.9D-16, -7.0D-17, -2.0D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.437338  1 C  py                28     -0.437338  6 C  py         
+     8      0.388253  1 C  py                32     -0.388253  6 C  py         
+ 
+ Vector   13  Occ=0.000000D+00  E= 4.873411D-02  Symmetry=b2
+              MO Center= -4.5D-17, -2.6D-17,  1.9D-01, r^2= 2.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.759037  4 C  py                17      0.499591  4 C  py         
+     8     -0.486650  1 C  py                32     -0.486650  6 C  py         
+     4     -0.285542  1 C  py                28     -0.285542  6 C  py         
+ 
+ Vector   14  Occ=0.000000D+00  E= 1.105924D-01  Symmetry=a1
+              MO Center=  1.6D-16,  4.9D-17,  6.1D-01, r^2= 5.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      1.061885  3 H  s                 37      1.061885  8 H  s          
+    24      1.031659  5 H  s                  6     -0.921185  1 C  s          
+    19     -0.919617  4 C  s                 30     -0.921185  6 C  s          
+     7     -0.496574  1 C  px                31      0.496574  6 C  px         
+    22     -0.457779  4 C  pz                11      0.382028  2 H  s          
+ 
+ Vector   15  Occ=0.000000D+00  E= 1.336269D-01  Symmetry=a1
+              MO Center=  2.4D-14,  1.5D-16, -6.8D-01, r^2= 4.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.242144  2 H  s                 35      1.242144  7 H  s          
+    24     -0.984890  5 H  s                  6     -0.832039  1 C  s          
+    30     -0.832039  6 C  s                  9      0.568865  1 C  pz         
+    33      0.568865  6 C  pz                19      0.544640  4 C  s          
+    22      0.319169  4 C  pz                 5      0.228905  1 C  pz         
+ 
+ Vector   16  Occ=0.000000D+00  E= 1.502236D-01  Symmetry=b1
+              MO Center= -2.6D-14, -2.3D-17, -4.4D-01, r^2= 6.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.778640  1 C  s                 30     -1.778640  6 C  s          
+    11     -1.000884  2 H  s                 35      1.000884  7 H  s          
+    13     -0.950460  3 H  s                 37      0.950460  8 H  s          
+    20     -0.655101  4 C  px                 7      0.192477  1 C  px         
+    31      0.192477  6 C  px                 3      0.134343  1 C  px         
+ 
+ Vector   17  Occ=0.000000D+00  E= 1.945381D-01  Symmetry=b1
+              MO Center= -6.0D-14, -2.0D-18, -3.2D-01, r^2= 6.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      1.314625  3 H  s                 37     -1.314625  8 H  s          
+    11     -1.048848  2 H  s                 35      1.048848  7 H  s          
+     9     -0.817431  1 C  pz                33      0.817431  6 C  pz         
+     7     -0.702856  1 C  px                31     -0.702856  6 C  px         
+     5     -0.240030  1 C  pz                29      0.240030  6 C  pz         
+ 
+ Vector   18  Occ=0.000000D+00  E= 1.994170D-01  Symmetry=a1
+              MO Center=  4.5D-14, -1.6D-16,  7.2D-01, r^2= 5.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      2.241820  4 C  s                 24     -1.522620  5 H  s          
+     9     -0.968039  1 C  pz                13      0.970370  3 H  s          
+    33     -0.968039  6 C  pz                37      0.970370  8 H  s          
+    11     -0.713075  2 H  s                 35     -0.713075  7 H  s          
+    22      0.701435  4 C  pz                 6     -0.677862  1 C  s          
+ 
+ Vector   19  Occ=0.000000D+00  E= 3.094262D-01  Symmetry=a1
+              MO Center= -2.0D-14, -3.8D-17, -1.9D-01, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      3.509969  4 C  s                 22     -2.455881  4 C  pz         
+     7      2.076582  1 C  px                31     -2.076582  6 C  px         
+     6     -1.889875  1 C  s                 30     -1.889875  6 C  s          
+    24      1.347214  5 H  s                 13     -0.886021  3 H  s          
+    37     -0.886021  8 H  s                 11      0.504653  2 H  s          
+ 
+ Vector   20  Occ=0.000000D+00  E= 3.735607D-01  Symmetry=b1
+              MO Center=  3.7D-14,  2.6D-17, -1.1D-01, r^2= 4.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      3.515496  4 C  px                 6     -2.062663  1 C  s          
+    30      2.062663  6 C  s                  9     -1.678155  1 C  pz         
+    33      1.678155  6 C  pz                 7      1.635139  1 C  px         
+    31      1.635139  6 C  px                11     -1.074280  2 H  s          
+    35      1.074280  7 H  s                 16      0.370034  4 C  px         
+ 
+ Vector   21  Occ=0.000000D+00  E= 5.184720D-01  Symmetry=b1
+              MO Center= -7.1D-16,  2.4D-32,  4.1D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      1.072150  4 C  px                16     -0.518091  4 C  px         
+     9      0.514299  1 C  pz                33     -0.514299  6 C  pz         
+     7     -0.484996  1 C  px                31     -0.484996  6 C  px         
+     6     -0.461500  1 C  s                 30      0.461500  6 C  s          
+     5     -0.368394  1 C  pz                29      0.368394  6 C  pz         
+ 
+ Vector   22  Occ=0.000000D+00  E= 5.272534D-01  Symmetry=b2
+              MO Center= -7.2D-16, -1.4D-21, -1.6D-01, r^2= 3.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.683870  1 C  py                 8     -0.685405  1 C  py         
+    28      0.683870  6 C  py                32     -0.685405  6 C  py         
+    17      0.406451  4 C  py                21     -0.138282  4 C  py         
+ 
+ Vector   23  Occ=0.000000D+00  E= 5.453064D-01  Symmetry=a1
+              MO Center=  2.6D-16,  5.0D-17, -3.8D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7     -0.588233  1 C  px                31      0.588233  6 C  px         
+     3      0.557448  1 C  px                27     -0.557448  6 C  px         
+    22     -0.386603  4 C  pz                 9     -0.306213  1 C  pz         
+    33     -0.306213  6 C  pz                12      0.295561  3 H  s          
+    36      0.295561  8 H  s                  2     -0.269548  1 C  s          
+ 
+ Vector   24  Occ=0.000000D+00  E= 5.941277D-01  Symmetry=a2
+              MO Center=  4.3D-15, -6.0D-16, -2.0D-01, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      0.869603  1 C  py                32     -0.869603  6 C  py         
+     4     -0.756232  1 C  py                28      0.756232  6 C  py         
+ 
+ Vector   25  Occ=0.000000D+00  E= 6.528246D-01  Symmetry=a1
+              MO Center=  5.7D-16,  6.3D-17,  5.6D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      0.810897  1 C  pz                33      0.810897  6 C  pz         
+    19      0.610975  4 C  s                 23     -0.590939  5 H  s          
+     5     -0.446797  1 C  pz                29     -0.446797  6 C  pz         
+     2     -0.414759  1 C  s                 26     -0.414759  6 C  s          
+     3      0.361939  1 C  px                27     -0.361939  6 C  px         
+ 
+ Vector   26  Occ=0.000000D+00  E= 6.631011D-01  Symmetry=b2
+              MO Center= -4.1D-15, -2.2D-22,  4.2D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      1.579206  4 C  py                17     -1.006958  4 C  py         
+     8     -0.742633  1 C  py                32     -0.742633  6 C  py         
+     4      0.311746  1 C  py                28      0.311746  6 C  py         
+ 
+ Vector   27  Occ=0.000000D+00  E= 6.728866D-01  Symmetry=a1
+              MO Center=  1.0D-14, -1.2D-16, -3.4D-01, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      1.256767  4 C  s                  6      0.900120  1 C  s          
+    30      0.900120  6 C  s                 15     -0.850745  4 C  s          
+     2     -0.554911  1 C  s                 26     -0.554911  6 C  s          
+     7      0.526938  1 C  px                31     -0.526938  6 C  px         
+    10     -0.415485  2 H  s                 12     -0.413490  3 H  s          
+ 
+ Vector   28  Occ=0.000000D+00  E= 6.940530D-01  Symmetry=b1
+              MO Center= -6.7D-15,  5.7D-16, -1.6D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.777706  4 C  px                 6     -0.696096  1 C  s          
+    30      0.696096  6 C  s                  7     -0.657885  1 C  px         
+    31     -0.657885  6 C  px                20     -0.646742  4 C  px         
+    10      0.393732  2 H  s                 34     -0.393732  7 H  s          
+    12      0.385313  3 H  s                 36     -0.385313  8 H  s          
+ 
+ Vector   29  Occ=0.000000D+00  E= 8.529369D-01  Symmetry=a1
+              MO Center= -5.0D-18, -2.2D-18, -1.1D-01, r^2= 4.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      3.040805  4 C  pz                24     -1.790923  5 H  s          
+     9     -1.604541  1 C  pz                33     -1.604541  6 C  pz         
+    11     -1.331213  2 H  s                 35     -1.331213  7 H  s          
+     6      1.288500  1 C  s                 30      1.288500  6 C  s          
+     7     -1.102555  1 C  px                31      1.102555  6 C  px         
+ 
+ Vector   30  Occ=0.000000D+00  E= 8.824746D-01  Symmetry=b1
+              MO Center=  3.5D-14,  1.1D-17, -1.2D-01, r^2= 5.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      1.892821  1 C  pz                33     -1.892821  6 C  pz         
+    13     -1.569877  3 H  s                 37      1.569877  8 H  s          
+    20     -1.522827  4 C  px                 6      1.251634  1 C  s          
+    30     -1.251634  6 C  s                 11      1.166054  2 H  s          
+    35     -1.166054  7 H  s                  7      0.794224  1 C  px         
+ 
+ Vector   31  Occ=0.000000D+00  E= 9.258873D-01  Symmetry=a1
+              MO Center= -3.3D-15,  2.0D-18,  6.7D-01, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24      1.903851  5 H  s                 22     -1.385920  4 C  pz         
+    19     -0.829461  4 C  s                 23     -0.826735  5 H  s          
+    11     -0.776601  2 H  s                 35     -0.776601  7 H  s          
+    18      0.729552  4 C  pz                15      0.599836  4 C  s          
+     9     -0.496541  1 C  pz                33     -0.496541  6 C  pz         
+ 
+ Vector   32  Occ=0.000000D+00  E= 9.484157D-01  Symmetry=a1
+              MO Center= -2.3D-14, -1.9D-17,  4.2D-02, r^2= 5.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.297346  1 C  s                 30      1.297346  6 C  s          
+    13     -1.215212  3 H  s                 37     -1.215212  8 H  s          
+    19      0.860352  4 C  s                  2     -0.825654  1 C  s          
+    26     -0.825654  6 C  s                  7      0.664925  1 C  px         
+    31     -0.664925  6 C  px                12      0.622769  3 H  s          
+ 
+ Vector   33  Occ=0.000000D+00  E= 9.803830D-01  Symmetry=b1
+              MO Center= -2.3D-15,  3.3D-18, -6.3D-01, r^2= 4.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      1.503241  4 C  px                11     -1.269582  2 H  s          
+    35      1.269582  7 H  s                  7      0.992531  1 C  px         
+    31      0.992531  6 C  px                13     -0.819100  3 H  s          
+    37      0.819100  8 H  s                  9     -0.786768  1 C  pz         
+    33      0.786768  6 C  pz                10      0.638921  2 H  s          
+ 
+ Vector   34  Occ=0.000000D+00  E= 1.025991D+00  Symmetry=b1
+              MO Center=  3.9D-14,  1.2D-17, -1.5D-01, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.901399  1 C  s                 30     -3.901399  6 C  s          
+    20     -2.724514  4 C  px                 2     -1.454449  1 C  s          
+    26      1.454449  6 C  s                  7     -1.260182  1 C  px         
+    31     -1.260182  6 C  px                16      0.517882  4 C  px         
+     9      0.507381  1 C  pz                33     -0.507381  6 C  pz         
+ 
+ Vector   35  Occ=0.000000D+00  E= 1.165403D+00  Symmetry=a1
+              MO Center= -9.0D-13,  2.0D-17,  4.4D-01, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      5.965253  4 C  s                  6     -3.337609  1 C  s          
+    30     -3.337609  6 C  s                 15     -1.723962  4 C  s          
+     2      1.004290  1 C  s                 26      1.004290  6 C  s          
+     9     -0.917896  1 C  pz                33     -0.917896  6 C  pz         
+     7      0.711459  1 C  px                31     -0.711459  6 C  px         
+ 
+ Vector   36  Occ=0.000000D+00  E= 1.170182D+00  Symmetry=b1
+              MO Center=  8.6D-13,  2.8D-19, -1.8D-02, r^2= 4.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      3.503238  4 C  px                 9     -2.313617  1 C  pz         
+    33      2.313617  6 C  pz                 6     -2.160866  1 C  s          
+    30      2.160866  6 C  s                 12      0.709991  3 H  s          
+    36     -0.709991  8 H  s                 13      0.626903  3 H  s          
+    37     -0.626903  8 H  s                 10     -0.554108  2 H  s          
+ 
+ Vector   37  Occ=0.000000D+00  E= 1.357576D+00  Symmetry=a1
+              MO Center= -5.3D-15,  2.4D-18,  1.0D-02, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      4.832214  4 C  pz                19     -3.641134  4 C  s          
+     6      3.023516  1 C  s                 30      3.023516  6 C  s          
+     7     -1.806589  1 C  px                31      1.806589  6 C  px         
+     9     -1.531209  1 C  pz                33     -1.531209  6 C  pz         
+    24     -1.440044  5 H  s                 15      0.983842  4 C  s          
+ 
+ 
+                     DFT Final Beta Molecular Orbital Analysis
+                     -----------------------------------------
+ 
+ Vector    1  Occ=1.000000D+00  E=-1.019220D+01  Symmetry=a1
+              MO Center=  1.3D-16,  1.9D-32,  4.4D-01, r^2= 2.9D-02
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.994927  4 C  s                 15      0.035889  4 C  s          
+    19     -0.032312  4 C  s          
+ 
+ Vector    2  Occ=1.000000D+00  E=-1.017635D+01  Symmetry=b1
+              MO Center= -5.0D-11,  3.6D-18, -2.0D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.703756  1 C  s                 25     -0.703756  6 C  s          
+ 
+ Vector    3  Occ=1.000000D+00  E=-1.017633D+01  Symmetry=a1
+              MO Center=  5.0D-11,  8.1D-29, -2.0D-01, r^2= 1.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.703543  1 C  s                 25      0.703543  6 C  s          
+ 
+ Vector    4  Occ=1.000000D+00  E=-7.813210D-01  Symmetry=a1
+              MO Center= -9.9D-16, -4.6D-18,  1.4D-01, r^2= 1.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.334798  4 C  s                 19      0.228980  4 C  s          
+     2      0.211041  1 C  s                 26      0.211041  6 C  s          
+    14     -0.167486  4 C  s                  6      0.140101  1 C  s          
+    30      0.140101  6 C  s                  1     -0.108452  1 C  s          
+    25     -0.108452  6 C  s                 23      0.086298  5 H  s          
+ 
+ Vector    5  Occ=1.000000D+00  E=-6.548964D-01  Symmetry=b1
+              MO Center=  7.0D-16,  2.5D-16, -9.3D-02, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.285049  1 C  s                 26     -0.285049  6 C  s          
+    16      0.232796  4 C  px                 6      0.213290  1 C  s          
+    30     -0.213290  6 C  s                  1     -0.142246  1 C  s          
+    25      0.142246  6 C  s                 12      0.120878  3 H  s          
+    36     -0.120878  8 H  s                 10      0.104118  2 H  s          
+ 
+ Vector    6  Occ=1.000000D+00  E=-5.495977D-01  Symmetry=a1
+              MO Center= -1.6D-15,  2.3D-17,  3.5D-03, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.224060  4 C  s                 19      0.208695  4 C  s          
+    23      0.180390  5 H  s                 18      0.172428  4 C  pz         
+     2     -0.157118  1 C  s                 26     -0.157118  6 C  s          
+     6     -0.145728  1 C  s                 10     -0.146430  2 H  s          
+    30     -0.145728  6 C  s                 34     -0.146430  7 H  s          
+ 
+ Vector    7  Occ=1.000000D+00  E=-4.726166D-01  Symmetry=a1
+              MO Center=  3.6D-15,  2.1D-17,  2.0D-01, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    18      0.281695  4 C  pz                 3      0.256916  1 C  px         
+    27     -0.256916  6 C  px                12      0.181808  3 H  s          
+    36      0.181808  8 H  s                 13      0.122329  3 H  s          
+    23      0.122663  5 H  s                 37      0.122329  8 H  s          
+     5      0.119903  1 C  pz                29      0.119903  6 C  pz         
+ 
+ Vector    8  Occ=1.000000D+00  E=-4.295553D-01  Symmetry=b1
+              MO Center= -3.3D-15, -3.5D-17, -4.1D-01, r^2= 2.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.320056  4 C  px                 5      0.293132  1 C  pz         
+    29     -0.293132  6 C  pz                10     -0.193215  2 H  s          
+    34      0.193215  7 H  s                 11     -0.142969  2 H  s          
+    35      0.142969  7 H  s                  3     -0.138391  1 C  px         
+    27     -0.138391  6 C  px                 9      0.109603  1 C  pz         
+ 
+ Vector    9  Occ=1.000000D+00  E=-3.786139D-01  Symmetry=b1
+              MO Center=  2.0D-15,  6.0D-18, -9.7D-03, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.310580  1 C  px                27      0.310580  6 C  px         
+    16     -0.254813  4 C  px                12      0.216488  3 H  s          
+    36     -0.216488  8 H  s                 13      0.211611  3 H  s          
+    37     -0.211611  8 H  s                  5      0.127912  1 C  pz         
+    29     -0.127912  6 C  pz                 7      0.108943  1 C  px         
+ 
+ Vector   10  Occ=1.000000D+00  E=-3.558635D-01  Symmetry=a1
+              MO Center= -2.7D-16, -2.3D-31,  8.7D-02, r^2= 2.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    18      0.323275  4 C  pz                 5     -0.253791  1 C  pz         
+    29     -0.253791  6 C  pz                23      0.239061  5 H  s          
+    24      0.229499  5 H  s                 11      0.189921  2 H  s          
+    35      0.189921  7 H  s                 10      0.178505  2 H  s          
+    34      0.178505  7 H  s                 22      0.111371  4 C  pz         
+ 
+ Vector   11  Occ=1.000000D+00  E=-2.866724D-01  Symmetry=b2
+              MO Center= -1.1D-15,  3.3D-16,  1.8D-01, r^2= 1.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      0.445361  4 C  py                21      0.304822  4 C  py         
+     4      0.240794  1 C  py                28      0.240794  6 C  py         
+     8      0.160156  1 C  py                32      0.160156  6 C  py         
+ 
+ Vector   12  Occ=0.000000D+00  E=-6.885084D-02  Symmetry=a2
+              MO Center=  2.1D-15, -4.4D-16, -2.0D-01, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8      0.432503  1 C  py                32     -0.432503  6 C  py         
+     4      0.397830  1 C  py                28     -0.397830  6 C  py         
+ 
+ Vector   13  Occ=0.000000D+00  E= 7.554204D-02  Symmetry=b2
+              MO Center= -1.4D-15, -4.5D-16,  5.0D-02, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.710597  4 C  py                 8     -0.555117  1 C  py         
+    32     -0.555117  6 C  py                17      0.451117  4 C  py         
+     4     -0.295128  1 C  py                28     -0.295128  6 C  py         
+ 
+ Vector   14  Occ=0.000000D+00  E= 1.140442D-01  Symmetry=a1
+              MO Center=  1.2D-14,  5.5D-17,  8.5D-01, r^2= 5.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24     -1.223162  5 H  s                 19      1.120662  4 C  s          
+    13     -1.011807  3 H  s                 37     -1.011807  8 H  s          
+     6      0.739425  1 C  s                 30      0.739425  6 C  s          
+    22      0.503319  4 C  pz                 7      0.500618  1 C  px         
+    31     -0.500618  6 C  px                18      0.240558  4 C  pz         
+ 
+ Vector   15  Occ=0.000000D+00  E= 1.380966D-01  Symmetry=a1
+              MO Center= -1.5D-16,  4.2D-16, -8.8D-01, r^2= 4.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      1.288027  2 H  s                 35      1.288027  7 H  s          
+     6     -0.951060  1 C  s                 30     -0.951060  6 C  s          
+    24     -0.825756  5 H  s                  9      0.575182  1 C  pz         
+    33      0.575182  6 C  pz                19      0.343224  4 C  s          
+    22      0.269610  4 C  pz                 5      0.221668  1 C  pz         
+ 
+ Vector   16  Occ=0.000000D+00  E= 1.591527D-01  Symmetry=b1
+              MO Center=  1.0D-14,  5.1D-17, -4.2D-01, r^2= 6.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.767337  1 C  s                 30     -1.767337  6 C  s          
+    11     -1.007149  2 H  s                 35      1.007149  7 H  s          
+    13     -0.975802  3 H  s                 37      0.975802  8 H  s          
+    20     -0.614762  4 C  px                 7      0.226763  1 C  px         
+    31      0.226763  6 C  px                 3      0.137385  1 C  px         
+ 
+ Vector   17  Occ=0.000000D+00  E= 1.987900D-01  Symmetry=b1
+              MO Center= -3.2D-15,  2.0D-17, -3.5D-01, r^2= 6.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      1.307085  3 H  s                 37     -1.307085  8 H  s          
+    11     -1.069480  2 H  s                 35      1.069480  7 H  s          
+     9     -0.830439  1 C  pz                33      0.830439  6 C  pz         
+     7     -0.702336  1 C  px                31     -0.702336  6 C  px         
+     5     -0.240846  1 C  pz                29      0.240846  6 C  pz         
+ 
+ Vector   18  Occ=0.000000D+00  E= 2.023402D-01  Symmetry=a1
+              MO Center= -1.9D-14, -3.5D-17,  7.0D-01, r^2= 5.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      2.136848  4 C  s                 24     -1.489193  5 H  s          
+    13      1.037768  3 H  s                 37      1.037768  8 H  s          
+     9     -0.975685  1 C  pz                33     -0.975685  6 C  pz         
+    22      0.718067  4 C  pz                11     -0.711350  2 H  s          
+    35     -0.711350  7 H  s                  6     -0.689344  1 C  s          
+ 
+ Vector   19  Occ=0.000000D+00  E= 3.122795D-01  Symmetry=a1
+              MO Center=  2.1D-15,  2.0D-19, -2.3D-01, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      3.554960  4 C  s                 22     -2.448637  4 C  pz         
+     7      2.076777  1 C  px                31     -2.076777  6 C  px         
+     6     -1.928774  1 C  s                 30     -1.928774  6 C  s          
+    24      1.320169  5 H  s                 13     -0.856774  3 H  s          
+    37     -0.856774  8 H  s                 11      0.517619  2 H  s          
+ 
+ Vector   20  Occ=0.000000D+00  E= 3.774371D-01  Symmetry=b1
+              MO Center=  2.9D-16, -1.2D-16, -1.0D-01, r^2= 4.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      3.542853  4 C  px                 6     -2.090481  1 C  s          
+    30      2.090481  6 C  s                  9     -1.682595  1 C  pz         
+    33      1.682595  6 C  pz                 7      1.635159  1 C  px         
+    31      1.635159  6 C  px                11     -1.061877  2 H  s          
+    35      1.061877  7 H  s                 16      0.352910  4 C  px         
+ 
+ Vector   21  Occ=0.000000D+00  E= 5.219394D-01  Symmetry=b1
+              MO Center= -2.4D-15, -6.5D-18,  4.1D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      1.085056  4 C  px                16     -0.531163  4 C  px         
+     9      0.501859  1 C  pz                33     -0.501859  6 C  pz         
+     7     -0.485336  1 C  px                31     -0.485336  6 C  px         
+     6     -0.464869  1 C  s                 30      0.464869  6 C  s          
+     5     -0.360958  1 C  pz                29      0.360958  6 C  pz         
+ 
+ Vector   22  Occ=0.000000D+00  E= 5.490252D-01  Symmetry=a1
+              MO Center=  2.5D-16, -3.0D-17, -3.7D-01, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7     -0.556444  1 C  px                31      0.556444  6 C  px         
+     3      0.545846  1 C  px                27     -0.545846  6 C  px         
+    22     -0.436341  4 C  pz                 9     -0.304222  1 C  pz         
+    33     -0.304222  6 C  pz                12      0.299349  3 H  s          
+    36      0.299349  8 H  s                 10     -0.270669  2 H  s          
+ 
+ Vector   23  Occ=0.000000D+00  E= 5.590145D-01  Symmetry=b2
+              MO Center=  1.7D-15,  3.9D-20,  2.4D-02, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.623372  1 C  py                28      0.623372  6 C  py         
+    17      0.595780  4 C  py                21     -0.502201  4 C  py         
+     8     -0.481101  1 C  py                32     -0.481101  6 C  py         
+ 
+ Vector   24  Occ=0.000000D+00  E= 6.397364D-01  Symmetry=a2
+              MO Center=  2.1D-15, -5.4D-16, -2.0D-01, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     8     -0.848463  1 C  py                32      0.848463  6 C  py         
+     4      0.777742  1 C  py                28     -0.777742  6 C  py         
+ 
+ Vector   25  Occ=0.000000D+00  E= 6.571127D-01  Symmetry=a1
+              MO Center=  3.9D-16, -3.0D-17,  5.8D-01, r^2= 2.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      0.768800  1 C  pz                33      0.768800  6 C  pz         
+    19      0.716643  4 C  s                 23     -0.599720  5 H  s          
+     5     -0.436907  1 C  pz                29     -0.436907  6 C  pz         
+     2     -0.418733  1 C  s                 26     -0.418733  6 C  s          
+    15     -0.386911  4 C  s                  3      0.371314  1 C  px         
+ 
+ Vector   26  Occ=0.000000D+00  E= 6.650933D-01  Symmetry=b2
+              MO Center= -3.7D-15,  1.2D-20,  2.5D-01, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      1.511068  4 C  py                17     -0.893198  4 C  py         
+     8     -0.859294  1 C  py                32     -0.859294  6 C  py         
+     4      0.461192  1 C  py                28      0.461192  6 C  py         
+ 
+ Vector   27  Occ=0.000000D+00  E= 6.806360D-01  Symmetry=a1
+              MO Center= -2.2D-14, -2.5D-16, -3.4D-01, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      1.332375  4 C  s                 15     -0.867716  4 C  s          
+     6      0.813298  1 C  s                 30      0.813298  6 C  s          
+     7      0.542491  1 C  px                31     -0.542491  6 C  px         
+     2     -0.503561  1 C  s                 26     -0.503561  6 C  s          
+     9     -0.418566  1 C  pz                10     -0.419445  2 H  s          
+ 
+ Vector   28  Occ=0.000000D+00  E= 7.033099D-01  Symmetry=b1
+              MO Center=  2.4D-14,  8.3D-16, -1.6D-01, r^2= 3.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    16      0.788288  4 C  px                20     -0.674094  4 C  px         
+     7     -0.661854  1 C  px                31     -0.661854  6 C  px         
+     6     -0.630476  1 C  s                 30      0.630476  6 C  s          
+    10      0.396404  2 H  s                 34     -0.396404  7 H  s          
+    12      0.380833  3 H  s                 36     -0.380833  8 H  s          
+ 
+ Vector   29  Occ=0.000000D+00  E= 8.556738D-01  Symmetry=a1
+              MO Center=  8.8D-16, -3.5D-18,  5.4D-03, r^2= 3.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      3.086266  4 C  pz                24     -1.884454  5 H  s          
+     9     -1.589809  1 C  pz                33     -1.589809  6 C  pz         
+    11     -1.282226  2 H  s                 35     -1.282226  7 H  s          
+     6      1.240791  1 C  s                 30      1.240791  6 C  s          
+     7     -1.103664  1 C  px                31      1.103664  6 C  px         
+ 
+ Vector   30  Occ=0.000000D+00  E= 8.884970D-01  Symmetry=b1
+              MO Center=  5.2D-15,  2.7D-17, -1.4D-01, r^2= 5.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     9      1.858665  1 C  pz                33     -1.858665  6 C  pz         
+    13     -1.540946  3 H  s                 37      1.540946  8 H  s          
+    20     -1.444318  4 C  px                11      1.173873  2 H  s          
+    35     -1.173873  7 H  s                  6      1.163680  1 C  s          
+    30     -1.163680  6 C  s                  7      0.790994  1 C  px         
+ 
+ Vector   31  Occ=0.000000D+00  E= 9.261122D-01  Symmetry=a1
+              MO Center= -1.1D-15, -2.4D-17,  6.3D-01, r^2= 3.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    24      1.832808  5 H  s                 22     -1.238210  4 C  pz         
+    19     -0.888600  4 C  s                 23     -0.822241  5 H  s          
+    11     -0.808235  2 H  s                 35     -0.808235  7 H  s          
+    18      0.687265  4 C  pz                15      0.623517  4 C  s          
+     9     -0.575791  1 C  pz                33     -0.575791  6 C  pz         
+ 
+ Vector   32  Occ=0.000000D+00  E= 9.551284D-01  Symmetry=a1
+              MO Center= -8.8D-14, -1.8D-17, -1.9D-02, r^2= 5.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      1.189721  1 C  s                 30      1.189721  6 C  s          
+    13     -1.179195  3 H  s                 37     -1.179195  8 H  s          
+    19      1.045387  4 C  s                  2     -0.815210  1 C  s          
+    26     -0.815210  6 C  s                  7      0.703016  1 C  px         
+    31     -0.703016  6 C  px                15     -0.633826  4 C  s          
+ 
+ Vector   33  Occ=0.000000D+00  E= 9.846395D-01  Symmetry=b1
+              MO Center=  6.8D-14, -3.4D-18, -5.8D-01, r^2= 4.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      1.669935  4 C  px                11     -1.220491  2 H  s          
+    35      1.220491  7 H  s                  7      1.086507  1 C  px         
+    31      1.086507  6 C  px                13     -0.825203  3 H  s          
+    37      0.825203  8 H  s                  9     -0.803932  1 C  pz         
+    33      0.803932  6 C  pz                10      0.633004  2 H  s          
+ 
+ Vector   34  Occ=0.000000D+00  E= 1.045939D+00  Symmetry=b1
+              MO Center=  1.1D-14, -2.6D-17, -1.8D-01, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     6      3.964977  1 C  s                 30     -3.964977  6 C  s          
+    20     -2.659044  4 C  px                 2     -1.495432  1 C  s          
+    26      1.495432  6 C  s                  7     -1.162894  1 C  px         
+    31     -1.162894  6 C  px                 9      0.504400  1 C  pz         
+    33     -0.504400  6 C  pz                11     -0.478805  2 H  s          
+ 
+ Vector   35  Occ=0.000000D+00  E= 1.171369D+00  Symmetry=a1
+              MO Center= -9.7D-14,  3.8D-18,  4.3D-01, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    19      5.876531  4 C  s                  6     -3.385953  1 C  s          
+    30     -3.385953  6 C  s                 15     -1.673056  4 C  s          
+     2      1.046991  1 C  s                 26      1.046991  6 C  s          
+     9     -0.918909  1 C  pz                33     -0.918909  6 C  pz         
+     7      0.681526  1 C  px                31     -0.681526  6 C  px         
+ 
+ Vector   36  Occ=0.000000D+00  E= 1.174800D+00  Symmetry=b1
+              MO Center=  7.0D-14, -4.2D-18, -2.6D-02, r^2= 4.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      3.481140  4 C  px                 9     -2.330247  1 C  pz         
+    33      2.330247  6 C  pz                 6     -2.127991  1 C  s          
+    30      2.127991  6 C  s                 12      0.703473  3 H  s          
+    36     -0.703473  8 H  s                 13      0.648763  3 H  s          
+    37     -0.648763  8 H  s                 10     -0.550384  2 H  s          
+ 
+ Vector   37  Occ=0.000000D+00  E= 1.358683D+00  Symmetry=a1
+              MO Center=  3.1D-14, -1.7D-18,  5.2D-03, r^2= 3.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      4.833408  4 C  pz                19     -3.660693  4 C  s          
+     6      3.051769  1 C  s                 30      3.051769  6 C  s          
+     7     -1.806903  1 C  px                31      1.806903  6 C  px         
+     9     -1.534098  1 C  pz                33     -1.534098  6 C  pz         
+    24     -1.438088  5 H  s                 15      0.985971  4 C  s          
+ 
+
+   alpha - beta orbital overlaps 
+   ----------------------------- 
+
+
+   alpha      1      2      3      4      5      6      7      8      9     10
+    beta      1      2      3      4      5      6      7      8      9     10
+ overlap   0.996  1.000  0.996  0.998  1.000  0.997  0.999  1.000  1.000  1.000
+
+
+   alpha     11     12     13     14     15     16     17     18     19     20
+    beta     11     12     13     14     15     16     17     18     19     20
+ overlap   0.985  0.999  0.984  0.987  0.988  0.999  1.000  0.999  1.000  1.000
+
+
+   alpha     21     22     23     24     25     26     27     28     29     30
+    beta     21     23     22     24     25     26     27     28     29     30
+ overlap   1.000  0.976  1.000  0.999  0.999  0.977  0.999  1.000  0.999  1.000
+
+
+   alpha     31     32     33     34     35     36     37
+    beta     31     32     33     34     35     36     37
+ overlap   0.997  0.998  0.998  0.997  0.999  1.000  1.000
+
+     --------------------------
+     Expectation value of S2:  
+     --------------------------
+      <S2> =      0.7820 (Exact =     0.7500)
+ 
+
+ center of mass
+ --------------
+ x =  -0.00000000 y =   0.00000000 z =   0.01402197
+
+ moments of inertia (a.u.)
+ ------------------
+          32.956100368337           0.000000000000           0.000000000000
+           0.000000000000         209.357428735927           0.000000000000
+           0.000000000000           0.000000000000         176.401328367590
+ 
+     Multipole analysis of the density
+     ---------------------------------
+ 
+     L   x y z        total         alpha         beta         nuclear
+     -   - - -        -----         -----         ----         -------
+     0   0 0 0     -0.000000    -12.000000    -11.000000     23.000000
+ 
+     1   1 0 0     -0.000000      0.000000     -0.000000     -0.000000
+     1   0 1 0      0.000000      0.000000      0.000000      0.000000
+     1   0 0 1      0.031414      0.307328     -0.275914     -0.000000
+ 
+     2   2 0 0    -13.129896    -65.543410    -58.422013    110.835527
+     2   1 1 0      0.000000      0.000000      0.000000      0.000000
+     2   1 0 1     -0.000000     -0.000000     -0.000000     -0.000000
+     2   0 2 0    -16.084355     -9.130938     -6.953417      0.000000
+     2   0 1 1      0.000000      0.000000      0.000000      0.000000
+     2   0 0 2    -13.018523    -20.219446    -19.720804     26.921727
+ 
+
+ Parallel integral file used       5 records with       0 large values
+
+
+
+--------------------------------------------------------------------------------
+
+          ****************************
+          *** ORBITAL LOCALIZATION ***
+          ****************************
+
+              Pipek-Mezey localization
+              ------------------------
+               (occ and virt orbitals)
+
+ UNRESTRICTED calculation
+
+ ======
+ Spin 1
+ ======
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   6.2559228767   3.6918587305    0.00D+00
+              2   2.1249911344   1.6728883424    7.85D-01
+              3   1.9048716236   1.5858014282    3.32D-01
+              4   1.9047701566   1.5857194366    7.12D-03
+              5   1.9047640836   1.5857186563    2.25D-04
+              6   1.9047635632   1.5857186044    1.25D-05
+              7   1.9047635601   1.5857186019    6.15D-07
+              8   1.9047635602   1.5857186019    2.27D-08
+              9   1.9047635602   1.5857186019    0.00D+00
+ 
+    1     -10.127192 1.000      6( 1.00)
+    2     -10.127192 1.000      1( 1.00)
+    3     -10.124554 1.000      4( 1.00)
+    4      -0.628127 1.000      1( 0.56)     4( 0.48)     5(-0.01)
+    5      -0.628127 1.000      6( 0.56)     4( 0.48)     5(-0.01)
+    6      -0.524879 1.000      6( 0.59)     7( 0.44)     4(-0.01)     8(-0.01)
+    7      -0.524879 1.000      1( 0.59)     2( 0.44)     4(-0.01)     3(-0.01)
+    8      -0.524877 1.000      1( 0.58)     3( 0.44)     2(-0.01)
+    9      -0.524877 1.000      6( 0.58)     8( 0.44)     7(-0.01)
+   10      -0.512008 1.000      4( 0.55)     5( 0.47)     6(-0.01)     1(-0.01)
+   11      -0.255456 1.000      1( 0.80)     4( 0.20)
+   12      -0.255456 1.000      6( 0.80)     4( 0.20)
+ 
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   6.1332188095   3.3068237850    0.00D+00
+              2   3.6740579588   1.2171387504    7.85D-01
+              3   2.6274985650   0.9490790944    7.79D-01
+              4   2.2531834883   0.8822025972    7.10D-01
+              5   2.2531834714   0.8816443203    3.37D-02
+              6   2.2531834714   0.8816095406    5.65D-03
+              7   2.2531834714   0.8816061414    1.30D-03
+              8   2.2531834714   0.8816058148    2.77D-04
+              9   2.2531834714   0.8816057295    5.86D-05
+             10   2.2531834714   0.8816057056    1.26D-05
+             11   2.2531834714   0.8816056998    2.70D-06
+             12   2.2531834714   0.8816056985    5.77D-07
+             13   2.2531834714   0.8816056982    1.23D-07
+             14   2.2531834714   0.8816056981    2.66D-08
+             15   2.2531834714   0.8816056979    5.27D-09
+ 
+   13       0.106282 0.000      4( 0.60)     6( 0.20)     1( 0.20)
+   14       0.141616 0.000      3( 0.71)     1( 0.33)     4(-0.03)
+   15       0.141616 0.000      8( 0.71)     6( 0.33)     4(-0.03)
+   16       0.148102 0.000      2( 0.71)     1( 0.33)     4(-0.03)
+   17       0.148102 0.000      7( 0.71)     6( 0.33)     4(-0.03)
+   18       0.151257 0.000      4( 1.10)     1(-0.05)     6(-0.05)
+   19       0.169598 0.000      7( 1.34)     6(-0.31)     8(-0.01)
+   20       0.169598 0.000      2( 1.34)     1(-0.31)     3(-0.01)
+   21       0.175630 0.000      8( 1.34)     6(-0.32)     7(-0.01)
+   22       0.175630 0.000      3( 1.34)     1(-0.32)     2(-0.01)
+   23       0.179280 0.000      6( 1.56)     8(-0.45)     4(-0.11)
+   24       0.179280 0.000      1( 1.56)     3(-0.45)     4(-0.11)
+   25       0.180818 0.000      4( 1.75)     5(-0.53)     1(-0.12)     6(-0.12)
+   26       0.202787 0.000      5( 0.72)     4( 0.34)     6(-0.02)     1(-0.02)
+   27       0.211256 0.000      5( 1.40)     4(-0.38)
+   28       0.215876 0.000      1( 1.57)     2(-0.45)     4(-0.14)
+   29       0.215876 0.000      6( 1.57)     7(-0.45)     4(-0.14)
+   30       0.234931 0.000      4( 2.06)     1(-0.86)     6(-0.21)
+   31       0.234931 0.000      4( 2.06)     6(-0.86)     1(-0.21)
+   32       0.315868 0.000      1( 0.51)     4( 0.50)
+   33       0.315868 0.000      6( 0.51)     4( 0.50)
+   34       0.320354 0.000      6( 1.85)     4(-0.86)     1( 0.03)     5(-0.02)
+   35       0.320354 0.000      1( 1.85)     4(-0.86)     6( 0.03)     5(-0.02)
+   36       0.571468 0.000      6( 1.05)     4(-0.05)
+   37       0.571468 0.000      1( 1.05)     4(-0.05)
+ 
+ PM transformation (occ.) written to file 
+ ./testjob.lmotrans_A
+
+ ======
+ Spin 2
+ ======
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   6.4954065000   3.8849109208    0.00D+00
+              2   2.3194047351   1.8313227050    7.85D-01
+              3   2.3194047351   1.6960699528    2.81D-01
+              4   2.3194047351   1.6958291179    1.16D-02
+              5   2.3194047351   1.6958284717    3.14D-04
+              6   2.3194047351   1.6958284482    1.38D-05
+              7   2.3194047351   1.6958284476    3.42D-07
+              8   2.3194047351   1.6958284476    0.00D+00
+ 
+    1     -10.126831 1.000      4( 1.00)
+    2     -10.120729 1.000      6( 1.00)
+    3     -10.120729 1.000      1( 1.00)
+    4      -0.624331 1.000      4( 0.52)     6( 0.51)     5(-0.01)     7(-0.01)
+    5      -0.624331 1.000      4( 0.52)     1( 0.51)     5(-0.01)     2(-0.01)
+    6      -0.517625 1.000      4( 0.56)     5( 0.46)     1(-0.01)     6(-0.01)
+    7      -0.508351 1.000      1( 0.53)     3( 0.48)     2(-0.01)
+    8      -0.508351 1.000      6( 0.53)     8( 0.48)     7(-0.01)
+    9      -0.508032 1.000      6( 0.54)     7( 0.48)     8(-0.01)
+   10      -0.508032 1.000      1( 0.54)     2( 0.48)     3(-0.01)
+   11      -0.286672 1.000      4( 0.59)     6( 0.21)     1( 0.21)
+ 
+
+           iter   Max. delocal   Mean delocal    Converge
+           ----   ------------   ------------    --------
+              1   6.1890992881   3.3496158079    0.00D+00
+              2   4.9938660018   1.4228466242    7.85D-01
+              3   2.1105100136   0.9206475339    7.83D-01
+              4   1.9146964810   0.8806102935    2.50D-01
+              5   1.9121131905   0.8801978385    7.72D-02
+              6   1.9117665341   0.8801838830    1.37D-02
+              7   1.9117452414   0.8801830262    3.16D-03
+              8   1.9117399680   0.8801831497    7.27D-04
+              9   1.9117385814   0.8801831530    1.65D-04
+             10   1.9117382555   0.8801831495    3.78D-05
+             11   1.9117381811   0.8801831481    8.69D-06
+             12   1.9117381633   0.8801831477    2.01D-06
+             13   1.9117381572   0.8801831476    4.66D-07
+             14   1.9117381582   0.8801831476    1.08D-07
+             15   1.9117381596   0.8801831477    2.39D-08
+             16   1.9117381592   0.8801831477    7.45D-09
+ 
+   12       1.801322 0.000      6( 0.81)     4( 0.20)     1(-0.01)
+   13       1.801322 0.000      1( 0.81)     4( 0.20)     6(-0.01)
+   14       1.882100 0.000      3( 0.68)     1( 0.36)     4(-0.03)
+   15       1.882100 0.000      8( 0.68)     6( 0.36)     4(-0.03)
+   16       1.888685 0.000      2( 0.68)     1( 0.36)     4(-0.03)
+   17       1.888685 0.000      7( 0.68)     6( 0.36)     4(-0.03)
+   18       1.904102 0.000      7( 1.33)     6(-0.30)     8(-0.01)
+   19       1.904102 0.000      2( 1.33)     1(-0.30)     3(-0.01)
+   20       1.910380 0.000      8( 1.33)     6(-0.31)     7(-0.01)
+   21       1.910380 0.000      3( 1.33)     1(-0.31)     2(-0.01)
+   22       1.912438 0.000      1( 1.55)     3(-0.44)     4(-0.11)
+   23       1.912438 0.000      6( 1.55)     8(-0.44)     4(-0.11)
+   24       1.918287 0.000      4( 1.76)     5(-0.53)     1(-0.13)     6(-0.13)
+   25       1.939169 0.000      5( 0.74)     4( 0.33)     1(-0.02)     6(-0.02)
+   26       1.943974 0.000      5( 1.41)     4(-0.39)
+   27       1.945489 0.000      6( 1.57)     7(-0.44)     4(-0.14)
+   28       1.945489 0.000      1( 1.57)     2(-0.44)     4(-0.14)
+   29       1.970617 0.000      4( 2.06)     1(-0.86)     6(-0.20)     7( 0.01)
+   30       1.970617 0.000      4( 2.06)     6(-0.86)     1(-0.20)     2( 0.01)
+   31       2.052539 0.000      6( 1.86)     4(-0.87)     1( 0.03)     5(-0.02)
+   32       2.052539 0.000      1( 1.86)     4(-0.87)     6( 0.03)     5(-0.02)
+   33       2.054258 0.000      6( 0.55)     4( 0.47)     1(-0.01)
+   34       2.054258 0.000      1( 0.55)     4( 0.47)     6(-0.01)
+   35       2.406100 0.000      1( 1.05)     4(-0.05)
+   36       2.406100 0.000      6( 1.05)     4(-0.05)
+   37       2.411032 0.000      4( 1.11)     6(-0.05)     1(-0.05)
+ 
+ PM transformation (occ.) written to file 
+ ./testjob.lmotrans_B
+
+ Exiting Localization driver routine
+
+          -------------
+          Dipole Moment
+          -------------
+
+ Center of charge (in au) is the expansion point
+         X =      -0.0000000 Y =       0.0000000 Z =      -0.0000000
+
+   Dipole moment        0.0314140205 A.U.
+             DMX       -0.0000000000 DMXEFC        0.0000000000
+             DMY       -0.0000000000 DMYEFC        0.0000000000
+             DMZ        0.0314140205 DMZEFC        0.0000000000
+   -EFC- dipole         0.0000000000 A.U.
+   Total dipole         0.0314140205 A.U.
+
+   Dipole moment        0.0798470791 Debye(s)
+             DMX       -0.0000000000 DMXEFC        0.0000000000
+             DMY       -0.0000000000 DMYEFC        0.0000000000
+             DMZ        0.0798470791 DMZEFC        0.0000000000
+   -EFC- dipole         0.0000000000 DEBYE(S)
+   Total dipole         0.0798470791 DEBYE(S)
+
+ 1 a.u. = 2.541766 Debyes 
+
+ Task  times  cpu:        0.4s     wall:        0.4s
+ 
+ 
+                                NWChem Input Module
+                                -------------------
+ 
+ 
+ Summary of allocated global arrays
+-----------------------------------
+  No active global arrays
+
+
+MA_summarize_allocated_blocks: starting scan ...
+MA_summarize_allocated_blocks: scan completed: 0 heap blocks, 0 stack blocks
+MA usage statistics:
+
+	allocation statistics:
+					      heap	     stack
+					      ----	     -----
+	current number of blocks	         0	         0
+	maximum number of blocks	        22	        57
+	current total bytes		         0	         0
+	maximum total bytes		   3070104	  22513544
+	maximum total K-bytes		      3071	     22514
+	maximum total M-bytes		         4	        23
+ 
+ 
+                                     CITATION
+                                     --------
+                Please cite the following reference when publishing
+                           results obtained with NWChem:
+ 
+          E. Apra, E. J. Bylaska, W. A. de Jong, N. Govind, K. Kowalski,
+       T. P. Straatsma, M. Valiev, H. J. J. van Dam, Y. Alexeev, J. Anchell,
+       V. Anisimov, F. W. Aquino, R. Atta-Fynn, J. Autschbach, N. P. Bauman,
+     J. C. Becca, D. E. Bernholdt, K. Bhaskaran-Nair, S. Bogatko, P. Borowski,
+         J. Boschen, J. Brabec, A. Bruner, E. Cauet, Y. Chen, G. N. Chuev,
+      C. J. Cramer, J. Daily, M. J. O. Deegan, T. H. Dunning Jr., M. Dupuis,
+   K. G. Dyall, G. I. Fann, S. A. Fischer, A. Fonari, H. Fruchtl, L. Gagliardi,
+      J. Garza, N. Gawande, S. Ghosh, K. Glaesemann, A. W. Gotz, J. Hammond,
+       V. Helms, E. D. Hermes, K. Hirao, S. Hirata, M. Jacquelin, L. Jensen,
+   B. G. Johnson, H. Jonsson, R. A. Kendall, M. Klemm, R. Kobayashi, V. Konkov,
+      S. Krishnamoorthy, M. Krishnan, Z. Lin, R. D. Lins, R. J. Littlefield,
+      A. J. Logsdail, K. Lopata, W. Ma, A. V. Marenich, J. Martin del Campo,
+   D. Mejia-Rodriguez, J. E. Moore, J. M. Mullin, T. Nakajima, D. R. Nascimento,
+    J. A. Nichols, P. J. Nichols, J. Nieplocha, A. Otero-de-la-Roza, B. Palmer,
+    A. Panyala, T. Pirojsirikul, B. Peng, R. Peverati, J. Pittner, L. Pollack,
+   R. M. Richard, P. Sadayappan, G. C. Schatz, W. A. Shelton, D. W. Silverstein,
+   D. M. A. Smith, T. A. Soares, D. Song, M. Swart, H. L. Taylor, G. S. Thomas,
+            V. Tipparaju, D. G. Truhlar, K. Tsemekhman, T. Van Voorhis,
+      A. Vazquez-Mayagoitia, P. Verma, O. Villa, A. Vishnu, K. D. Vogiatzis,
+        D. Wang, J. H. Weare, M. J. Williamson, T. L. Windus, K. Wolinski,
+        A. T. Wong, Q. Wu, C. Yang, Q. Yu, M. Zacharias, Z. Zhang, Y. Zhao,
+                                and R. J. Harrison
+                        "NWChem: Past, present, and future
+                         J. Chem. Phys. 152, 184102 (2020)
+                               doi:10.1063/5.0004997
+ 
+                                      AUTHORS
+                                      -------
+  E. Apra, E. J. Bylaska, N. Govind, K. Kowalski, M. Valiev, D. Mejia-Rodriguez,
+       A. Kunitsa, N. P. Bauman, A. Panyala, W. A. de Jong, T. P. Straatsma,
+   H. J. J. van Dam, D. Wang, T. L. Windus, J. Hammond, J. Autschbach, A. Woods,
+    K. Bhaskaran-Nair, J. Brabec, K. Lopata, S. A. Fischer, S. Krishnamoorthy,
+     M. Jacquelin, W. Ma, M. Klemm, O. Villa, Y. Chen, V. Anisimov, F. Aquino,
+     S. Hirata, M. T. Hackler, E. Hermes, L. Jensen, J. E. Moore, J. C. Becca,
+      V. Konjkov, T. Risthaus, M. Malagoli, A. Marenich, A. Otero-de-la-Roza,
+        J. Mullin, P. Nichols, R. Peverati, J. Pittner, Y. Zhao, P.-D. Fan,
+        A. Fonari, M. J. Williamson, R. J. Harrison, J. R. Rehr, M. Dupuis,
+     D. Silverstein, D. M. A. Smith, J. Nieplocha, V. Tipparaju, M. Krishnan,
+     B. E. Van Kuiken, A. Vazquez-Mayagoitia, M. Swart, Q. Wu, T. Van Voorhis,
+     A. A. Auer, M. Nooijen, L. D. Crosby, E. Brown, G. Cisneros, G. I. Fann,
+   H. Fruchtl, J. Garza, K. Hirao, R. A. Kendall, J. A. Nichols, K. Tsemekhman,
+    K. Wolinski, J. Anchell, D. E. Bernholdt, P. Borowski, T. Clark, D. Clerc,
+   H. Dachsel, M. J. O. Deegan, K. Dyall, D. Elwood, E. Glendening, M. Gutowski,
+   A. C. Hess, J. Jaffe, B. G. Johnson, J. Ju, R. Kobayashi, R. Kutteh, Z. Lin,
+   R. Littlefield, X. Long, B. Meng, T. Nakajima, S. Niu, L. Pollack, M. Rosing,
+   K. Glaesemann, G. Sandrone, M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe,
+                               A. T. Wong, Z. Zhang.
+
+ Total times  cpu:        0.4s     wall:        0.4s

--- a/src/ddscf/localize.F
+++ b/src/ddscf/localize.F
@@ -248,30 +248,25 @@ c
 #include "bas.fh"
 #include "util.fh"
 c
-c     Localize the nloc orbitals in iloc(*) by mixing with each other
+c     Localize the nloc orbitals in iloc() by mixing with each other
 c
-      integer basis, nloc, iloc(*), nbf, nmo
-      double precision c(nbf, 2), sc(nbf, 2)
+      integer basis, nloc, iloc(nmo), nbf, nmo
       integer g_c, g_sc
-      integer maxat, nlist
-*............................   these should be dynamically allocated ?
-      parameter (maxat = nw_max_atom)
-      integer list(maxat)
-      double precision pop(maxat)
-c
-      integer iter, ss, s, tt, t, a, u, bflo, bfhi, natoms, geom
+      double precision c(nbf, 2), sc(nbf, 2)
+
+      integer iter, ss, s, tt, t, a, u, bflo, bfhi, geom, natoms
       double precision ast, bst, qast, qat, qas, gamma, cosg, sing, d,
      $     qs, dprev, tol, dmax, gamma_tol, gamma_max, tmp
-      integer nrot, set, pair, neven
+      integer nrot, set, pair, neven, locpow
 c
       if (.not. bas_geom(basis, geom)) call errquit
      $     ('localize: basis ', 0, BASIS_ERR)
       if (.not. geom_ncent(geom, natoms)) call errquit
      $     ('localize: geom',0, GEOM_ERR)
-c
-      if (natoms.gt.maxat) call errquit
-     &      ('localize: maxat too small ', 911, UNKNOWN_ERR)
-c
+
+c     locpow (localization sum exponent) should be 2 or 4
+      locpow = 2
+      
       tol = 1d-8
       gamma_tol = 1d-10
 c
@@ -368,8 +363,20 @@ c
                      end do
                      qast = qast * 0.5d0
 c     
+                     if (locpow.eq.2) then
                      ast = ast + qast**2 - 0.25d0*(qas - qat)**2
                      bst = bst + qast*(qas - qat)
+                     elseif (locpow.eq.4) then
+                       tmp = -1.0d0*(qas**4 + qat**4)
+                       tmp = tmp + 6.0d0*((qas**2 + qat**2)* qast**2)
+                       tmp = tmp + qas**3 * qat + qas * qat**3
+                       ast = ast + 0.25d0*tmp
+                       tmp = 4.0d0 * qast*(qas**3 - qat**3)
+                       bst = bst + 0.25d0*tmp
+                     else
+                       call errquit('pmloc: locpow ', locpow,
+     &                   UNKNOWN_ERR)
+                     end if
                   end do
 c     
                   gamma = 0.25d0*acos(-ast/sqrt(ast**2+bst**2))
@@ -401,53 +408,8 @@ c
 c
  1000 continue
 
-      
-c     Analyze localization of each mo:
-c     per lmo, a list of atomic populations is printed
-c     in decreasing magnitude, with the polulations in parentheses. 
-c
-      if (ga_nodeid() .eq. 0) then
-         write(6,*)
-         do ss = 1, nloc
-            s = iloc(ss)
-            call ga_get(g_c,  1, nbf, s, s, c(1,1), 1)
-            call ga_get(g_sc, 1, nbf, s, s,sc(1,1), 1)
-            nlist = 0
-            do a = 1, natoms
-               if (.not. bas_ce2bfr(basis, a, bflo, bfhi))
-     $              call errquit('localized: basis ', 0,
-     &       BASIS_ERR)
-               qas  = 0.0d0
-               do u = bflo, bfhi
-                  qas  = qas  + c(u,1)*sc(u,1)
-               end do
-               if (abs(qas) .gt. 0.01d0) then
-                  nlist = nlist + 1
-                  list(nlist) = a
-                  pop(nlist) = qas
-               end if
-            end do
-            do u = 1, nlist
-               do t = 1, u-1
-                  if (abs(pop(t)).lt.abs(pop(u))) then
-                     tmp = pop(u)
-                     pop(u) = pop(t)
-                     pop(t) = tmp
-                     tt = list(u)
-                     list(u) = list(t)
-                     list(t) = tt
-                  end if
-               end do
-            end do
-            write(6,9002) s, (list(a), pop(a), a=1,nlist)
- 9002         format(i5, 100(2x,i4,'(',f5.2,')'))
-         end do
-         call util_flush(6)
-      end if
-c
       call ga_sync
-c
-      end      
+      end
 c
 c     =================================================================
 c      
@@ -469,7 +431,7 @@ c
 c
 c     Localize the nloc orbitals in iloc(*) by mixing with each other
 c
-      integer basis, nloc, iloc(*), nbf, nmo
+      integer basis, nloc, iloc(nmo), nbf, nmo
       double precision c(nbf, 2), uc(nbf, 2, 4)
       integer g_c, g_uc(4) ! x, y, z, overlap
 c

--- a/src/property/GNUmakefile
+++ b/src/property/GNUmakefile
@@ -64,6 +64,7 @@
          CalcPerturbedTDPmat1_opt.o \
          localization_driver.o \
          ibo_localization.o \
+         pm_localization.o \
          hnd_vec_write.o \
 	 giao_b1_movecs_tools.o \
          aor_r1_beta_anl_tools.o\

--- a/src/property/aor_r1_beta_anl.F
+++ b/src/property/aor_r1_beta_anl.F
@@ -234,7 +234,7 @@ c       ----------------------------------------------
      &      g_tran))            ! create g_tran
      &      call errquit (trim(cstemp),0,GA_ERR)
           if (debug) write (luout,*) 'g_tran allocated'
-          call util_file_name('lmotrans',.true.,.true.,lmotrans)
+          call util_file_name('lmotrans',.false.,.false.,lmotrans)
           if(.not.file_read_ga(lmotrans,g_tran)) call errquit
      $      ('aor_r1_beta_anl: could not read lmotrans',0, DISK_ERR)
         end if                  ! lmo

--- a/src/property/ibo_localization.F
+++ b/src/property/ibo_localization.F
@@ -86,11 +86,6 @@ c     local variables:
       integer ga_create_atom_blocked
       external ga_create_atom_blocked
 
-
-      character*(256) lmotrans
-      logical file_write_ga
-      external file_write_ga
-
       character*(16) pname
 
 c     =================================================================
@@ -696,15 +691,6 @@ c         swap LMOs in IAO basis, for the analysis below
       end if ! master
 
       call ga_sync
-
-c     write transformation to scratch file
-
-      call util_file_name('lmotrans',.true.,.true.,lmotrans)
-      if(.not.file_write_ga(lmotrans,g_tmp1)) call errquit
-     &  (pname//': could not write lmotrans',0, DISK_ERR)
-
-      if (debug) write (luout,*)
-     &  pname//': lmos reordered and lmotrans written'
 
 c     transform CMOs to re-ordered LMOs
 

--- a/src/property/localization_driver.F
+++ b/src/property/localization_driver.F
@@ -44,20 +44,26 @@ c     subroutine arguments:
       integer loctype
 
 c     local GA handles:
-      integer g_uc(4), g_smat, g_sc, g_tran
+      integer g_uc(4), g_smat, g_sc, g_t
       integer g_movecs(2), g_cmo(2), g_temp, g_tmp1, g_tmp2
+      integer g_sc0
 
 c     MA variables:
       integer l_c, k_c, l_sc, k_sc, l_eval, k_eval, l_occ, k_occ
       integer l_dip(3), k_dip(3)
       integer l_pop, k_pop, l_list, k_list
+      integer l_iloc, k_iloc
 
 c     other local variables:
 
       integer loc_opt
 
       integer nclosed(2), nopen(2), nvirt(2), ncore, nocc, nvir,
-     &  ndens, nbf, nmo, nloc, i, natoms
+     &  nbf, nmo, nloc, i, natoms, nspin
+
+      character*(2) lspin(2)
+      data lspin /'_A','_B'/
+      character*(10) filename
 
       integer info, dbg, ispin
       
@@ -69,10 +75,6 @@ c     other local variables:
 
       logical     oskel, status
       data tol2e   /1.0d-10/
-
-      integer maxnloc
-      parameter (maxnloc = 10000)
-      integer iloc(maxnloc)
 
       double precision dummy(3)
       double precision origin(3)
@@ -107,7 +109,7 @@ c     ==================================================================
       if (debug) write(luout,*) 'entering '//pname
 
       if (loctype.lt.1 .or. loctype.gt.3)
-     &   call errquit('loc_driver: loctype out of range',0, RTDB_ERR)
+     &   call errquit(pname//': loctype out of range',0, RTDB_ERR)
 
       oprint = util_print('information', print_low)
       oprint = oprint .and. ga_nodeid().eq.0
@@ -140,15 +142,6 @@ c     retrieve localization option from rtdb if it exists
      &                               loc_opt  ))
      &  loc_opt = 0
 
-c     option is currently only implemented for IBOs:
-
-      if (loc_opt.gt.0 .and. (loctype.ne.3)) then
-        if (oprint) write(luout,'(/1x,a/1x,a)')
-     &    'localization option not implemented for chosen loc. type',
-     &    'setting option to 0 ...'
-        loc_opt = 0
-      end if
-
       if (oprint) then
         if (loc_opt .eq.0) then
           call util_print_centered(luout,
@@ -165,8 +158,6 @@ c     option is currently only implemented for IBOs:
         end if
       end if
 
-
-
 c     -------------------------------------------------------
 c     assemble some data:
 c     MO coeffs, orbital energies, density matrix, occupation
@@ -174,13 +165,13 @@ c     numbers, basis set info, matrix elements, etc.
 c     -------------------------------------------------------
 
       if (.not. bas_numbf(basis,nbf)) call
-     &   errquit('loc_driver: could not get nbf',0, BASIS_ERR)
+     &   errquit(pname//': could not get nbf',0, BASIS_ERR)
 c     allocate dbl_mb(k_occ) = fractional occupation numbers:
       if (.not. ma_push_get(mt_dbl,2*nbf,'occ num',l_occ,k_occ)) call
-     &    errquit('loc_driver: ma_push_get failed k_occ',0,MA_ERR)
+     &    errquit(pname//': ma_push_get failed k_occ',0,MA_ERR)
 c     allocate dbl_mb(leval) = orbital energies:
       if (.not. ma_push_get(mt_dbl,2*nbf,'eigenval',l_eval,k_eval)) call
-     &    errquit('loc_driver: ma_push_get failed k_eval',0,MA_ERR)
+     &    errquit(pname//': ma_push_get failed k_eval',0,MA_ERR)
 
       call hnd_prp_vec_read(rtdb,geom,basis,nbf,nclosed,nopen,
      &                      nvirt,scftyp,g_movecs,dbl_mb(k_occ),
@@ -188,7 +179,8 @@ c     allocate dbl_mb(leval) = orbital energies:
 
       if (debug)
      &   write (luout,*) 'loc driver: nclosed,nopen,nvirt',nclosed(1),
-     &  nopen(1), nvirt(1)
+     &  nopen(1), nvirt(1),nclosed(2),
+     &  nopen(2), nvirt(2)
 
       natoms = 0
 
@@ -201,41 +193,47 @@ c     allocate dbl_mb(leval) = orbital energies:
       if (natoms.gt.nw_max_atom) call errquit
      &  (pname//': nw_max_atom too small ', 911, UNKNOWN_ERR)
 
-c     Skip localization if we have an open-shell system
-c     (to be extended eventually, localizing alpha and
-c     beta spin orbitals separately):
-      
+c     Check if we have a spin-restricted or unrestricted
+c     calculation and set nspin accoringly
+
+      nspin = 0
+
       if (scftyp.eq.'UHF') then
-        if (oprint) write(luout,9020)
-        goto 7000
-c       Note: ndens = 1 means closed shell
-c             ndens = 3 open shell, then g_dens has 3 components
-c                       with 1=alpha, 2=beta, 3=total
-      endif
-      
-c     perform some sanity checks for the orbital occupations:
-      
+
+        if (master) write (luout,'(/1x,a)')
+     &    'UNRESTRICTED calculation'
+        nspin = 2
+        if (nclosed(1).ne.0 .or. nclosed(2).ne.0) call
+     &    errquit(pname//': UHF but nclosed.ne.0',1, CALC_ERR)
+
+      else if (scftyp.eq.'RHF') then
+        nspin = 1
 c     for RHF system there should be no open shell orbitals
       if (nopen(1).ne.0) call
-     &  errquit('loc_driver: nopen.ne.0',0, CALC_ERR)
-      
-c     in this case, nclosed and nvirt should add up to nmo
+     &    errquit(pname//': RHF but nopen.ne.0',nopen(1), CALC_ERR)
+
+      else
+c       at present, ROHF, MCSCF not supported
+        call errquit(pname//': SCF type not supported: '//
+     &    trim(scftyp),1,INPUT_ERR)
+      end if
+
+c     Restricted: nclosed and nvirt should add up to nmo
+      if (nspin .eq. 1) then
       if ((nclosed(1)+nvirt(1)).ne.nmo) call
-     &   errquit('loc_driver: wrong no. of orbitals',0, CALC_ERR)
+     &    errquit(pname//': wrong no. of rhf orbitals',
+     &    nmo, CALC_ERR)
+c     Unrestrcited: nopen + nvirt = nmo, per spin
+      else if (nspin.eq.2) then
+        if ((nopen(1)+nvirt(1)+nopen(2)+nvirt(2)).ne.(2*nmo)) call
+     &    errquit(pname//': wrong no. of uhf orbitals',
+     &    nmo, CALC_ERR)
+      end if
 
+      if (nspin.le.0 .or. nspin.gt.2) call
+     &  errquit(pname//': nspin wrong',nspin, CALC_ERR)
 
-c     maxnloc is hard coded. We should allocate array iloc
-c     dynamically but for now let's make sure we don't get out of
-c     bounds:
-
-      if (nmo.gt.maxnloc) call
-     &  errquit('loc_driver: maxnloc too small',0, BASIS_ERR)
-
-c     for the time being, we set these variables here:
-
-      ispin = 1
-      nocc = nclosed(1)
-      nvir = nvirt(ispin)
+      if (debug) write (luout,*) 'loc_driver: setup complete'
 
 
 c     --------------------------------------------
@@ -255,7 +253,9 @@ c     =================================================================
 c       ========================
 c       Pipek-Mezey localization
 c       ========================
-        
+
+        if (.not. ma_push_get(mt_int, nmo, 'iloc', l_iloc,
+     &    k_iloc)) call errquit(pname//': loc:iloc', 0, MA_ERR)
 
 c       AO Overlap Matrix S:
 
@@ -263,83 +263,144 @@ c       AO Overlap Matrix S:
         call ga_zero(g_smat)
         call int_1e_ga(basis, basis, g_smat, 'overlap', .false.)
 
-c       PM localization needs S*C: 
- 
+c       allocate memory
+
         if (.not. ga_create(MT_DBL, nbf, nmo, 'loc:sc',
-     $        nbf, 0, g_sc)) call errquit('loc_driver: sc',0, GA_ERR)
-         call ga_dgemm('n', 'n', nbf, nmo, nbf, 
-     $        1.0d0, g_smat, g_movecs(1), 0.0d0, g_sc)
+     $    nbf, 0, g_sc)) call errquit(pname//': sc',0, GA_ERR)
 
-c        allocate some memory used in the localization routine:
+        if (.not.ga_duplicate(g_sc, g_sc0,'g_sc0')) call
+     &     errquit(pname//': ga_create failed g_sc0',1,GA_ERR)
 
-         if (.not. ma_push_get(mt_dbl, 2*nbf, 'sc', l_sc, k_sc))
-     $        call errquit('loc_driver: ma for sc', 0, MA_ERR)
-         if (.not. ma_push_get(mt_dbl, 2*nbf, 'c', l_c, k_c))
-     $        call errquit('loc_driver: ma for c', 0, MA_ERR)
+        if (.not. ma_push_get(mt_dbl, 2*nbf, 'sc', l_sc, k_sc))
+     $       call errquit(pname//': ma for sc', 0, MA_ERR)
+        if (.not. ma_push_get(mt_dbl, 2*nbf, 'c', l_c, k_c))
+     $       call errquit(pname//': ma for c', 0, MA_ERR)
+        if (.not. ma_push_get(mt_dbl, natoms, 'pop', l_pop, k_pop))
+     &    call errquit(pname//': loc:pop', 0, MA_ERR)
+         if (.not. ma_push_get(mt_int, natoms,'list', l_list, k_list))
+     &     call errquit(pname//': loc:list', 0, MA_ERR)
 
-c        localize core and occupied orbitals
+         do ispin = 1,nspin
 
-         ispin = 1
+           if (nspin.eq.1) then
+             nocc = nclosed(ispin)
+           else if (nspin.eq.2) then
+             nocc = nopen(ispin)
+           else
+             call errquit(pname//': pmloc nspin out of order',
+     &         nspin, UNKNOWN_ERR)
+           end if
+           nvir = nvirt(ispin)
 
-         do i = 1, nclosed(ispin)
-            iloc(i) = i
-         end do
-         nloc = nclosed(ispin)
-         
-c        jochen: comment:
-c        the PM localization routine was already available
-c        in nwchem
-         call localizePM(basis, dbl_mb(k_c), dbl_mb(k_sc), 
-     &        nloc, iloc, nbf, nmo, g_movecs, g_sc)
+           if (nspin.gt.1 .and. master) then
+             write(luout,"(/1x,6('=')/1x,'Spin ',i1/1x,6('='))") ispin
+           end if
 
+c          PM localization needs S*C for this spin:
+           call ga_dgemm('n', 'n', nbf, nmo, nbf,
+     $       1.0d0, g_smat, g_movecs(ispin), 0.0d0, g_sc)
+
+c          save g_sc in g_sc0 to calculate the loc. transform later
+
+           call ga_copy(g_sc, g_sc0)
+
+           if (loc_opt.eq.0) then
+
+             ltyp = 'occ'
+             call pm_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin), g_sc, g_sc0,
+     &         nocc, nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+           else if (loc_opt.eq.1) then
+
+             ltyp = 'vir'
+             call pm_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin), g_sc, g_sc0,
+     &         nocc, nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+           else if (loc_opt.eq.2) then
+
+             ltyp = 'occ'
+             call pm_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin), g_sc, g_sc0,
+     &         nocc, nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+             ltyp = 'vir'
+             call pm_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin), g_sc, g_sc0,
+     &         nocc, nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+           else
+             call errquit(pname//': loc_opt out of range',loc_opt,
+     &         UNKNOWN_ERR)
+
+           end if
+
+c          write transformation for this spin to scratch file
+c          (occ-occ transformation only)
+
+           if (loc_opt.eq.0 .or. loc_opt.eq.2) then
+
+             if (.not. ga_create(MT_DBL, nocc, nocc, 'loc:trans',
+     &         nocc, 0, g_t)) call errquit(pname//' pmloc: g_t',
+     &         1, GA_ERR)
+
+             call ga_dgemm('t', 'n', nocc, nocc, nbf,
+     &         1.0d0, g_sc0, g_movecs(ispin), 0.0d0, g_t)
+
+             if (nspin.eq.1) then
+               filename='lmotrans'
+             else if (nspin.eq.2) then
+               filename='lmotrans'//lspin(ispin)
+             else
+               call errquit (
+     &           pname//' pmloc: nspin value not valid',1,
+     &           UNKNOWN_ERR)
+             end if
+
+             call util_file_name(filename,.true.,.true.,lmotrans)
+             if(.not.file_write_ga(lmotrans,g_t)) call errquit
+     &         (pname//' pmloc: could not write lmotrans',1, DISK_ERR)
+
+             if (debug) write (luout,*)
+     &         pname//': pmloc lmotrans written'
+
+             if (.not. ga_destroy(g_t)) call errquit(
+     &         pname//' pmloc: error destroying g_t',1, GA_ERR)
+
+           end if ! save lmotrans for occ MOs
+
+         end do ! ispin
+
+c        deallocate arrays
 
 c        clean up some temp arrays
          if (.not. ga_destroy(g_sc)) call errquit(
-     &      'loc_driver: error destroying g_sc',0, GA_ERR)
-         if (.not. ma_pop_stack(l_c)) call errquit(
-     &      'loc_driver: error MA pop c',0, MA_ERR)
-         if (.not. ma_pop_stack(l_sc)) call errquit(
-     &      'loc_driver: error MA pop sc',0, MA_ERR)
+     &      pname//': error destroying g_sc',0, GA_ERR)
 
-c        calculate the LMO transformation matrix 
-c        from C(dagger,canonical) S C(locorb)
-
-c        first, read the CMOs again -> g_cmo
-
-         call hnd_prp_vec_read(rtdb,geom,basis,nbf,nclosed,nopen,
-     &      nvirt,scftyp,g_cmo,dbl_mb(k_occ),
-     &      dbl_mb(k_eval),nmo)
-
-         if (.not. ga_create(MT_DBL, nclosed(1), nbf, 'loc:temp',
-     &      nbf, 0, g_temp))
-     &      call errquit('loc_driver: temp',0, GA_ERR)
-         call ga_zero(g_temp)
-         call ga_dgemm('t', 'n', nclosed(1), nbf, nbf, 
-     $      1.0d0, g_cmo(1), g_smat, 0.0d0, g_temp)
+         if (.not. ma_chop_stack(l_sc)) call errquit(
+     &      pname//': error MA pop sc',0, MA_ERR)
 
          if (.not. ga_destroy(g_smat)) call errquit(
-     &      'loc_driver: error destroying g_smat',0, GA_ERR)
-         if (.not. ga_create(MT_DBL, nclosed(1), nclosed(1),
-     &      'loc:smat',nbf, 0, g_smat))
-     &      call errquit('loc_driver: smat',0, GA_ERR)
-         call ga_zero(g_smat)
-         call ga_dgemm('n', 'n', nclosed(1), nclosed(1), nbf, 
-     $      1.0d0, g_temp, g_movecs(1), 0.0d0, g_smat)
-
-         if (.not. ga_destroy(g_temp)) call errquit(
-     &      'loc_driver: error destroying g_temp',0, GA_ERR)
-         if (.not. ga_destroy(g_cmo(1))) call errquit(
-     &      'loc_driver: error destroying g_cmo(1)',0, GA_ERR)
-
-c        loc transform is in g_smat. Write to file
-
-         call util_file_name('lmotrans',.true.,.true.,lmotrans)
-         if(.not.file_write_ga(lmotrans,g_smat)) call errquit
-     $      ('loc_driver: could not write lmotrans',0, DISK_ERR)
-
-c        smat not needed anymore
-         if (.not. ga_destroy(g_smat)) call errquit(
-     &     'loc_driver: error destroying g_smat',0, GA_ERR)
+     &     pname//': error destroying g_smat',1, GA_ERR)
+         if (.not. ga_destroy(g_sc0)) call errquit(
+     &     pname//': error destroying g_sc0',1, GA_ERR)
 
 c     =================================================================
 
@@ -349,9 +410,17 @@ c       =================
 c       Boys localization
 c       =================
 
+        if (nspin.gt.1) call
+     &    errquit(pname//': Boys loc. not supported for open shell',
+     &    nspin, INPUT_ERR)
+
+        if (loc_opt.gt.0) call
+     &    errquit(pname//': Boys loc. not supported for virtuals',
+     &    loc_opt, INPUT_ERR)
+
         do i = 1,4
           if (.not. ga_create(MT_DBL, nbf, nbf, 'uc',
-     $       nbf, 0, g_uc(i))) call errquit('loc_driver:uc'
+     $       nbf, 0, g_uc(i))) call errquit(pname//': uc'
      &       ,i,GA_ERR)
           call ga_zero(g_uc(i))
          end do
@@ -365,7 +434,7 @@ c        dipole moment AO matrices -> uc(1) - uc(3)
 
 c        calculate dipole-AO times C (mo-coeffs), store in uc(i)
          if (.not. ga_create(MT_DBL, nbf, nmo, 'sc',
-     $        nbf, 0, g_sc)) call errquit('loc_driver: sc',0, GA_ERR)
+     $        nbf, 0, g_sc)) call errquit(pname//': sc',0, GA_ERR)
          do i = 1, 3
             call ga_dgemm('n', 'n', nbf, nmo, nbf, 
      $           1.0d0, g_uc(i), g_movecs, 0.0d0, g_sc)
@@ -389,16 +458,20 @@ c       store S C in array uc(4)
         if (debug) write(luout,*) 'g_uc(4) done'
 c     
          if (.not. ma_push_get(mt_dbl, 8*nbf, 'sc', l_sc, k_sc))
-     $        call errquit('loc_driver: ma for sc', 0, MA_ERR)
+     $        call errquit(pname//': ma for sc', 0, MA_ERR)
          if (.not. ma_push_get(mt_dbl, 8*nbf, 'c', l_c, k_c))
-     $        call errquit('ma for c', 0, MA_ERR)
+     $     call errquit(pname//': ma for c', 0, MA_ERR)
+
+         if (.not. ma_push_get(mt_int, nmo, 'iloc', l_iloc,
+     &     k_iloc)) call errquit(pname//': loc:iloc', 1, MA_ERR)
 
          if (debug) write(luout,*) 'MA c, sc complete'
 
 c        localize core and occupied orbitals:
 
          do i = 1, nclosed(1)
-            iloc(i) = i
+           int_mb(k_iloc - 1 + i) = i
+c           iloc(i) = i
          end do
          nloc = nclosed(1)
 
@@ -408,13 +481,13 @@ c        The Boys localization maximizes B2.
 c        we can use g_sc as a temp array as it is not further used
 
          if (.not. ga_destroy(g_sc)) call errquit(
-     &      'loc_driver: error destroying g_sc',0, GA_ERR)
+     &      pname//': error destroying g_sc',0, GA_ERR)
          if (.not. ga_create(MT_DBL, nmo, nmo, 'sc',
-     $      nbf, 0, g_sc)) call errquit('loc_driver: sc',0, GA_ERR)
+     $      nbf, 0, g_sc)) call errquit(pname//': sc',0, GA_ERR)
 
          do i = 1,3
            if (.not. ma_push_get(mt_dbl, nmo, 'sc', l_dip(i), k_dip(i)))
-     $        call errquit('loc_driver: ma for dip', i, MA_ERR)
+     $        call errquit(pname//': ma for dip', i, MA_ERR)
          end do
 
          do i = 1,3
@@ -447,20 +520,20 @@ c         end if
 
          do i = 3,1,-1
            if (.not. ma_pop_stack(l_dip(i))) call errquit(
-     &        'loc_driver: error MA pop dip',i, MA_ERR)
+     &        pname//': error MA pop dip',i, MA_ERR)
          end do
 
 c        jochen: comment:
 c        the Boys localization routine was already available
 c        in nwchem
          call localizeFB(basis, dbl_mb(k_c), dbl_mb(k_sc), 
-     $        nloc, iloc, nbf, nmo, g_movecs, g_uc)
+     $        nloc, int_mb(k_iloc), nbf, nmo, g_movecs, g_uc)
 
 c        calculate orbital centroids again and print information
 
          do i = 1,3
            if (.not. ma_push_get(mt_dbl, nmo, 'sc', l_dip(i), k_dip(i)))
-     $        call errquit('loc_driver: ma for dip', i, MA_ERR)
+     $        call errquit(pname//': ma for dip', i, MA_ERR)
          end do
 
          do i = 1,3
@@ -493,28 +566,28 @@ c         end if
 
          do i = 3,1,-1
            if (.not. ma_pop_stack(l_dip(i))) call errquit(
-     &        'loc_driver: error MA pop dip',i, MA_ERR)
+     &        pname//': error MA pop dip',i, MA_ERR)
          end do
 
 c        clean up  temp arrays:
 
          if (.not. ga_destroy(g_sc)) call errquit(
-     &      'loc_driver: error destroying g_sc',0, GA_ERR)
+     &      pname//': error destroying g_sc',0, GA_ERR)
 
          if (.not. ma_pop_stack(l_c)) call errquit(
-     &      'loc_driver: error MA pop c',0, MA_ERR)
+     &      pname//': error MA pop c',0, MA_ERR)
 
          if (.not. ma_pop_stack(l_sc)) call errquit(
-     &      'loc_driver: error MA pop sc',0, MA_ERR)
+     &      pname//': error MA pop sc',0, MA_ERR)
 
          do i = 1, 4
             if (.not. ga_destroy(g_uc(i)))
-     &        call errquit('loc_driver: error destroying uc',i, GA_ERR)
+     &        call errquit(pname//': error destroying uc',i, GA_ERR)
          end do
 
 c        smat not needed anymore
          if (.not. ga_destroy(g_smat)) call errquit(
-     &     'loc_driver: error destroying g_smat',0, GA_ERR)
+     &     pname//': error destroying g_smat',0, GA_ERR)
 
 
 c      ===============================================================
@@ -525,13 +598,11 @@ c        ===================================================
 c        IAO-IBO localization (occupied or virtual orbitals)
 c        ===================================================
 
+         g_smat  = ga_create_atom_blocked(geom, basis, 'loc:smat')
+         call ga_zero(g_smat)
+         call int_1e_ga(basis, basis, g_smat, 'overlap', .false.)
 
-         ispin = 1
-         nocc = nclosed(ispin)
-         nvir = nvirt(ispin)
-
-c        allocate MA array for pairs of MOs. The actual dimensions
-c        needed are less or equal to 2*nbf
+c        allocate memory
 
          if (.not. ma_push_get(mt_dbl, 2*nbf, 'c mo', l_c, k_c))
      &     call errquit(pname//': ma for c', 0, MA_ERR)
@@ -539,49 +610,124 @@ c        needed are less or equal to 2*nbf
          if (.not. ma_push_get(mt_dbl, natoms, 'pop', l_pop, k_pop))
      &     call errquit(pname//': loc:pop', 0, MA_ERR)
 
-         if (.not. ma_push_get(mt_int, natoms, 'list', l_list, k_list))
-     &     call errquit(pname//': loc:list', 0, MA_ERR)
+         if (.not. ma_push_get(mt_int, natoms, 'list', l_list,
+     &     k_list)) call errquit(pname//': loc:list', 0, MA_ERR)
 
-         if (loc_opt.eq.0) then
-           ltyp = 'occ'
-           call ibo_localization(rtdb, geom, ltyp, basis,
-     &       g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
-     &       dbl_mb(k_eval+(ispin-1)*nbf),
-     &       dbl_mb(k_occ+(ispin-1)*nbf),
-     &       dbl_mb(k_c),
-     &       dbl_mb(k_pop), int_mb(k_list))
+         if (.not. ga_create(MT_DBL, nbf, nmo, 'loc:sc0',
+     &     nbf, 0, g_sc0)) call errquit(pname//' ibo: sc0',0, GA_ERR)
 
-         else if (loc_opt.eq.1) then
-           ltyp = 'vir'
-           call ibo_localization(rtdb, geom, ltyp, basis,
-     &       g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
-     &       dbl_mb(k_eval+(ispin-1)*nbf),
-     &       dbl_mb(k_occ+(ispin-1)*nbf),
-     &       dbl_mb(k_c),
-     &       dbl_mb(k_pop), int_mb(k_list))
+         do ispin = 1,nspin
 
-         else if(loc_opt.eq.2) then
-           ltyp = 'occ'
-           call ibo_localization(rtdb, geom, ltyp, basis,
-     &       g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
-     &       dbl_mb(k_eval+(ispin-1)*nbf),
-     &       dbl_mb(k_occ+(ispin-1)*nbf),
-     &       dbl_mb(k_c),
-     &       dbl_mb(k_pop), int_mb(k_list))
+           if (nspin.eq.1) then
+             nocc = nclosed(ispin)
+           else if (nspin.eq.2) then
+             nocc = nopen(ispin)
+           else
+             call errquit(pname//': nspin out of order',
+     &         nspin, UNKNOWN_ERR)
+           end if
+           nvir = nvirt(ispin)
 
-           ltyp = 'vir'
-           call ibo_localization(rtdb, geom, ltyp, basis,
-     &       g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
-     &       dbl_mb(k_eval+(ispin-1)*nbf),
-     &       dbl_mb(k_occ+(ispin-1)*nbf),
-     &       dbl_mb(k_c),
-     &       dbl_mb(k_pop), int_mb(k_list))
+           if (nspin.gt.1 .and. master) then
+             write(luout,"(/1x,6('=')/1x,'Spin ',i1/1x,6('='))") ispin
+           end if
 
-         else
-           call errquit(pname//': loc_opt out of range',loc_opt,
+           if (debug) write(luout,*) pname//': ispin,nocc,nvir,nmo',
+     &       ispin,nocc,nvir,nmo
+
+           if (nocc+nvir.ne.nmo) call errquit(pname//
+     &       ': nocc+nvir.ne.nmo. Non-aufbau config?',nocc+nvir,
      &       UNKNOWN_ERR)
 
-         end if ! loc_opt
+c          calculate SC with the original MOs, so we can generate
+c          the localization transformation later for this spin
+
+           call ga_dgemm('n', 'n', nbf, nmo, nbf,
+     $       1.0d0, g_smat, g_movecs(ispin), 0.0d0, g_sc0)
+
+           if (loc_opt.eq.0) then
+             ltyp = 'occ'
+             call ibo_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+           else if (loc_opt.eq.1) then
+             ltyp = 'vir'
+             call ibo_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+           else if(loc_opt.eq.2) then
+             ltyp = 'occ'
+             call ibo_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+             ltyp = 'vir'
+             call ibo_localization(rtdb, geom, ltyp, basis,
+     &         g_movecs(ispin),nocc,nvir, nmo, nbf, natoms,
+     &         dbl_mb(k_eval+(ispin-1)*nbf),
+     &         dbl_mb(k_occ+(ispin-1)*nbf),
+     &         dbl_mb(k_c),
+     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+
+           else
+             call errquit(pname//': loc_opt out of range',loc_opt,
+     &         UNKNOWN_ERR)
+
+           end if ! loc_opt
+
+           if (debug) write (luout,*)
+     &       pname//': back from ibo_localization'
+
+c          write transformation for this spin to scratch file
+c          (occ-occ transformation only)
+
+           if (loc_opt.eq.0 .or. loc_opt.eq.2) then
+
+             if (.not. ga_create(MT_DBL, nocc, nocc, 'loc:trans',
+     &         nocc, 0, g_t)) call errquit(pname//' ibo: g_t',1, GA_ERR)
+
+             call ga_dgemm('t', 'n', nocc, nocc, nbf,
+     &         1.0d0, g_sc0, g_movecs(ispin), 0.0d0, g_t)
+
+             if (nspin.eq.1) then
+               filename='lmotrans'
+             else if (nspin.eq.2) then
+               filename='lmotrans'//lspin(ispin)
+             else
+               call errquit (
+     &           pname//' ibo: nspin value not valid',1,
+     &           UNKNOWN_ERR)
+             end if
+
+             call util_file_name(filename,.true.,.true.,lmotrans)
+             if(.not.file_write_ga(lmotrans,g_t)) call errquit
+     &         (pname//' ibo: could not write lmotrans',1, DISK_ERR)
+
+             if (debug) write (luout,*)
+     &         pname//': ibo lmotrans written'
+
+             if (.not. ga_destroy(g_t)) call errquit(
+     &         pname//' ibo: error destroying g_t',1, GA_ERR)
+
+           end if ! save lmotrans for occ MOs
+
+         end do ! ispin
+
+         if (.not. ga_destroy(g_smat)) call errquit(
+     &     pname//' ibo: error destroying g_smat',1, GA_ERR)
+         if (.not. ga_destroy(g_sc0)) call errquit(
+     &     pname//' ibo: error destroying g_sc0',1, GA_ERR)
 
        end if ! loctype
 
@@ -602,11 +748,16 @@ c     clean up
 c     --------
 
 
-      if (.not.ga_destroy(g_movecs(1))) call 
-     &    errquit('loc_driver: ga_destroy failed g_movecs',0,GA_ERR)
+      if (.not.ga_destroy(g_movecs(1))) call
+     &  errquit(pname//': ga_destroy failed g_movecs',0,GA_ERR)
+
+      if (nspin.eq.2) then
+        if (.not.ga_destroy(g_movecs(2))) call
+     &    errquit(pname//': ga_destroy failed g_movecs-2',0,GA_ERR)
+      end if
 
       if (.not.ma_chop_stack(l_occ)) call
-     &   errquit('loc_driver: ma_chop_stack failed k_occ',l_occ,MA_ERR)
+     &   errquit(pname//': ma_chop_stack failed k_occ',l_occ,MA_ERR)
 
       call schwarz_tidy()
       call int_terminate()

--- a/src/property/localization_driver.F
+++ b/src/property/localization_driver.F
@@ -374,12 +374,13 @@ c          (occ-occ transformation only)
      &           UNKNOWN_ERR)
              end if
 
-             call util_file_name(filename,.true.,.true.,lmotrans)
+             call util_file_name(filename,.false.,.false.,lmotrans)
              if(.not.file_write_ga(lmotrans,g_t)) call errquit
      &         (pname//' pmloc: could not write lmotrans',1, DISK_ERR)
 
-             if (debug) write (luout,*)
-     &         pname//': pmloc lmotrans written'
+             if (master) write (luout,'(1x,a/1x,a)')
+     &         'PM transformation (occ.) written to file ',
+     &         trim(lmotrans)
 
              if (.not. ga_destroy(g_t)) call errquit(
      &         pname//' pmloc: error destroying g_t',1, GA_ERR)
@@ -710,12 +711,13 @@ c          (occ-occ transformation only)
      &           UNKNOWN_ERR)
              end if
 
-             call util_file_name(filename,.true.,.true.,lmotrans)
+             call util_file_name(filename,.false.,.false.,lmotrans)
              if(.not.file_write_ga(lmotrans,g_t)) call errquit
      &         (pname//' ibo: could not write lmotrans',1, DISK_ERR)
 
-             if (debug) write (luout,*)
-     &         pname//': ibo lmotrans written'
+             if (master) write (luout,'(1x,a/1x,a)')
+     &         'IBO transformation (occ.) written to file ',
+     &         trim(lmotrans)
 
              if (.not. ga_destroy(g_t)) call errquit(
      &         pname//' ibo: error destroying g_t',1, GA_ERR)
@@ -769,7 +771,7 @@ c     Localization done. return
 c     ---------------------------------------
       
       if (oprint) then
-        write (LuOut,*) 'Exiting Localization driver routine'
+        write (LuOut,'(/1x,a)') 'Exiting Localization driver routine'
       endif
 
 c     ==================================================================

--- a/src/property/pm_localization.F
+++ b/src/property/pm_localization.F
@@ -65,13 +65,6 @@ c     local variables:
       parameter (small=1d-8)
 
       double precision minval, swap
-c      integer l_val, k_val
-
-c$$$      logical int_normalize
-c$$$      external int_normalize
-c$$$
-c$$$      integer ga_create_atom_blocked
-c$$$      external ga_create_atom_blocked
 
       character*(15) pname
 
@@ -153,9 +146,6 @@ c     the Fock matrix was diagonal in the basis of input MOs.
           s = iloc(ss)
           eval(s) = c(s,2)
         end do
-
-c       write(6,*) 'transformed the MO energies'
-c       write(6,*) (eval(t), t = 1,nloc)
 
         do ss = 1, nloc -1
           s = iloc(ss)

--- a/src/property/pm_localization.F
+++ b/src/property/pm_localization.F
@@ -1,0 +1,256 @@
+
+      subroutine pm_localization(rtdb, geom, ltyp, basis, g_c,
+     &  g_sc, g_sc0,
+     &  nocc, nvir, nmo, nbf, natoms, eval, occ, c, sc, iloc, pop, list,
+     &  ispin,nspin)
+
+c     =================================================================
+c     set up Pipek-Mezey localization
+
+c     g_c, g_sc, g_sc0 and arrays occ and eval are for the MOs of a
+c     given spin (alpha or beta)
+
+c     The localization routine called from here is in
+c     src/ddscf/localize.F
+c     The PM localization code was already available there, but is
+c     now interfaced more cleanly with the property code, and we added
+c     the LMO sorting, support for spin-unrestricted SCF
+
+c     =================================================================
+
+      implicit none
+
+#include "errquit.fh"
+#include "mafdecls.fh"
+#include "global.fh"
+#include "msgids.fh"
+#include "geom.fh"
+#include "rtdb.fh"
+#include "bas.fh"
+#include "util.fh"
+#include "stdio.fh"
+#include "apiP.fh"
+#include "prop.fh"
+#include "bgj.fh"
+
+
+c     subroutine arguments:
+
+      integer rtdb, geom, basis
+      character*(3) ltyp
+      integer g_c, g_sc, g_sc0
+      integer nocc, nvir, nmo, nbf, natoms
+      double precision eval(nbf), occ(nbf), c(nbf,2), sc(nbf,2)
+      double precision pop(natoms)
+      integer list(natoms)
+      integer iloc(nmo)
+      integer ispin, nspin
+
+c     local GA handles:
+
+      integer g_t
+
+c     local variables:
+
+      logical master, debug
+      integer dbg, info
+
+      integer ncore, nloc
+
+      integer s, ss, nlist, a, i, t, tt, u, bflo, bfhi
+
+      double precision tmp, qas
+
+      double precision small
+      parameter (small=1d-8)
+
+      double precision minval, swap
+c      integer l_val, k_val
+
+c$$$      logical int_normalize
+c$$$      external int_normalize
+c$$$
+c$$$      integer ga_create_atom_blocked
+c$$$      external ga_create_atom_blocked
+
+      character*(15) pname
+
+c     =================================================================
+
+      pname = 'pm_localization'
+
+      dbg = 0
+      master =  ga_nodeid().eq.0
+      debug = (dbg>0) .and. master ! .true. during development
+
+      if (ltyp.ne.'occ' .and. ltyp.ne.'vir')  call errquit
+     &     (pname//': loc. type unknown', 0, BASIS_ERR)
+
+      if(debug) then
+        if (ltyp.eq.'occ') write (luout,*)
+     &       'entering occupied PM localization'
+        if (ltyp.eq.'vir') write (luout,*)
+     &    'entering virtual PM localization'
+      end if
+
+      if (.not. geom_num_core(rtdb, geom, 'ddscf', ncore)) ncore = 0
+
+      if (debug) write (luout,*) 'ncore = ',ncore
+
+      if (ltyp.eq.'occ') then
+
+c       localize the occupied MOs
+        do i = 1, nocc
+          iloc(i) = i
+        end do
+        nloc = nocc
+
+        call localizePM(basis, c, sc,
+     &    nloc, iloc, nbf, nmo, g_c, g_sc)
+
+
+      else if (ltyp.eq.'vir') then
+
+        do i = nocc+1, nmo
+          iloc(i-nocc) = i
+        end do
+        nloc = nmo - nocc
+
+        if(nloc.ne.nvir) call errquit(
+     &    pname//': error nloc.ne.nvir',
+     &    nloc-nvir, UNKNOWN_ERR)
+
+        call localizePM(basis, c, sc,
+     &    nloc, iloc, nbf, nmo, g_c, g_sc)
+
+
+      end if ! ltyp?
+
+c     calculate the localization transform
+
+      if (.not. ga_create(MT_DBL, nmo, nmo, 'loc:trans',
+     &  nloc, 0, g_t)) call errquit(pname//': g_t',1, GA_ERR)
+
+      call ga_dgemm('t', 'n', nmo, nmo, nbf,
+     &  1.0d0, g_sc0, g_c, 0.0d0, g_t)
+
+c     transform MO energies, then sort the localized MOs. We assume that
+c     the Fock matrix was diagonal in the basis of input MOs.
+
+      if (ga_nodeid().eq.0) then
+
+        do tt = 1,nloc
+          t = iloc(tt)
+          call ga_get(g_t, 1, nloc, t, t, c(1,1), 1)
+          tmp = 0.0d0
+          do ss = 1,nloc
+            s = iloc(ss)
+            tmp = tmp + eval(s) * c(s,1)**2
+          end do ! s
+          c(t,2) = tmp ! transformed MO energies
+        end do ! t
+        do ss = 1,nloc
+          s = iloc(ss)
+          eval(s) = c(s,2)
+        end do
+
+c       write(6,*) 'transformed the MO energies'
+c       write(6,*) (eval(t), t = 1,nloc)
+
+        do ss = 1, nloc -1
+          s = iloc(ss)
+          minval = eval(s)
+c         find lowest eval(u) below eval(s)
+          u = 0
+          do tt = ss+1, nloc
+            t = iloc(tt)
+            if (eval(t).lt.minval) then
+              u = t
+              minval = eval(t)
+            end if
+          end do
+c         if u > 0 we swap s and t
+          if (u.ne.0) then
+c           swap orbital energies
+            swap = eval(s)
+            eval(s) = eval(u)
+            eval(u) = swap
+c           swap LMOs
+            call ga_get(g_c, 1, nbf, s,   s, c(1,1), 1)
+            call ga_get(g_c, 1, nbf, u,   u, c(1,2), 1)
+            call ga_put(g_c, 1, nbf, s,   s, c(1,2), 1)
+            call ga_put(g_c, 1, nbf, u,   u, c(1,1), 1)
+c           swap corresponding SC columns
+            call ga_get(g_sc, 1, nbf, s,  s, c(1,1), 1)
+            call ga_get(g_sc, 1, nbf, u,  u, c(1,2), 1)
+            call ga_put(g_sc, 1, nbf, s,  s, c(1,2), 1)
+            call ga_put(g_sc, 1, nbf, u,  u, c(1,1), 1)
+c           swap columns of LMO transformation
+            call ga_get(g_t, 1, nloc, s,  s, c(1,1), 1)
+            call ga_get(g_t, 1, nloc, u,  u, c(1,2), 1)
+            call ga_put(g_t, 1, nloc, s,  s, c(1,2), 1)
+            call ga_put(g_t, 1, nloc, u,  u, c(1,1), 1)
+          end if
+        end do ! ss
+
+      end if ! ga_nodeid.eq.0
+
+      call ga_sync
+
+      if (.not. ga_destroy(g_t)) call errquit(
+     &  pname//': error destroying g_t',1, GA_ERR)
+
+c     Analyze localization of each mo:
+c     per lmo, a list of atomic populations is printed
+c     in decreasing magnitude, with the populations in parentheses.
+
+      if (ga_nodeid() .eq. 0) then
+         write(luout,*)
+         do ss = 1, nloc
+            s = iloc(ss)
+            call ga_get(g_c,  1, nbf, s, s, c(1,1), 1)
+            call ga_get(g_sc, 1, nbf, s, s,sc(1,1), 1)
+            nlist = 0
+            do a = 1, natoms
+               if (.not. bas_ce2bfr(basis, a, bflo, bfhi))
+     &              call errquit(pname//': basis ', 0,
+     &       BASIS_ERR)
+               qas  = 0.0d0
+               do u = bflo, bfhi
+                  qas  = qas  + c(u,1)*sc(u,1)
+               end do
+               if (abs(qas) .gt. 0.01d0) then
+                  nlist = nlist + 1
+                  list(nlist) = a
+                  pop(nlist) = qas
+               end if
+            end do
+            do u = 1, nlist
+               do t = 1, u-1
+                  if (abs(pop(t)).lt.abs(pop(u))) then
+                     tmp = pop(u)
+                     pop(u) = pop(t)
+                     pop(t) = tmp
+                     tt = list(u)
+                     list(u) = list(t)
+                     list(t) = tt
+                  end if
+               end do
+            end do
+
+            write(luout,9002) s, eval(s),
+     &        occ(s),(list(a), pop(a), a=1,nlist)
+ 9002       format(i5, 1x, f14.6,1x, f5.3, 1x,100(2x,i4,'(',f5.2,')'))
+          end do
+          write(luout,*)
+         call util_flush(6)
+      end if
+c
+      call ga_sync
+
+      return
+
+      end
+
+
+

--- a/src/property/prop_input.F
+++ b/src/property/prop_input.F
@@ -332,7 +332,7 @@ c ... jochen: localization input
             if (inp_i(itmp)) then ! localization option
               loc_opt = itmp
             end if
-          else ! default is PM
+          else ! default is PM loc. for the occupied set
             loc_pm = 0
             loc_opt = 0
           end if

--- a/src/property/prp.F
+++ b/src/property/prp.F
@@ -121,7 +121,8 @@ c
 c
 c     ----- dipole moment -----
 c
-      if(nodip.eq.0.or.nopmloc.eq.0.or.noboysloc.eq.0.or.nodpl.eq.0) 
+      if(nodip.eq.0.or.nopmloc.eq.0.or.noboysloc.eq.0.or.noiboloc.eq.0
+     &  .or.nodpl.eq.0) 
      &  call hnd_mtpole(rtdb,basis,geom,1)
 c
 c     ----- quadrupole moment -----


### PR DESCRIPTION
IBO and Pipek-Mezey localization now works for occupied and virtuals in spin-restricted and spin-unrestricted calculations. New example jobs were added in QA. 