### PR TITLE
slurm fix

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -257,7 +257,7 @@ jobs:
             cc: gcc
             use_libxc: 1
             xcode_version: 15.3
-          - os: macos-14
+          - os: macos-15
             experimental: true 
             mpi_impl: openmpi
             armci_network: MPI-TS
@@ -297,7 +297,7 @@ jobs:
             fc: gfortran-10
             cc: gcc-10
             use_libxc: 1
-          - os: macos-14
+          - os: macos-15
             experimental: true 
             mpi_impl: openmpi
             armci_network: MPI-PR
@@ -328,7 +328,7 @@ jobs:
             fc: gfortran-13
             blas: "accelerate"
             blas_size: 4
-          - os: macos-12
+          - os: macos-13
             experimental: true
             mpi_impl: mpich
             armci_network: MPI-PT
@@ -431,7 +431,7 @@ jobs:
             cc: gcc
             blas: "brew_openblas"
             blas_size: 4
-          - os: macos-14
+          - os: macos-15
             experimental: true
             mpi_impl: openmpi
             armci_network: MPI-TS

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -522,6 +522,10 @@ jobs:
         if: steps.setup-cache.outputs.cache-hit == 'true'
         run: |
           ./travis/cache_fetch.sh
+      - name: get external files
+        if: steps.setup-cache.outputs.cache-hit == 'false'
+        run: |
+          bash ./contrib/getfiles.nwchem ~/cache
       - name: compile
         id: compile
         run: |

--- a/QA/runtests.mpi.unix
+++ b/QA/runtests.mpi.unix
@@ -32,7 +32,7 @@
 export HYDRA_DEBUG=0
 # find memory leaks using  this glibc feature that
 # initialized memory blocks to non-zero values
-if [[ -z "${USE_ASAN}" ]]; then
+if [[ -z "${USE_ASAN}"  ]] && [[ "${FC}" != "flang-new-20"  ]]; then
     export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))
 fi    
 source ./qa_funcs.sh

--- a/contrib/getfiles.nwchem
+++ b/contrib/getfiles.nwchem
@@ -12,4 +12,9 @@ cd $NWCHEM_TOP/src/libext/scalapack
 COMMIT=782e739f8eb0e7f4d51ad7dd23fc1d03dc99d240
 rm -f scalapack-$COMMIT.zip
 curl -L https://github.com/Reference-ScaLAPACK/scalapack/archive/$COMMIT.zip -o scalapack-$COMMIT.zip
-
+#caching
+if [ ! -z "$1" ]; then
+    rsync -av $NWCHEM_TOP/src/nwpw/nwpwlib/nwpwxc/dftd3.tgz "$1"/.
+    rsync -av $NWCHEM_TOP/src/libext/openblas/OpenBLAS*gz "$1"/.
+    rsync -av $NWCHEM_TOP/src/libext/scalapack/scalapack*zip "$1"/.
+fi

--- a/src/util/util_wall_remain.c
+++ b/src/util/util_wall_remain.c
@@ -39,13 +39,8 @@ Integer FATR util_batch_job_time_remaining_(void)
 Integer FATR util_batch_job_time_remaining_(void)
 {
   Integer wallspent=0;
-  uint32_t uval;
-  char *cval;
-  cval = getenv("SLURM_JOBID");
-  if(cval != NULL){
-    sscanf(cval,"%d",&uval);
-    wallspent = (Integer) slurm_get_rem_time(uval);
-  }
+  if (SLURM_VERSION_MAJOR(SLURM_VERSION_NUMBER) >= 23 && SLURM_VERSION_MINOR(SLURM_VERSION_NUMBER) >= 11) slurm_init(NULL);
+  wallspent = (Integer) slurm_get_rem_time(0);
   return ((Integer) wallspent);
 }
 #else

--- a/travis/cache_fetch.sh
+++ b/travis/cache_fetch.sh
@@ -12,3 +12,6 @@ set -v
 	  ls -lart /home/runner/work/nwchem/nwchem/src/libext/mpich/mpich/../../include || true
 	  ls -lart /home/runner/work/nwchem/nwchem/src/libext/include || true
 	  ls -lart /home/runner/work/nwchem/nwchem/src/libext/mpich || true
+	  rsync -av ~/cache/dftd3.tgz src/nwpw/nwpwlib/nwpwxc/. || true
+	  rsync -av ~/cache/OpenBLAS*gz src/libext/openblas/. || true
+          rsync -av ~/cache/scalapack*zip src/libext/scalapack/. || true


### PR DESCRIPTION
`slurm_init()` required for version 23.11 and later  
It fixes the slurm error  
`nwchem: fatal: No hash plugins loaded. Was slurm_init() called before calling any Slurm API functions?`

From the Slurm NEWS file
```
* Changes in Slurm 23.11.1
...
-- Trigger fatal exit when Slurm API function is called before slurm_init() is
    called.
```