### PR TITLE
fix peigs warnings

### DIFF
--- a/src/peigs/ctof/bortho_f.c
+++ b/src/peigs/ctof/bortho_f.c
@@ -118,7 +118,7 @@ void bortho_( n, matB, mapB, m, matZ, mapZ, iwork, work, ort, info)
   if( *n < *m ) {
       fprintf(stderr,
               "Error in routine bortho_. m (=%d) < n (=%d). me = %d \n",
-              *m, *n, me);
+              (int)(*m), (int)(*n), (int)me);
       exit(-1);
   }
   

--- a/src/peigs/ctof/ortho_f.c
+++ b/src/peigs/ctof/ortho_f.c
@@ -113,7 +113,7 @@ void ortho_( n, m, matZ, mapZ, iwork, work, ort, info)
   if( *n < *m ) {
       fprintf(stderr,
               "Error in routine ortho_. m (=%d) < n (=%d). me = %d \n",
-              *m, *n, me);
+              (int)(*m), (int)(*n), (int)me);
       exit(-1);
   }
   

--- a/src/peigs/ctof/pdspev_f.c
+++ b/src/peigs/ctof/pdspev_f.c
@@ -145,7 +145,7 @@ void pdspev_(n, matrixA, mapA, matZ, mapZ, eval, iscratch, iscsize,
       *info = linfo;
     
     fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-             msg, me, -linfo );
+             msg, (int)me, (int)(-linfo) );
     l_exit_( &linfo, msg );
     return;
   }
@@ -156,7 +156,7 @@ void pdspev_(n, matrixA, mapA, matZ, mapZ, eval, iscratch, iscsize,
   if ( *ibuffsz < nvecsA + nvecsZ + 2 ) {
       *info = -10;
       
-      fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, me );
+      fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, (int)me );
       l_exit_( info, msg );
       return;
     }

--- a/src/peigs/ctof/pdspevx_f.c
+++ b/src/peigs/ctof/pdspevx_f.c
@@ -168,7 +168,7 @@ void pdspevx_( ivector, irange, n, matrixA, mapA, lb, ub, ilb, iub, abstol,
 	  *info = linfo;
 	
         fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-                 msg, me, -linfo );
+                 msg, (int)me, (int)(-linfo) );
 	l_exit_( &linfo, msg );
 	return;
    }
@@ -179,7 +179,7 @@ void pdspevx_( ivector, irange, n, matrixA, mapA, lb, ub, ilb, iub, abstol,
     if ( *ibuffsz < nvecsA + nvecsZ + 2 ) {
 	*info = -18;
 	
-        fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, me );
+        fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, (int)me );
 	l_exit_( info, msg );
 	return;
       }

--- a/src/peigs/ctof/pdspgv_f.c
+++ b/src/peigs/ctof/pdspgv_f.c
@@ -157,7 +157,7 @@ void pdspgv_(ifact, n, matrixA, mapA, matrixB, mapB, matZ, mapZ, eval,
        *info = linfo;
      
      fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-              msg, me, -linfo );
+              msg, (int)me, (int)(-linfo) );
      l_exit_( &linfo, msg );
      return;
    }
@@ -169,7 +169,7 @@ void pdspgv_(ifact, n, matrixA, mapA, matrixB, mapB, matZ, mapZ, eval,
     if ( *ibuffsz < (nvecsA + nvecsB + nvecsZ + 3 )) {
 	*info = -10;
 	
-        fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, me );
+        fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, (int)me );
 	l_exit_( info, msg );
 	return;
       }

--- a/src/peigs/ctof/pdspgvx_f.c
+++ b/src/peigs/ctof/pdspgvx_f.c
@@ -177,7 +177,7 @@ void pdspgvx_( ifact, ivector, irange, n, matrixA, mapA, matrixB, mapB,
         *info = linfo;
 
      fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-              msg, me, -linfo );
+              msg, (int)me, (int)(-linfo) );
      l_exit_( &linfo, msg );
      return;
    }
@@ -189,7 +189,7 @@ void pdspgvx_( ifact, ivector, irange, n, matrixA, mapA, matrixB, mapB,
    if ( *ibuffsz < nvecsA + nvecsB + nvecsZ + 3 ) {
       *info = -21;
 
-      fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, me );
+      fprintf( stderr, " %s me = %d ibuffsz is too small. \n", msg, (int)me );
       l_exit_( info, msg );
       return;
    }

--- a/src/peigs/src/c/b_ortho.c
+++ b/src/peigs/src/c/b_ortho.c
@@ -188,7 +188,7 @@ void b_ortho ( n, colB, mapB, m, colZ, mapZ, ibuffptr, iwork, work, ort, info)
   if( *n < *m ) {
       fprintf(stderr,
               "Error in routine b_ortho. m (=%d) < n (=%d). me = %d \n",
-              *m, *n, me);
+              (int)(*m), (int)(*n), (int)me);
       exit(-1);
   }
   

