### PR TITLE
Fix capitalisation of Python NWChemError

### DIFF
--- a/src/python/nwchem_wrap.c
+++ b/src/python/nwchem_wrap.c
@@ -1836,8 +1836,8 @@ void initnwchem()
   if (module == NULL)
     INITERROR;
 
-  NwchemError = PyErr_NewException("nwchem.NwchemError", NULL, NULL);
-  PyModule_AddObject(module, "NwchemError", NwchemError);
+  NwchemError = PyErr_NewException("nwchem.NWChemError", NULL, NULL);
+  PyModule_AddObject(module, "NWChemError", NwchemError);
 
   struct module_state *st = GETSTATE(module);
   st->error = PyErr_NewException("nwchem.error", NULL, NULL);


### PR DESCRIPTION
Changes the Python Exception object from `NwchemError` to `NWChemError`, which is consistent with the [documentation](https://nwchemgit.github.io/Python.html?h=#handling-exceptions-from-nwchem), and is the exception type expected by e.g. [/contrib/python/nwgeom.py](https://github.com/nwchemgit/nwchem/blob/master/contrib/python/nwgeom.py). Searching through GitHub for "NwchemError" I can't find any code that depends on the current spelling, but if there's reason to believe that some projects may depend on it, then I can add a DeprecationWarning.