### PR TITLE
minor cleanup after pull request #925 was merged into nwchem

### DIFF
--- a/QA/tests/localize-ibo-aa/localize-ibo-aa.out
+++ b/QA/tests/localize-ibo-aa/localize-ibo-aa.out
@@ -1,5 +1,4 @@
-running on 6 processors
- argument  1 = acrylic-acid.nw
+ argument  1 = /home/workspace/jochena/nwchem/loc-bugfix/QA/tests/localize-ibo-aa/localize-ibo-aa.nw
  
 
 
@@ -80,9 +79,7 @@ property
  localization ibo 2
 end
 
-#task scf energy
 task scf property
-
 
 
 ================================================================================
@@ -92,7 +89,7 @@ task scf property
                                          
  
  
-             Northwest Computational Chemistry Package (NWChem) 7.2.0
+             Northwest Computational Chemistry Package (NWChem) 7.2.1
              --------------------------------------------------------
  
  
@@ -126,20 +123,20 @@ task scf property
            ---------------
 
     hostname        = ja04
-    program         = /home/workspace/jochena/nwchem/github-fork-ibovir-devel/bin/LINUX64/nwchem
-    date            = Tue Feb 14 12:19:49 2023
+    program         = /home/workspace/jochena/nwchem/loc-bugfix/bin/LINUX64/nwchem
+    date            = Wed Jan  3 09:35:21 2024
 
-    compiled        = Tue_Feb_14_12:19:44_2023
-    source          = /home/workspace/jochena/nwchem/github-fork-ibovir-devel
-    nwchem branch   = 7.2.0
-    nwchem revision = nwchem_on_git-4622-g8f291f7cfd
+    compiled        = Wed_Jan_03_09:30:30_2024
+    source          = /home/workspace/jochena/nwchem/loc-bugfix
+    nwchem branch   = 7.2.1
+    nwchem revision = nwchem_on_git-5270-g7a744690ee
     ga revision     = 5.8.0
     use scalapack   = F
-    input           = acrylic-acid.nw
+    input           = /home/workspace/jochena/nwchem/loc-bugfix/QA/tests/localize-ibo-aa/localize-ibo-aa.nw
     prefix          = testjob.
     data base       = ./testjob.db
     status          = startup
-    nproc           =        5
+    nproc           =        7
     time left       =     -1s
 
 
@@ -147,10 +144,10 @@ task scf property
            Memory information
            ------------------
 
-    heap     =    6553598 doubles =     50.0 Mbytes
-    stack    =    6553595 doubles =     50.0 Mbytes
-    global   =   13107200 doubles =    100.0 Mbytes (distinct from heap & stack)
-    total    =   26214393 doubles =    200.0 Mbytes
+    heap     =      6553594 doubles =       50.0 Mbytes
+    stack    =      6553599 doubles =       50.0 Mbytes
+    global   =     13107200 doubles =      100.0 Mbytes (distinct from heap & stack)
+    total    =     26214393 doubles =      200.0 Mbytes
     verify   = yes
     hardfail = no 
 
@@ -159,7 +156,7 @@ task scf property
            ---------------------
  
   0 permanent = .
-  0 scratch   = /tmp
+  0 scratch   = .
  
  
  
@@ -267,7 +264,7 @@ task scf property
 
   library name resolved from: environment
   library file name is: <
- /home/workspace/jochena/nwchem/github-fork-ibovir-devel/src/basis/libraries/>
+ /home/workspace/jochena/nwchem/loc-bugfix/src/basis/libraries/>
   
 
 
@@ -280,7 +277,7 @@ task scf property
 
   library name resolved from: environment
   library file name is: <
- /home/workspace/jochena/nwchem/github-fork-ibovir-devel/src/basis/libraries/>
+ /home/workspace/jochena/nwchem/loc-bugfix/src/basis/libraries/>
   
                       Basis "iao basis" -> "" (spherical)
                       -----
@@ -471,7 +468,7 @@ task scf property
 
 
 
- Forming initial guess at       0.0s
+ Forming initial guess at       0.1s
 
  
       Superposition of Atomic Density Guess
@@ -489,7 +486,7 @@ task scf property
  LUMO         =      -0.055429
  
 