--- a/src/peigs/src/c/ci_entry.c
+++ b/src/peigs/src/c/ci_entry.c
@@ -119,7 +119,7 @@ Integer ci_entry (me, n, i, j, map)
   }
   
   if (map == NULL) {
-    printf(" Peigs: ci_entry_  node %d : Mapping problem\n", *me);
+    printf(" Peigs: ci_entry_  node %d : Mapping problem\n", (int)(*me));
     indx = -5;
     xerbla_("ci_entry\n", &indx);
   }
@@ -142,7 +142,7 @@ Integer ci_entry (me, n, i, j, map)
   }
   
   if ( *i < *j ) {
-    printf("PeIGS: ci_entry_ :node %d : i < j \n", *me);
+    printf("PeIGS: ci_entry_ :node %d : i < j \n", (int)(*me));
     indx = -4;
     xerbla_("ci_entry\n", &indx);
   }
@@ -228,7 +228,7 @@ Integer ci_entry_(me, n, i, j, map)
   }
 
   if (map == NULL) {
-    printf(" Peigs: ci_entry_  node %d : Mapping problem\n", *me);
+    printf(" Peigs: ci_entry_  node %d : Mapping problem\n", (int)(*me));
     indx = -5;
     xerbla_("ci_entry\n", &indx);
   }
@@ -251,7 +251,7 @@ Integer ci_entry_(me, n, i, j, map)
   }
   
   if ( *i < *j ) {
-    printf( "PeIGS: ci_entry_ :node %d : i < j \n", *me);
+    printf( "PeIGS: ci_entry_ :node %d : i < j \n", (int)(*me));
     indx = -4;
     xerbla_("ci_entry\n", &indx);
   }
@@ -318,7 +318,7 @@ Integer ci_size_(me, n, map)
   
   if ( *me > mxnprc_() || *me < 0 ) {
     indx = -1;
-    printf(" Node %d Error in ci_size arg 1 with me = %d mxnprc = %d \n", iam, *me, mxnprc_());
+    printf(" Node %d Error in ci_size arg 1 with me = %d mxnprc = %d \n", (int)iam, (int)(*me), (int)mxnprc_());
     xerbla_("ci_siz\n", &indx);
   }
   
@@ -332,7 +332,7 @@ Integer ci_size_(me, n, map)
   }
   
   if (map == NULL) {
-    printf(" Peigs: ci_size_  node %d : Mapping problem\n", *me);
+    printf(" Peigs: ci_size_  node %d : Mapping problem\n", (int)(*me));
     indx = -3;
     xerbla_("ci_siz\n", &indx);
   }
@@ -393,46 +393,46 @@ Integer fil_mapvec_( me, n, map, mapvec)
 
   if ( me == NULL ) {
     i = -1;
-    printf(" Peigs: fil_mapvec_  node %d : first argument is NULL \n", mxmynd_());
-    printf("me = %d fil_mapvec_  \n", *me);
+    printf(" Peigs: fil_mapvec_  node %d : first argument is NULL \n", (int)mxmynd_());
+    printf("me = %d fil_mapvec_  \n", (int)(*me));
   }
   
   if (( *me > mxnprc_() ) || ( *me < 0 )) {
     i = -1;
-    printf(" Peigs: fil_mapvec_  node %d : first argument %d out of bounds \n", mxmynd_(), *me);
-    printf("fil_mapvec_ %d \n", i);
+    printf(" Peigs: fil_mapvec_  node %d : first argument %d out of bounds \n", (int)mxmynd_(), (int)(*me));
+    printf("fil_mapvec_ %d \n", (int)i);
   }
   
   if ( n == NULL ) {
     i = -2;
-    printf(" Peigs: fil_mapvec_  node %d : 2nd argument is NULL i\n", *me);
-    printf("fil_mapvec_ %d \n", i);
+    printf(" Peigs: fil_mapvec_  node %d : 2nd argument is NULL i\n", (int)(*me));
+    printf("fil_mapvec_ %d \n", (int)i);
   }
   else if ( *n < 1 ) {
     i = -2;
-    printf(" Peigs: fil_mapvec_  node %d : Mapping problem second argument is invalid \n", *me);
-    printf("fil_mapvec_ %d \n", i);
+    printf(" Peigs: fil_mapvec_  node %d : Mapping problem second argument is invalid \n", (int)(*me));
+    printf("fil_mapvec_ %d \n", (int)i);
   }
   
   if (map == NULL) {
-    printf(" Peigs: fil_mapvec_  node %d : Mapping problem\n", *me);
+    printf(" Peigs: fil_mapvec_  node %d : Mapping problem\n", (int)(*me));
     i = -3;
-    printf("fil_mapvec_ %d \n", i);
+    printf("fil_mapvec_ %d \n", (int)i);
   }
   
   iptr = map;
   for ( i = 0 ; i < *n ; i++ )
     if ( (iptr++) == NULL ) {
       i = -3;
-      printf(" Peigs: fil_mapvec_  node %d : 3rd argument error. \n", *me);
-      printf("fil_mapvec_ %d \n", i);
+      printf(" Peigs: fil_mapvec_  node %d : 3rd argument error. \n", (int)(*me));
+      printf("fil_mapvec_ %d \n", (int)i);
     }
   
   if (mapvec == NULL) {
-    printf(" Peigs: fil_mapvec_  node %d : Mapping problem\n", *me);
-    printf(" Peigs: fil_mapvec_  node %d : 4th argument error. \n", *me);
+    printf(" Peigs: fil_mapvec_  node %d : Mapping problem\n", (int)(*me));
+    printf(" Peigs: fil_mapvec_  node %d : 4th argument error. \n", (int)(*me));
     i = -4;
-    printf("fil_mapvec_ %d \n", i);
+    printf("fil_mapvec_ %d \n", (int)i);
   }
   
   
