### PR TITLE
Columbus sonadc 7

### DIFF
--- a/src/nwc_columbus/aoints/int_1e_sifs.F
+++ b/src/nwc_columbus/aoints/int_1e_sifs.F
@@ -1,5 +1,5 @@
       subroutine int_1e_sifs(ibas, aoints, energy, nenrgy, nbft,
-     &   nmap,map,imtype,ifmt1,ibvtyp,ibitv,l1rec,n1max,
+     &   nmap,map,imtype,ibvtyp,ibitv,l1rec,n1max,
      &   clab, ninfo, info)
       implicit none
 #include "errquit.fh"
@@ -51,7 +51,7 @@ c
 c     sifs parameters
 c
       integer aoints
-      integer ifmt1, n1max
+      integer n1max
       INTEGER l1rec, ntitle, ibuf, nsym, ibvtyp, ierr
       integer ibitv
       integer mxbf
@@ -426,7 +426,7 @@ cgk debug
 cgk end
       call int_so_sifs(ibas, oskel, aoints, nbft, max1e, mem1, l1rec,
      &  n1max, dbl_mb(k_sifbuf), dbl_mb(k_sifval), ninfo, info, clab,
-     &  fcore, ibvtyp, ibitv, ifmt1)
+     &  fcore, ibvtyp, ibitv)
 
 cgk debug
 !      write(*,*)'gk: calling int_mom_sifs from int_1e_sifs'
@@ -434,7 +434,7 @@ cgk debug
 cgk end
       call int_mom_sifs(ibas, oskel, aoints, nbft, l1rec,
      &  n1max, dbl_mb(k_sifbuf), dbl_mb(k_sifval), ninfo, info, 
-     &  fcore, ibvtyp, ibitv, ifmt1)
+     &  fcore, ibvtyp, ibitv)
 cgk debug
 !      write(*,*)'gk: back from int_so_sifs in int_1e_sifs'
 cgk end

--- a/src/nwc_columbus/aoints/int_2e_sifs.F
+++ b/src/nwc_columbus/aoints/int_2e_sifs.F
@@ -1,5 +1,5 @@
       subroutine int_2e_sifs( geom, basis, tol2e, oskel, aoint2, ninfo, 
-     &    info, ifmt, ibvtyp, ibitv, clabs)
+     &    info, ibvtyp, ibitv, clabs)
 c
       implicit none
 #include "errquit.fh"
@@ -19,7 +19,7 @@ c     arguments
 c     
       integer geom, basis            ! [input] parameter handles
       integer aoint2 
-      integer ninfo, ifmt, ibvtyp
+      integer ninfo, ibvtyp
       integer ibitv
       integer info(ninfo)
       double precision tol2e         ! [input] integral selection threshold
@@ -185,7 +185,7 @@ cgk end
 
          call int_2e_sifs_a( geom, basis, ablklen, tol2e, oskel,
      $        dbl_mb(k_atmp), int_mb(k_block), nblock,  aoint2, ninfo, 
-     &        info, ifmt, ibvtyp, ibitv, clabs)
+     &        info, ibvtyp, ibitv, clabs)
 
 cgk debug
 *     write(*,*)'gk: back from int_2e_sifs_a'

--- a/src/nwc_columbus/aoints/int_2e_sifs_a.F
+++ b/src/nwc_columbus/aoints/int_2e_sifs_a.F
@@ -1,5 +1,5 @@
       subroutine int_2e_sifs_a( geom, basis, ablklen, tol2e, oskel,
-     $     tmp, blocks, nblock, aoint2, ninfo, info, ifmt, ibvtyp, 
+     $     tmp, blocks, nblock, aoint2, ninfo, info, ibvtyp, 
      &     ibitv, clabs)
       implicit none
 #include "errquit.fh"
@@ -52,7 +52,7 @@ c
       external nxtask
       integer l_sifval, l_sifbuf, l2rec, n2max
       integer k_sifval, k_sifbuf 
-      integer ninfo, ifmt, ibvtyp, ibitv, aoint2, nipv, itypea, 
+      integer ninfo, ibvtyp, ibitv, aoint2, nipv, itypea, 
      &          itypeb, wait, nrec, reqnum, ierr, iwait
       integer info(ninfo)
       integer clabs(4,*)
@@ -216,7 +216,7 @@ cgk end
      $                       geom, basis, oskel, iatlo, jatlo, katlo, 
      &                       latlo, iathi, jathi, kathi, lathi, 
      &                       ijk_prev, tmp, tol2e, aoint2, ninfo, info, 
-     &                       ifmt, ibvtyp, dbl_mb(k_sifval), ibitv, 
+     &                       ibvtyp, dbl_mb(k_sifval), ibitv, 
      &                       dbl_mb(k_sifbuf), clabs, int_mb(k_i),
      &                       int_mb(k_j), int_mb(k_k), int_mb(k_l),
      &                       dbl_mb(k_g))

--- a/src/nwc_columbus/aoints/int_2e_sifs_b.F
+++ b/src/nwc_columbus/aoints/int_2e_sifs_b.F
@@ -1,6 +1,6 @@
       subroutine int_2e_sifs_b( basis, tol2e, q4, iat, jat, kat, lat, 
      $     ilo, jlo, klo, llo, ihi, jhi, khi, lhi, aoint2,  ninfo, 
-     $     info, ifmt, ibvtyp, values,  ibitv, buffer, clabs,
+     $     info, ibvtyp, values,  ibitv, buffer, clabs,
      &     ilabs, jlabs, klabs, llabs, eris )
 c     
       implicit none
@@ -39,7 +39,7 @@ c
       double precision sij, smax, denmax
       integer neri
       integer i