- Starting SCF solution at       0.1s
+ Starting SCF solution at       0.2s
 
 
 
@@ -504,22 +501,22 @@ task scf property
 
               iter       energy          gnorm     gmax       time
              ----- ------------------- --------- --------- --------
-                 1     -265.3310324443  1.42D+00  2.92D-01      0.1
-                 2     -265.4360577045  4.13D-01  8.78D-02      0.2
-                 3     -265.4514376314  3.64D-02  9.22D-03      0.4
-                 4     -265.4516512505  1.03D-03  2.34D-04      0.6
+                 1     -265.3310324443  1.42D+00  2.92D-01      0.2
+                 2     -265.4360577045  4.13D-01  8.78D-02      0.3
+                 3     -265.4514376314  3.64D-02  9.22D-03      0.5
+                 4     -265.4516512505  1.03D-03  2.34D-04      0.7
                  5     -265.4516513711  7.80D-06  1.92D-06      0.9
 
 
        Final RHF  results 
        ------------------ 
 
-         Total SCF energy =   -265.451651371050
+         Total SCF energy =   -265.451651371051
       One-electron energy =   -682.442839763841
       Two-electron energy =    255.473969802116
  Nuclear repulsion energy =    161.517218590675
 
-        Time for solution =      0.9s
+        Time for solution =      0.7s
 
 
              Final eigenvalues
@@ -560,7 +557,7 @@ task scf property
                        -------------------------------------
  
  Vector    6  Occ=2.000000D+00  E=-1.441125D+00
-              MO Center= -1.1D+00,  2.6D-02, -2.1D-17, r^2= 1.2D+00
+              MO Center= -1.1D+00,  2.6D-02,  7.5D-17, r^2= 1.2D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     58      0.413566  5 O  s                 30      0.293845  3 C  s          
@@ -568,7 +565,7 @@ task scf property
     57      0.208468  5 O  s                 45      0.150994  4 O  s          
  
  Vector    7  Occ=2.000000D+00  E=-1.338769D+00
-              MO Center= -9.1D-01, -4.1D-01,  6.6D-17, r^2= 1.4D+00
+              MO Center= -9.1D-01, -4.1D-01, -5.3D-17, r^2= 1.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     44      0.424994  4 O  s                 58     -0.352816  5 O  s          
@@ -577,7 +574,7 @@ task scf property
     57     -0.176450  5 O  s          
  
  Vector    8  Occ=2.000000D+00  E=-1.070923D+00
-              MO Center=  1.1D+00,  2.8D-01,  3.4D-17, r^2= 1.5D+00
+              MO Center=  1.1D+00,  2.8D-01,  1.6D-17, r^2= 1.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     16      0.400200  2 C  s                  2      0.337172  1 C  s          
@@ -585,7 +582,7 @@ task scf property
     17      0.160365  2 C  s          
  
  Vector    9  Occ=2.000000D+00  E=-8.974613D-01
-              MO Center=  2.3D-01,  2.6D-01, -1.0D-16, r^2= 3.3D+00
+              MO Center=  2.3D-01,  2.6D-01, -3.0D-17, r^2= 3.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     30     -0.305983  3 C  s                  2      0.303431  1 C  s          
@@ -594,7 +591,7 @@ task scf property
      1     -0.152955  1 C  s          
  
  Vector   10  Occ=2.000000D+00  E=-7.642057D-01
-              MO Center=  1.6D-01,  3.0D-01,  5.3D-16, r^2= 4.1D+00
+              MO Center=  1.6D-01,  3.0D-01,  1.4D-16, r^2= 4.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     60      0.316925  5 O  px                16     -0.241192  2 C  s          
@@ -604,7 +601,7 @@ task scf property
      4      0.156757  1 C  px                71      0.155748  6 H  s          
  
  Vector   11  Occ=2.000000D+00  E=-7.114488D-01
-              MO Center=  2.7D-01,  9.8D-03, -3.3D-16, r^2= 3.1D+00
+              MO Center=  2.7D-01,  9.8D-03, -2.5D-16, r^2= 3.1D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     19      0.248395  2 C  py                81      0.212079  8 H  s          
@@ -614,7 +611,7 @@ task scf property
     44      0.168207  4 O  s                 46     -0.165171  4 O  px         
  
  Vector   12  Occ=2.000000D+00  E=-6.942998D-01