@@ -443,8 +443,8 @@ Integer fil_mapvec_( me, n, map, mapvec)
     if ( *(iptr++) == idummy ) {
       if ( mapvec + k == NULL ) {
         i = -4;
-	printf(" Peigs: fil_mapvec_  node %d : 4th argument error. \n", *me);
-	printf("fil_mapvec_ %d \n", i);
+	printf(" Peigs: fil_mapvec_  node %d : 4th argument error. \n", (int)(*me));
+	printf("fil_mapvec_ %d \n", (int)i);
       }
       mapvec[k] = i;
       k++;

--- a/src/peigs/src/c/clustrfix.c
+++ b/src/peigs/src/c/clustrfix.c
@@ -362,7 +362,7 @@ Integer clustrfix_ (n, d, e, m, w, iblock, nsplit, isplit, num_clustr, clustr_in
   
   jjj =0;
   for ( iii = 0; iii < num_cls; iii++ ) {
-    printf(" cptr c1 %d cn  %d b1 %d bn %d \n", clustr_info[jjj], clustr_info[jjj+1], clustr_info[jjj+2], clustr_info[jjj+3]);
+    printf(" cptr c1 %d cn  %d b1 %d bn %d \n", (int)clustr_info[jjj], (int)clustr_info[jjj+1], (int)clustr_info[jjj+2], (int)clustr_info[jjj+3]);
     jjj += 4;
   }
   

--- a/src/peigs/src/c/exit.c
+++ b/src/peigs/src/c/exit.c
@@ -75,8 +75,8 @@ void g_exit2_( n, array, procmap, len, iwork )
 
   me = mxmynd_ ();
   
-  fprintf(stderr, "G_EXIT2: Node %d Error.  A routine called g_exit2_, \n", me);
-  fprintf(stderr, "Message from calling routine: %s  node id = %d \n", array, me);
+  fprintf(stderr, "G_EXIT2: Node %d Error.  A routine called g_exit2_, \n", (int)me);
+  fprintf(stderr, "Message from calling routine: %s  node id = %d \n", array, (int)me);
 
   mxpend_ ();
 
@@ -148,7 +148,7 @@ void g_exit_( n, array, procmap, len, iwork, work )
   qqsort( proclist, 0, nprocs-1);
   
   if ( nprocs > maxprocs ) {
-    fprintf(stderr, "G_EXIT: Node %d Error: Number of processors in Proc List exceeds number allocated \n", me);
+    fprintf(stderr, "G_EXIT: Node %d Error: Number of processors in Proc List exceeds number allocated \n", (int)me);
     xerbl2_ ( );
     return;
   }
@@ -161,7 +161,7 @@ void g_exit_( n, array, procmap, len, iwork, work )
   
   if ( *n < 0 ) {
     *n = -51;
-    fprintf(stderr, " %s  My node id = %d info = %d (g_exit_) \n", array, me, *n);
+    fprintf(stderr, " %s  My node id = %d info = %d (g_exit_) \n", array, (int)me, (int)(*n));
     /*
       xerbl2_ ( );
       */

--- a/src/peigs/src/c/exit2.c
+++ b/src/peigs/src/c/exit2.c
@@ -58,7 +58,7 @@ void l_exit_ ( info, array )
   
   me = mxmynd_ ();
   
-  fprintf(stderr, " %s  My node id = %d info = %d (l_exit_) \n", array, me, *info);
+  fprintf(stderr, " %s  My node id = %d info = %d (l_exit_) \n", array, (int)me, (int)(*info));
   xerbl2_ ();
   return;
 }

--- a/src/peigs/src/c/inverse.c
+++ b/src/peigs/src/c/inverse.c
@@ -280,7 +280,7 @@ void inverseL ( msize, col, map, iwork, buffer, info)
   
   pxerbla2_( &j, (char *) iscrat, map, msize, iwork + n + 1, &linfo );
   
-  linfo = -abs(linfo);
+  linfo = -labs(linfo);
   
   g_exit_( &linfo, "Mapping problem or memory assignment problem INVERSE \n", map, &n, iwork, buffer );
   

--- a/src/peigs/src/c/memreq.c
+++ b/src/peigs/src/c/memreq.c
@@ -178,7 +178,7 @@ void memreq_(type, n, mapA, mapB, mapZ, isize, rsize, ptr_size, iscratch )
      for ( indx = 0; indx < *n; indx++ ) {
        if ( (iptr++ ) == NULL ) {
          linfo = -4;
-         fprintf(stderr, " me = %d error in mapB in memreq.c \n",me);
+         fprintf(stderr, " me = %d error in mapB in memreq.c \n",(int)me);
          l_exit_(&linfo,msg);
          return;
        }
@@ -194,7 +194,7 @@ void memreq_(type, n, mapA, mapB, mapZ, isize, rsize, ptr_size, iscratch )
    for ( indx = 0; indx < *n; indx++ ) {
      if ( (iptr++ ) == NULL ) {
        linfo = -5;
-       fprintf(stderr, " me = %d error in mapZ in memreq.c \n",me);
+       fprintf(stderr, " me = %d error in mapZ in memreq.c \n",(int)me);
        l_exit_(&linfo,msg);
        return;
      }

--- a/src/peigs/src/c/memreq_f.c
+++ b/src/peigs/src/c/memreq_f.c
@@ -165,7 +165,7 @@ void fmemreq_(type, n, mapA, mapB, mapZ, isize, rsize, ptr_size, iscratch )
     for ( indx = 0; indx < *n; indx++ ) {
       if ( (iptr++ ) == NULL ) {
 	linfo = -4;
-	fprintf(stderr, " me = %d error in mapB in fmemreq.c \n", me);
+	fprintf(stderr, " me = %d error in mapB in fmemreq.c \n", (int)me);
 	l_exit_(&linfo,msg);
 	return;
       }
@@ -181,7 +181,7 @@ void fmemreq_(type, n, mapA, mapB, mapZ, isize, rsize, ptr_size, iscratch )
   for ( indx = 0; indx < *n; indx++ ) {
     if ( (iptr++ ) == NULL ) {
       linfo = -5;
-      fprintf(stderr, " me = %d error in mapZ in fmemreq.c \n",me);
+      fprintf(stderr, " me = %d error in mapZ in fmemreq.c \n",(int)me);
       l_exit_(&linfo,msg);
       return;
     }

--- a/src/peigs/src/c/mgscs.c
+++ b/src/peigs/src/c/mgscs.c
@@ -181,7 +181,7 @@ Integer mgscs(n, vecA, mapA, b1, bn, c1, cn, iwork, work )
   for ( i = 0 ; i < ncolumnsA; i++ )
     if ( vecA[i] == NULL ){
       linfo = -2; 
-      fprintf(stderr, "node = %d NULL vector assignment in vecA \n", me);
+      fprintf(stderr, "node = %d NULL vector assignment in vecA \n", (int)me);
       xerbla_( "MGSCS \n", &linfo);
     }
     

--- a/src/peigs/src/c/ortho.c
+++ b/src/peigs/src/c/ortho.c
@@ -160,7 +160,7 @@ void ortho( n, m, colZ, mapZ, ibuffptr, iwork, work, ort, info)
   if( *n < *m ) {
       fprintf(stderr,
               "Error in routine ortho m (=%d) < n (=%d). me = %d \n",
-              *m, *n, me);
+              (int)(*m), (int)(*n), (int)me);
       exit(-1);
   }
   

--- a/src/peigs/src/c/pdiff.c
+++ b/src/peigs/src/c/pdiff.c
@@ -101,7 +101,7 @@ void pdiff( n, data, proclist, nprocs, iwork, msg1, msg2, info )
   indx = indxL ( me, *nprocs, proclist);
   
   if ( indx < 0 ) {
-    fprintf( stderr, " Error in pdiff.  me = %d not in proclist. \n", me );
+    fprintf( stderr, " Error in pdiff.  me = %d not in proclist. \n", (int)me );
     exit(-1);
   }
 
@@ -125,11 +125,11 @@ void pdiff( n, data, proclist, nprocs, iwork, msg1, msg2, info )
   }
     
   indx = memcmp( data, iwork, *n );
-  indx = abs(indx);
+  indx = labs(indx);
 
   if( indx != 0 ) {
     fprintf( stderr, " %s %s is different on processors %d and %d \n",
-             msg1, msg2, me, last_proc );
+             msg1, msg2, (int)me, (int)last_proc );
 
     *info = 1;
   }

--- a/src/peigs/src/c/pdspev_c.c
+++ b/src/peigs/src/c/pdspev_c.c
@@ -244,7 +244,7 @@ void pdspev(n, vecA, mapA, vecZ, mapZ, eval, iscratch, iscsize,
   strcpy( msg,  "Error in pdspev." );
   
 #ifdef DEBUG
-   printf("me = %d In pdspev \n", me );
+   printf("me = %d In pdspev \n", (int)me );
 #endif
 
  /*
@@ -284,7 +284,7 @@ void pdspev(n, vecA, mapA, vecZ, mapZ, eval, iscratch, iscsize,
     if ( info != NULL )
       *info = linfo;
     
-    fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n", msg, me, -linfo );
+    fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n", msg, (int)me, (int)(-linfo) );
     xstop_( &linfo );
     return;
   }
@@ -313,7 +313,7 @@ void pdspev(n, vecA, mapA, vecZ, mapZ, eval, iscratch, iscsize,
   if ( *info != 0 ) {
       linfo = *info;
       fprintf( stderr, " %s me = %d argument %d has an illegal value. \n",
-               msg, me, -linfo);
+               msg, (int)me, (int)(-linfo));
       xstop_( info );
       return;
   }
@@ -339,7 +339,7 @@ void pdspev(n, vecA, mapA, vecZ, mapZ, eval, iscratch, iscsize,
    if ( *info != 0 ) {
        linfo = *info;
        fprintf( stderr, " %s me = %d argument %d contains a pointer to NULL. \n",
-                msg, me, -linfo);
+                msg, (int)me, (int)(-linfo));
        xstop_( info );
        return;
    }
@@ -354,7 +354,7 @@ void pdspev(n, vecA, mapA, vecZ, mapZ, eval, iscratch, iscsize,
      *info = -5;
     
    if ( *info != 0 ) {
-       fprintf( stderr, " %s me = %d mapA,Z differ \n", msg, me );
+       fprintf( stderr, " %s me = %d mapA,Z differ \n", msg, (int)me );
        xstop_( info );
        return;
    }
@@ -379,7 +379,7 @@ void pdspev(n, vecA, mapA, vecZ, mapZ, eval, iscratch, iscsize,
    
    if ( linfo != 0 ) {
      *info = linfo;
-     fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, me );
+     fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, (int)me );
      xstop_( info );
      return;
    }
@@ -477,19 +477,19 @@ void pdspev(n, vecA, mapA, vecZ, mapZ, eval, iscratch, iscsize,
 	   dblptr, ibuffsize, scratch, ssize, info);
   
 #ifdef DEBUG99
-  printf("me = %d Exiting pdspev \n", me );
+  printf("me = %d Exiting pdspev \n", (int)me );
 
   lll = 0;
   for ( k = 0; k < *n; k++ ) {
     if ( mapZ[k] == me ) {
       for ( jjj = 0; jjj < *n; jjj++ )
-	printf(" %d  %d %g \n", lll, jjj, vecZ[lll][jjj]);
+	printf(" %d  %d %g \n", (int)lll, (int)jjj, vecZ[lll][jjj]);
       lll++;
     }
   }
 
   for ( jjj = 0; jjj < *n; jjj++ )
-    printf(" eval %d %g \n", jjj, eval[jjj]);
+    printf(" eval %d %g \n", (int)jjj, eval[jjj]);
 
 #endif
   

--- a/src/peigs/src/c/pdspevx.c
+++ b/src/peigs/src/c/pdspevx.c
@@ -350,7 +350,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
     me    = mxmynd_();
     nproc = mxnprc_();
     strcpy( msg,  "Error in pdspevx." );
-    sprintf( filename, "pdspevx.%d", me);
+    sprintf( filename, "pdspevx.%d", (int)me);
     
     /*
       setdbg_(&peigs_DEBUG);
@@ -411,7 +411,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
         *info = linfo;
       
       fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-	       msg, me, -linfo );
+	       msg, (int)me, (int)(-linfo) );
       xstop_( &linfo );
       return;
     }
@@ -453,7 +453,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
    if ( *info != 0 ) {
        linfo = *info;
        fprintf( stderr, " %s me = %d argument %d has an illegal value. \n",
-                msg, me, -linfo);
+                msg, (int)me, (int)(-linfo));
        xstop_( info );
        return;
    }
@@ -480,7 +480,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
    if ( *info != 0 ) {
        linfo = *info;
        fprintf( stderr, " %s me = %d argument %d contains a pointer to NULL. \n",
-                msg, me, -linfo);
+                msg, (int)me, (int)(-linfo));
        xstop_( info );
        return;
    }
@@ -495,7 +495,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
      *info = -13;
     
    if ( *info != 0 ) {
-       fprintf( stderr, " %s me = %d mapA,Z differ \n", msg, me );
+       fprintf( stderr, " %s me = %d mapA,Z differ \n", msg, (int)me );
        xstop_( info );
        return;
    }
@@ -520,7 +520,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
    
    if ( linfo != 0 ) {
      *info = linfo;
-     fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, me );
+     fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, (int)me );
      xstop_( info );
      return;
    }
@@ -791,7 +791,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
    */
 
 #ifdef DEBUG7
-   printf(" in pdspevx out tred2 me = %d \n", mxmynd_());
+   printf(" in pdspevx out tred2 me = %d \n", (int)mxmynd_());
    fflush(stdout);
 #endif
    
@@ -819,7 +819,7 @@ void pdspevx ( ivector, irange, n, vecA, mapA, lb, ub, ilb, iub, abstol,
       t1 = mxclock_();
 #endif
 #ifdef DEBUG7
-      printf(" in pdspevx pstebz11 me = %d \n", mxmynd_());
+      printf(" in pdspevx pstebz11 me = %d \n", (int)mxmynd_());
       fflush(stdout);
 #endif
       
@@ -913,7 +913,7 @@ for ( iii = 0; iii < msize; iii++)
      
    
 #ifdef DEBUG7
-   printf(" out pdspevx pstebz11 me = %d \n", mxmynd_());
+   printf(" out pdspevx pstebz11 me = %d \n", (int)mxmynd_());
 #endif
    
 #ifdef TIMING
@@ -934,7 +934,7 @@ for ( iii = 0; iii < msize; iii++)
    }
 
    if( *info != 0 ) {
-     fprintf(stderr, " %s me = %d pstebz_ returned info = %d \n", msg, me, *info );
+     fprintf(stderr, " %s me = %d pstebz_ returned info = %d \n", msg, (int)me, (int)(*info) );
      *info = 1;
    }
    
@@ -1026,7 +1026,7 @@ for ( iii = 0; iii < msize; iii++)
     
     
 #ifdef DEBUG7
-      printf(" me = %d just after pstein5 %d \n", me, *info );
+      printf(" me = %d just after pstein5 %d \n", (int)me, (int)(*info) );
       r_ritz_( &msize, dd, &ee[1], eval, mapZ, vecZ, d_scrat);
 #endif
     /*
@@ -1040,7 +1040,7 @@ for ( iii = 0; iii < msize; iii++)
 	 */
       
 #ifdef DEBUG7
-      printf(" me = %d just before pstein4 %d \n", me, *info );
+      printf(" me = %d just before pstein4 %d \n", (int)me, (int)(*info) );
       fflush(stdout);
 #endif
       
@@ -1059,13 +1059,13 @@ for ( iii = 0; iii < msize; iii++)
       
       
 #ifdef DEBUG7
-      printf(" me = %d just after pstein4 %d \n", me, *info );
+      printf(" me = %d just after pstein4 %d \n", (int)me, (int)(*info) );
       fflush(stderr);
 #endif
       
       
       if( *info != 0 ) {
-        fprintf(stderr, " %s me = %d pstein returned info = %d \n", msg, me, *info );
+        fprintf(stderr, " %s me = %d pstein returned info = %d \n", msg, (int)me, (int)(*info) );
         *info = 2;
       }
       

--- a/src/peigs/src/c/pdspgv_c.c
+++ b/src/peigs/src/c/pdspgv_c.c
@@ -317,7 +317,7 @@ void pdspgv( ifact, n, vecA, mapA, vecB, mapB, vecZ, mapZ,
 	*info = linfo;
       
       fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-               msg, me, -linfo );
+               msg, (int)me, (int)(-linfo) );
       xstop_( &linfo );
       return;
     }
@@ -350,7 +350,7 @@ void pdspgv( ifact, n, vecA, mapA, vecB, mapB, vecZ, mapZ,
     if ( *info != 0 ) {
         linfo = *info;
         fprintf( stderr, " %s me = %d argument %d has an illegal value. \n",
-                 msg, me, -linfo);
+                 msg, (int)me, (int)(-linfo));
         xstop_( info );
 	return;
     }
@@ -384,7 +384,7 @@ void pdspgv( ifact, n, vecA, mapA, vecB, mapB, vecZ, mapZ,
     if ( *info != 0 ) {
         linfo = *info;
         fprintf( stderr, " %s me = %d argument %d contains a pointer to NULL. \n",
-                 msg, me, -linfo);
+                 msg, (int)me, (int)(-linfo));
         xstop_( info );
 	return;
     }
@@ -403,7 +403,7 @@ void pdspgv( ifact, n, vecA, mapA, vecB, mapB, vecZ, mapZ,
       *info = -8;
     
     if ( *info != 0 ) {
-        fprintf( stderr, " %s me = %d mapA,B,Z differ \n", msg, me );
+        fprintf( stderr, " %s me = %d mapA,B,Z differ \n", msg, (int)me );
         xstop_( info );
 	return;
     }
@@ -429,7 +429,7 @@ void pdspgv( ifact, n, vecA, mapA, vecB, mapB, vecZ, mapZ,
   
     if ( linfo != 0 ) {
       *info = linfo;
-      fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, me );
+      fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, (int)me );
       xstop_( info );
       return;
     }

--- a/src/peigs/src/c/pdspgvx.c
+++ b/src/peigs/src/c/pdspgvx.c
@@ -420,7 +420,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
       *info = linfo;
       
     fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-             msg, me, -linfo );
+             msg, (int)me, (int)(-linfo) );
     xstop_( &linfo );
     return;
   }
