### PR TITLE
conditionalize -cuda flag on PGI/NV compiler

### DIFF
--- a/src/util/GNUmakefile
+++ b/src/util/GNUmakefile
@@ -315,7 +315,11 @@ ifdef TCE_HIP
 endif
 
 ifdef USE_OPENACC_TRPDRV
-  FOPTIONS += -cuda -DUSE_CUDA_AFFINITY
+  ifeq ($(_FC),pgf90)
+    LIB_DEFINES += -cuda -DUSE_CUDA_AFFINITY
+  else
+    LIB_DEFINES += $(CUDA_INCLUDE) -DUSE_CUDA_AFFINITY
+  endif
 endif
 
 ifdef TCE_OPENACC


### PR DESCRIPTION
`USE_OPENACC_TRPDRV` assumes NVHPC Fortran so the build system was not guarding it appropriately.  I fixed that, because it was causing a problem in a poorly configured environment.