-              MO Center= -5.7D-01, -1.8D-01, -2.1D-16, r^2= 3.0D+00
+              MO Center= -5.7D-01, -1.8D-01, -7.4D-17, r^2= 3.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     61      0.332130  5 O  py                47     -0.285481  4 O  py         
@@ -624,7 +621,7 @@ task scf property
     33      0.150516  3 C  py         
  
  Vector   13  Occ=2.000000D+00  E=-6.290129D-01
-              MO Center= -9.9D-01,  1.2D-01, -3.2D-16, r^2= 1.6D+00
+              MO Center= -9.9D-01,  1.2D-01,  4.4D-16, r^2= 1.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     62      0.438625  5 O  pz                65      0.308876  5 O  pz         
@@ -632,7 +629,7 @@ task scf property
     51      0.167682  4 O  pz                37      0.158757  3 C  pz         
  
  Vector   14  Occ=2.000000D+00  E=-6.234118D-01
-              MO Center=  8.0D-01,  1.3D-02,  4.5D-16, r^2= 3.8D+00
+              MO Center=  8.0D-01,  1.3D-02, -4.6D-16, r^2= 3.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      4      0.334286  1 C  px                76      0.262842  7 H  s          
@@ -641,7 +638,7 @@ task scf property
     18     -0.161739  2 C  px         
  
  Vector   15  Occ=2.000000D+00  E=-5.982438D-01
-              MO Center= -2.3D-02,  2.4D-01, -3.8D-17, r^2= 3.5D+00
+              MO Center= -2.3D-02,  2.4D-01, -8.4D-17, r^2= 3.5D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     61      0.305744  5 O  py                18      0.273635  2 C  px         
@@ -651,7 +648,7 @@ task scf property
     33     -0.180575  3 C  py                71     -0.170295  6 H  s          
  
  Vector   16  Occ=2.000000D+00  E=-5.496397D-01
-              MO Center=  1.1D+00,  6.0D-02,  3.0D-16, r^2= 3.3D+00
+              MO Center=  1.1D+00,  6.0D-02,  5.2D-17, r^2= 3.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      5      0.298431  1 C  py                71     -0.271981  6 H  s          
@@ -660,7 +657,7 @@ task scf property
     33      0.163556  3 C  py                61     -0.150120  5 O  py         
  
  Vector   17  Occ=2.000000D+00  E=-4.889073D-01
-              MO Center= -9.0D-01, -2.5D-01, -5.3D-16, r^2= 2.0D+00
+              MO Center= -9.0D-01, -2.5D-01, -2.7D-16, r^2= 2.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     62     -0.430815  5 O  pz                48      0.407766  4 O  pz         
@@ -668,7 +665,7 @@ task scf property
     34      0.166236  3 C  pz         
  
  Vector   18  Occ=2.000000D+00  E=-4.582158D-01
-              MO Center= -5.2D-01, -7.3D-01, -1.6D-16, r^2= 1.9D+00
+              MO Center= -5.2D-01, -7.3D-01,  1.5D-18, r^2= 1.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     46      0.549426  4 O  px                49      0.417524  4 O  px         
@@ -676,7 +673,7 @@ task scf property
     64     -0.174821  5 O  py                18      0.151160  2 C  px         
  
  Vector   19  Occ=2.000000D+00  E=-4.009704D-01
-              MO Center=  1.1D+00,  1.5D-01, -4.1D-16, r^2= 2.0D+00
+              MO Center=  1.1D+00,  1.5D-01,  2.8D-16, r^2= 2.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     20      0.384445  2 C  pz                 6      0.352495  1 C  pz         
@@ -684,7 +681,7 @@ task scf property
     48     -0.214439  4 O  pz                51     -0.173233  4 O  pz         
  
  Vector   20  Occ=0.000000D+00  E= 9.067747D-02
-              MO Center=  8.9D-01,  1.5D-02,  9.9D-17, r^2= 3.0D+00
+              MO Center=  8.9D-01,  1.5D-02,  1.4D-16, r^2= 3.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      9      0.621145  1 C  pz                23     -0.459696  2 C  pz         
@@ -694,7 +691,7 @@ task scf property
     65      0.155474  5 O  pz         
  
  Vector   21  Occ=0.000000D+00  E= 1.933962D-01