@@ -464,7 +464,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
   if ( *info != 0 ) {
       linfo = *info;
       fprintf( stderr, " %s me = %d argument %d has an illegal value. \n",
-               msg, me, -linfo);
+               msg, (int)me, (int)(-linfo));
       xstop_( info );
       return;
   }
@@ -510,7 +510,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
   if ( *info != 0 ) {
       linfo = *info;
       fprintf( stderr, " %s me = %d argument %d contains a pointer to NULL. \n",
-               msg, me, -linfo);
+               msg, (int)me, (int)(-linfo));
       xstop_( info );
       return;
   }
@@ -529,7 +529,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
     *info = -8;
 
   if ( *info != 0 ) {
-      fprintf( stderr, " %s me = %d mapA,B,Z differ \n", msg, me );
+      fprintf( stderr, " %s me = %d mapA,B,Z differ \n", msg, (int)me );
       xstop_( info );
       return;
   }
@@ -554,7 +554,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
   
   if ( linfo != 0 ) {
     *info = linfo;
-    fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, me );
+    fprintf( stderr, " %s me = %d Insufficient workspace provided. \n", msg, (int)me );
     xstop_( info );
     return;
   }
@@ -707,7 +707,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
       choleski( &msize, vecB, mapB, i_scrat, d_scrat, info );
       
       if( *info != 0 ) {
-        fprintf(stderr, " %s me = %d choleski returned info = %d \n", msg, me, *info );
+        fprintf(stderr, " %s me = %d choleski returned info = %d \n", msg, (int)me, (int)(*info) );
         *info = 1;
       }
       
