### PR TITLE
xcinp_fact_noloc bugfix

### DIFF
--- a/src/nwdft/input_dft/xc_inp.F
+++ b/src/nwdft/input_dft/xc_inp.F
@@ -4832,6 +4832,9 @@ c
                write(LuOut,*)' total ',funcname(1:inp_strlen(funcname)),
      &              ' is used. '
                goto 1
+            else
+               fact_out=1d0
+               call inp_prev_field()
             endif
          else
             fact_out=1d0


### PR DESCRIPTION
Corrects a bug where the input deck 
```
 xc xr2scan cr2scan
```


leads to no exchange-correlation:
```
              XC Information
              --------------
               r^2SCAN metaGGA Exchange Functional  0.000

          Convergence Information
```

(thanks @amalbavera)