-              MO Center= -2.6D+00,  1.3D-01,  2.0D-16, r^2= 2.6D+00
+              MO Center= -2.6D+00,  1.3D-01, -3.8D-16, r^2= 2.6D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     87      1.532433  9 H  s                 17     -0.762684  2 C  s          
@@ -704,7 +701,7 @@ task scf property
     60      0.181785  5 O  px                 3      0.180050  1 C  s          
  
  Vector   22  Occ=0.000000D+00  E= 1.990748D-01
-              MO Center=  2.4D+00,  1.2D+00,  5.2D-17, r^2= 4.4D+00
+              MO Center=  2.4D+00,  1.2D+00,  7.7D-17, r^2= 4.4D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      3      1.857859  1 C  s                 77     -1.791874  7 H  s          
@@ -714,7 +711,7 @@ task scf property
      8      0.218519  1 C  py                35      0.169789  3 C  px         
  
  Vector   23  Occ=0.000000D+00  E= 2.314259D-01
-              MO Center=  1.7D+00, -2.0D-01,  9.0D-16, r^2= 6.0D+00
+              MO Center=  1.7D+00, -2.0D-01, -1.4D-15, r^2= 6.0D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
      3      1.936960  1 C  s                 72     -1.805329  6 H  s          
@@ -723,7 +720,7 @@ task scf property
      8     -0.489914  1 C  py                 5     -0.154259  1 C  py         
  
  Vector   24  Occ=0.000000D+00  E= 2.626515D-01
-              MO Center=  1.3D-01, -2.5D-02,  7.6D-16, r^2= 2.9D+00
+              MO Center=  1.3D-01, -2.5D-02,  3.0D-15, r^2= 2.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     37     -0.804941  3 C  pz                23      0.756689  2 C  pz         
@@ -733,7 +730,7 @@ task scf property
     62      0.158924  5 O  pz         
  
  Vector   25  Occ=0.000000D+00  E= 2.688800D-01
-              MO Center=  1.9D+00,  3.8D-01, -1.8D-15, r^2= 6.9D+00
+              MO Center=  1.9D+00,  3.8D-01, -1.9D-16, r^2= 6.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     77     -1.706163  7 H  s                 72      1.689090  6 H  s          
@@ -743,7 +740,7 @@ task scf property
     87     -0.319009  9 H  s                  3     -0.288918  1 C  s          
  
  Vector   26  Occ=0.000000D+00  E= 3.855495D-01
-              MO Center= -4.6D-01, -2.3D-01, -1.7D-16, r^2= 3.7D+00
+              MO Center= -4.6D-01, -2.3D-01, -1.3D-15, r^2= 3.7D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     31      4.026240  3 C  s                 45     -1.439431  4 O  s          
@@ -753,7 +750,7 @@ task scf property
     50     -0.560923  4 O  py                82     -0.528079  8 H  s          
  
  Vector   27  Occ=0.000000D+00  E= 4.475195D-01
-              MO Center=  5.8D-01,  2.5D-01,  3.4D-16, r^2= 3.9D+00
+              MO Center=  5.8D-01,  2.5D-01,  3.0D-16, r^2= 3.9D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     21      3.533345  2 C  px                 3     -2.731556  1 C  s          
@@ -763,7 +760,7 @@ task scf property
      7      0.878572  1 C  px                30      0.524028  3 C  s          
  
  Vector   28  Occ=0.000000D+00  E= 4.523376D-01
-              MO Center=  1.5D+00, -1.4D-01, -3.7D-16, r^2= 4.3D+00
+              MO Center=  1.5D+00, -1.4D-01,  5.7D-17, r^2= 4.3D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     17      6.048068  2 C  s                  3     -4.672145  1 C  s          
@@ -773,7 +770,7 @@ task scf property
     59     -0.983223  5 O  s                 36      0.975052  3 C  py         
  
  Vector   29  Occ=0.000000D+00  E= 4.789847D-01