@@ -737,7 +737,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
 #endif
 
         if( *info != 0 ) {
-          fprintf(stderr, " %s me = %d inverseL returned info = %d \n", msg, me, *info );
+          fprintf(stderr, " %s me = %d inverseL returned info = %d \n", msg, (int)me, (int)(*info) );
           *info = 2;
         }
       
@@ -825,7 +825,7 @@ void pdspgvx( ifact, ivector, irange, n, vecA, mapA, vecB, mapB,
 #endif
 
     if( *info != 0 ) {
-      fprintf(stderr, " %s me = %d pdspevx returned info = %d \n", msg, me, *info );
+      fprintf(stderr, " %s me = %d pdspevx returned info = %d \n", msg, (int)me, (int)(*info) );
       *info = 3;
 	exit(-1);
     }

--- a/src/peigs/src/c/pdsptri.c
+++ b/src/peigs/src/c/pdsptri.c
@@ -348,7 +348,7 @@ void pdsptri( ivector, irange, n, dd, ee, dplus, lplus, lb, ub, ilb, iub, abstol
         *info = linfo;
 
      fprintf( stderr, " %s me = %d argument %d is a pointer to NULL. \n",
-              msg, me, -linfo );
+              msg, (int)me, (int)(-linfo) );
      xstop_( &linfo );
      return;
    }