-      integer aoint2, ninfo, ifmt, ibvtyp, last, itypea, itypeb,
+      integer aoint2, ninfo, ibvtyp, last, itypea, itypeb,
      &          iwait, nrec, reqnum, ierr, ibitv, nipv
       parameter(nipv=4)
       integer clabs(nipv,*)

--- a/src/nwc_columbus/aoints/int_mom_sifs.F
+++ b/src/nwc_columbus/aoints/int_mom_sifs.F
@@ -1,7 +1,6 @@
       subroutine int_mom_sifs(ibas, oskel, aoints, nbft, 
      &  l1rec, n1max, 
-     &  sifbuf, sifval, ninfo, info, fcore, ibvtyp, ibitv,
-     &  ifmt1)
+     &  sifbuf, sifval, ninfo, info, fcore, ibvtyp, ibitv)
       implicit none
 #include "errquit.fh"
 #include "cint1cache.fh"
@@ -54,7 +53,7 @@ c
 c     sifs parameters
 c
       integer aoints, ierr
-      integer ifmt1, l1rec, n1max
+      integer l1rec, n1max
       integer ibvtyp
       integer ibitv
       integer mxbf

--- a/src/nwc_columbus/aoints/int_so_sifs.F
+++ b/src/nwc_columbus/aoints/int_so_sifs.F
@@ -1,7 +1,6 @@
       subroutine int_so_sifs(ibas, oskel, aoints, nbft, max1e, mem1,
      &  l1rec, n1max, 
-     &  sifbuf, sifval, ninfo, info, clab, fcore, ibvtyp, ibitv,
-     &  ifmt1)
+     &  sifbuf, sifval, ninfo, info, clab, fcore, ibvtyp, ibitv)
       implicit none
 #include "errquit.fh"
 #include "cint1cache.fh"
@@ -54,7 +53,7 @@ c
 c     sifs parameters
 c
       integer aoints, ierr
-      integer ifmt1, l1rec, n1max
+      integer l1rec, n1max
       integer ibvtyp
       integer ibitv
       integer mxbf

--- a/src/nwc_columbus/aoints/rd_d2bl.F
+++ b/src/nwc_columbus/aoints/rd_d2bl.F
@@ -23,7 +23,7 @@ c     # bummer error types.
 c
 c  ##  integer section
 c
-      integer info(ninfmx),itypea,itypeb,ifmt,ibvtyp,ierr,ibitv(1)
+      integer info(ninfmx),itypea,itypeb,ibvtyp,ierr,ibitv(1)
       integer last,labs(4,*)
       integer nbuf
       integer sfile
@@ -48,7 +48,7 @@ cgk debug
 cgk end
       call sifrd2(sfile,   info,   nipv,    iretbv,
      &            buffer,  nbuf,   last,    itypea,
-     &            itypeb,  ifmt,   ibvtyp,  vals,
+     &            itypeb,  ibvtyp, vals,
      &            labs,    ibitv,  ierr)
 cgk debug
 !      write(*,*)'gk: after sifrd2'

--- a/src/nwc_columbus/aoints/sifs_2e_task.F
+++ b/src/nwc_columbus/aoints/sifs_2e_task.F
@@ -2,7 +2,7 @@ cgk be sure int_acc_set is called properly.
 
       subroutine sifs_2e_task( geom, basis, oskel, iatlo, jatlo, 
      &     katlo, latlo, iathi, jathi, kathi, lathi, ijk_prev,
-     $     tmp, tol2e, aoint2, ninfo, info, ifmt, ibvtyp, values, 
+     $     tmp, tol2e, aoint2, ninfo, info, ibvtyp, values, 
      &     ibitv, buffer, clabs, ilabs, jlabs, klabs, llabs, eris )
       implicit none
 #include "errquit.fh"
@@ -36,7 +36,7 @@ c
       logical int2e_set_bf_range
       external int2e_set_bf_range
       integer clabs(4,*)
-      integer aoint2, ninfo, ifmt, ibvtyp, ibitv
+      integer aoint2, ninfo, ibvtyp, ibitv
       integer info(ninfo)
       double precision values(*), buffer(*)
  
@@ -98,7 +98,7 @@ cgk debug
 cgk end
                      call int_2e_sifs_b(basis, tol2e, q4, iat, jat, 
      &                    kat, lat, ilo, jlo, klo, llo, ihi, jhi, khi, 
-     &                    lhi, aoint2, ninfo, info, ifmt, ibvtyp, 
+     &                    lhi, aoint2, ninfo, info, ibvtyp, 
      &                    values, ibitv, buffer, clabs,
      &                    ilabs, jlabs, klabs, llabs, eris)
 *                 end if

--- a/src/nwc_columbus/aoints/wrt_dft_aoints.F
+++ b/src/nwc_columbus/aoints/wrt_dft_aoints.F
@@ -496,7 +496,7 @@ cgk write
       info(6) = ifmt1 ! new for Columbus 7
       call int_1e_sifs(AO_bas_han, aoints, energy, mxengy, 
      &   nbf_ao, nmap, int_mb(k_map),imtype,
-     &   ifmt1, ibvtyp, ibitv, l1rec, n1max, int_mb(k_lab),
+     &   ibvtyp, ibitv, l1rec, n1max, int_mb(k_lab),
      &   ninfo, info)
 
 cgk debug
@@ -526,7 +526,7 @@ cgk end
 
       info(6) = ifmt ! new for Columbus 7
       call int_2e_sifs(geom, AO_bas_han, tol2e, oskel, aoint2, ninfo, 
-     &     info, ifmt, ibvtyp, ibitv, int_mb(k_lab))
+     &     info, ibvtyp, ibitv, int_mb(k_lab))
 
 c
 c     done with memory for sifs files


### PR DESCRIPTION
Removing superfluous references to ifmt and ifmt1, legacy of previous sifs version.