-              MO Center=  2.6D-01,  3.3D-01,  2.1D-18, r^2= 3.8D+00
+              MO Center=  2.6D-01,  3.3D-01, -2.4D-17, r^2= 3.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     17      2.858248  2 C  s                  3     -2.090889  1 C  s          
@@ -783,7 +780,7 @@ task scf property
     35      0.814942  3 C  px                63      0.614144  5 O  px         
  
  Vector   30  Occ=0.000000D+00  E= 5.702926D-01
-              MO Center=  1.4D+00,  5.8D-01, -1.9D-15, r^2= 2.8D+00
+              MO Center=  1.4D+00,  5.8D-01,  4.7D-15, r^2= 2.8D+00
    Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
   ----- ------------  ---------------      ----- ------------  ---------------
     17      2.332617  2 C  s                 31     -1.303425  3 C  s          
@@ -831,9 +828,9 @@ task scf property
  
      2   2 0 0    -15.439146      0.000000    246.890742
      2   1 1 0      0.077897      0.000000      0.000002
-     2   1 0 1      0.000000      0.000000      0.000000
+     2   1 0 1     -0.000000      0.000000      0.000000
      2   0 2 0    -24.880694      0.000000     90.697964
-     2   0 1 1     -0.000000      0.000000      0.000000
+     2   0 1 1      0.000000      0.000000      0.000000
      2   0 0 2    -22.450650      0.000000      0.000000
  
 
@@ -866,7 +863,7 @@ task scf property
               6   2.1555070209   1.5083589529    8.63D-05
               7   2.1555070209   1.5083589538    6.36D-06
               8   2.1555070209   1.5083589538    9.22D-08
-              9   2.1555070209   1.5083589538    3.73D-09
+              9   2.1555070209   1.5083589538    5.27D-09
 
  IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
  should be zero, for IBOs in the IAO basis
@@ -910,17 +907,16 @@ task scf property
 
            iter   Max. delocal   Mean delocal    Converge
            ----   ------------   ------------    --------
-              1   5.7963239473   4.2732750386    0.00D+00
-              2   2.4941110119   2.1820228090    7.23D-01
-              3   2.1364906389   1.9920797446    4.32D-01
-              4   2.1348072188   1.9904017968    1.39D-01
-              5   2.1348013497   1.9903805756    9.02D-03
-              6   2.1348017491   1.9903804736    7.84D-04
-              7   2.1348017624   1.9903804751    5.13D-05
-              8   2.1348017624   1.9903804751    3.41D-06
-              9   2.1348017624   1.9903804751    2.26D-07
-             10   2.1348017624   1.9903804751    1.34D-08
-             11   2.1348017624   1.9903804751    5.27D-09
+              1   7.4855751970   4.3168336458    0.00D+00
+              2   2.3398085416   2.0873841008    7.55D-01
+              3   2.1346570467   1.9908868937    3.58D-01
+              4   2.1348158454   1.9903813928    2.36D-02
+              5   2.1348018590   1.9903804763    1.30D-03
+              6   2.1348017645   1.9903804752    8.92D-05
+              7   2.1348017626   1.9903804751    5.81D-06
+              8   2.1348017626   1.9903804751    3.87D-07
+              9   2.1348017626   1.9903804751    2.53D-08
+             10   2.1348017626   1.9903804751    0.00D+00
 
  IBO loc: largest element in C(MO,T) C(MO) -1:          0.00000000
  should be zero, for IBOs in the IAO basis
@@ -943,9 +939,35 @@ task scf property
  in file locorb.movecs, number 
          20  to         29
 
+ IBO transformation (occ.) written to file 
+ ./testjob.lmotrans
+
  Exiting Localization driver routine
 
- Task  times  cpu:        1.0s     wall:        1.2s
+          -------------
+          Dipole Moment
+          -------------
+
+ Center of charge (in au) is the expansion point
+         X =       0.0000000 Y =      -0.0000000 Z =       0.0000000
+
+   Dipole moment        0.6842748873 A.U.
+             DMX        0.3687094649 DMXEFC        0.0000000000
+             DMY        0.5764420629 DMYEFC        0.0000000000
+             DMZ        0.0000000000 DMZEFC        0.0000000000
+   -EFC- dipole         0.0000000000 A.U.
+   Total dipole         0.6842748873 A.U.
+
+   Dipole moment        1.7392664243 Debye(s)
+             DMX        0.9371730637 DMXEFC        0.0000000000
+             DMY        1.4651806521 DMYEFC        0.0000000000
+             DMZ        0.0000000000 DMZEFC        0.0000000000
+   -EFC- dipole         0.0000000000 DEBYE(S)
+   Total dipole         1.7392664243 DEBYE(S)
+
+ 1 a.u. = 2.541766 Debyes 
+
+ Task  times  cpu:        0.9s     wall:        0.9s
  
  
                                 NWChem Input Module