@@ -411,7 +411,7 @@ void pdsptri( ivector, irange, n, dd, ee, dplus, lplus, lb, ub, ilb, iub, abstol
    if ( *info != 0 ) {
       linfo = *info;
       fprintf( stderr, " %s me = %d argument %d has an illegal value. \n",
-               msg, me, -linfo);
+               msg, (int)me, (int)(-linfo));
       xstop_( info );
       return;
    }
@@ -531,7 +531,7 @@ void pdsptri( ivector, irange, n, dd, ee, dplus, lplus, lb, ub, ilb, iub, abstol
     *meigval = neigval;
 
     if( *info != 0 ) {
-      fprintf(stderr, " %s me = %d pstebz returned info = %d \n", msg, me, *info );
+      fprintf(stderr, " %s me = %d pstebz returned info = %d \n", msg, (int)me, (int)(*info) );
       *info = 1;
       return;
     }
@@ -570,7 +570,7 @@ void pdsptri( ivector, irange, n, dd, ee, dplus, lplus, lb, ub, ilb, iub, abstol
 #endif
       
       if( *info != 0 ) {
-        fprintf(stderr, " %s me = %d pstein returned info = %d \n", msg, me, *info );
+        fprintf(stderr, " %s me = %d pstein returned info = %d \n", msg, (int)me, (int)(*info) );
         *info = 2;
       }
     }

--- a/src/peigs/src/c/peigs_dlasq1.c
+++ b/src/peigs/src/c/peigs_dlasq1.c
@@ -30,11 +30,11 @@ void peigs_dlasq1( Integer n, DoublePrecision *dplus, DoublePrecision *lplus, Do
   dlasq1_( &n, &work[0], &work[n], &work[n+n], info );
   
   if ( *info != 0 ){
-    printf(" error in dlasq1 info = %d \n", *info );
-    sprintf( filename, "pdspevx.%d", me);
+    printf(" error in dlasq1 info = %d \n", (int)(*info) );
+    sprintf( filename, "pdspevx.%d", (int)me);
     file = fopen(filename, "w");
     for ( iii = 0; iii < n; iii++)
-      fprintf(file, " %d %20.16f %20.16f \n", iii, dplus[iii], lplus[iii]);
+      fprintf(file, " %d %20.16f %20.16f \n", (int)iii, dplus[iii], lplus[iii]);
     fclose(file);
     fflush(file);
     fflush(stdout);

--- a/src/peigs/src/c/pgexit.c
+++ b/src/peigs/src/c/pgexit.c
@@ -82,7 +82,7 @@ void pgexit( info, msg, proclist, nprocs, work )
   
   if ( m != 0 ) {
     *info = -51;
-    fprintf( stderr, " %s  me = %d exiting via pgexit. \n", msg, mxmynd_() );
+    fprintf( stderr, " %s  me = %d exiting via pgexit. \n", msg, (int)mxmynd_() );
     xstop_( info );
   }
 

--- a/src/peigs/src/c/pstein5.c
+++ b/src/peigs/src/c/pstein5.c
@@ -230,7 +230,7 @@ void pstein5 ( n, dd, ee, dplus, lplus, ld, lld, meigval, eval, iblock, nsplit, 
     if ( info != NULL )
         *info = linfo;
     printf( " %s me = %d argument %d is a pointer to NULL. \n",
-	    msg, me, -linfo );
+	    msg, (int)me, (int)(-linfo) );
     fflush(stdout);
     xstop_( &linfo );
     return;
@@ -298,7 +298,7 @@ void pstein5 ( n, dd, ee, dplus, lplus, ld, lld, meigval, eval, iblock, nsplit, 
   if( *info != 0 ) {
     linfo = *info;
     printf( " %s me = %d argument %d has an illegal value. \n",
-	    msg, me, -linfo);
+	    msg, (int)me, (int)(-linfo));
     xstop_( info );
     return;
   }

--- a/src/peigs/src/c/pstein5.c
+++ b/src/peigs/src/c/pstein5.c
@@ -178,7 +178,7 @@ void pstein5 ( n, dd, ee, dplus, lplus, ld, lld, meigval, eval, iblock, nsplit, 
   
   
 #ifdef DEBUG1
-  fprintf(stderr, "me = %d In pstein \n", me );
+  fprintf(stderr, "me = %d In pstein \n", (int)me );
 #endif
   
   /*
@@ -442,7 +442,7 @@ void pstein5 ( n, dd, ee, dplus, lplus, ld, lld, meigval, eval, iblock, nsplit, 
   if ( isize < 0 ){
     *info = -99;
     fprintf(stderr, " Node %d: error in clustrf isize = %d neigval = %d \n", 
-	    me, isize, neigval );
+	    (int)me, (int)isize, (int)neigval );
     xstop_( info );
   }
   

--- a/src/peigs/src/c/pxerbla.c
+++ b/src/peigs/src/c/pxerbla.c
@@ -125,7 +125,7 @@ void pxerbla2_( n, array, procmap, len, iwork, info )
   qqsort( proclist, 0, nprocs-1);
   
   if ( nprocs > maxprocs ) {
-    fprintf(stderr, "PXERBLA: Node %d Error: Number of processors in Proc List exceeds number allocated \n", me);
+    fprintf(stderr, "PXERBLA: Node %d Error: Number of processors in Proc List exceeds number allocated \n", (int)me);
     *info = -1;
     return;
   }
@@ -165,7 +165,7 @@ void pxerbla2_( n, array, procmap, len, iwork, info )
     
     isize = *n;
     indx = memcmp( array, map_in, isize );
-    indx = abs(indx);
+    indx = labs(indx);
     *info = indx;
     return;
   }

--- a/src/peigs/src/c/tred22.c
+++ b/src/peigs/src/c/tred22.c
@@ -325,7 +325,7 @@ Integer tred2(n, vecA, mapA, Q, mapQ, diag, upperdiag, iwork, work )
   for ( i = 0 ; i < nrowsA; i++ )
     if ( vecA[i] == NULL ){
       linfo = -2; 
-      fprintf(stderr, "node = %d NULL vector assignment in vecA \n", me);
+      fprintf(stderr, "node = %d NULL vector assignment in vecA \n", (int)me);
       xerbla_( "TRED2 \n", &linfo);
     }
     
@@ -351,7 +351,7 @@ Integer tred2(n, vecA, mapA, Q, mapQ, diag, upperdiag, iwork, work )
   if ( upperdiag == NULL )
     linfo = -7;
   
-  sprintf(msg, "TRED22:Error in argument %d \n", linfo);
+  sprintf(msg, "TRED22:Error in argument %d \n", (int)linfo);
 
   /*
   printf(" in tred22.c me = %d \n", me );

--- a/src/peigs/src/c/xerbla.c
+++ b/src/peigs/src/c/xerbla.c
@@ -42,9 +42,9 @@ void xerbla( string, info )
 {
   extern Integer mxmynd_();
 
-  fprintf(stdout, " processor %d \n", mxmynd_());
+  fprintf(stdout, " processor %d \n", (int)mxmynd_());
   fprintf(stdout, " ** On entry to %s parameter number %d had an illegal value or pointer \n",
-          string, *info );
+          string, (int)(*info) );
   /*
      should put some global exit here
      */


### PR DESCRIPTION
I am working on Spack and peigs formatting warnings seem to be promoted to errors by some compilers/options, or at least were showing up as red and therefore making it harder to find real the errors.

All of these warnings are because of `Integer` being used for Fortran compatibility but all of the `printf` using `%d`.  I cannot see any reason to promote the format to `%ld` because we won't have more than `INT_MAX` processes or rows/columns in a matrix.