@@ -967,7 +989,7 @@ MA usage statistics:
 	current number of blocks	         0	         0
 	maximum number of blocks	        22	        14
 	current total bytes		         0	         0
-	maximum total bytes		    139376	  22511288
+	maximum total bytes		    139408	  22511320
 	maximum total K-bytes		       140	     22512
 	maximum total M-bytes		         1	        23
  
@@ -1025,4 +1047,4 @@ MA usage statistics:
    K. Glaesemann, G. Sandrone, M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe,
                                A. T. Wong, Z. Zhang.
 
- Total times  cpu:        1.0s     wall:        1.2s
+ Total times  cpu:        1.0s     wall:        1.0s

--- a/src/property/localization_driver.F
+++ b/src/property/localization_driver.F
@@ -313,7 +313,7 @@ c          save g_sc in g_sc0 to calculate the loc. transform later
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
            else if (loc_opt.eq.1) then
 
@@ -324,7 +324,7 @@ c          save g_sc in g_sc0 to calculate the loc. transform later
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
            else if (loc_opt.eq.2) then
 
@@ -335,7 +335,7 @@ c          save g_sc in g_sc0 to calculate the loc. transform later
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
              ltyp = 'vir'
              call pm_localization(rtdb, geom, ltyp, basis,
@@ -344,7 +344,7 @@ c          save g_sc in g_sc0 to calculate the loc. transform later
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c), dbl_mb(k_sc), int_mb(k_iloc),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
            else
              call errquit(pname//': loc_opt out of range',loc_opt,
@@ -653,7 +653,7 @@ c          the localization transformation later for this spin
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
            else if (loc_opt.eq.1) then
              ltyp = 'vir'
@@ -662,7 +662,7 @@ c          the localization transformation later for this spin
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
            else if(loc_opt.eq.2) then
              ltyp = 'occ'
@@ -671,7 +671,7 @@ c          the localization transformation later for this spin
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
              ltyp = 'vir'
              call ibo_localization(rtdb, geom, ltyp, basis,
@@ -679,7 +679,7 @@ c          the localization transformation later for this spin
      &         dbl_mb(k_eval+(ispin-1)*nbf),
      &         dbl_mb(k_occ+(ispin-1)*nbf),
      &         dbl_mb(k_c),
-     &         dbl_mb(k_pop), int_mb(k_list), ispin, nspin)
+     &         dbl_mb(k_pop), int_mb(k_list))
 
            else
              call errquit(pname//': loc_opt out of range',loc_opt,

--- a/src/property/pm_localization.F
+++ b/src/property/pm_localization.F
@@ -1,8 +1,7 @@
 
-      subroutine pm_localization(rtdb, geom, ltyp, basis, g_c,
-     &  g_sc, g_sc0,
-     &  nocc, nvir, nmo, nbf, natoms, eval, occ, c, sc, iloc, pop, list,
-     &  ispin,nspin)
+      subroutine pm_localization(rtdb, geom, ltyp, basis, g_c, g_sc,
+     &  g_sc0, nocc, nvir, nmo, nbf, natoms, eval, occ, c, sc, iloc,
+     &  pop, list)
 
 c     =================================================================
 c     set up Pipek-Mezey localization
@@ -44,7 +43,6 @@ c     subroutine arguments:
       double precision pop(natoms)
       integer list(natoms)
       integer iloc(nmo)
-      integer ispin, nspin
 
 c     local GA handles:
 


### PR DESCRIPTION
Routine ibo_localization was called from localization_driver with two additional arguments, now removed, that were not used in the routine. Calls to pm_localization had the same two unused arguments removed for consistency. QA test output localize-ibo-aa was updated so the test doesn't fail.