### PR TITLE
Fix cosmo output with gas phase disabled.

### DIFF
--- a/src/solvation/cosmo_smd_output.F
+++ b/src/solvation/cosmo_smd_output.F
@@ -18,7 +18,7 @@ c     Standard cosmo output
 c
         if (.not.do_cosmo_smd) then
            write(luout,911)
-           if (dabs(egas).gt.0.d0) then
+           if (dabs(egas).gt.1d-9) then
                 write(luout,912) egas
                 write(luout,913) esol
                 write(luout,914) (egas-esol),(egas-esol)*cau2kcal
@@ -30,7 +30,7 @@ c
         else  ! cosmo-smd output
 c
            write(luout,819)
-           if (dabs(egas).gt.0.d0) then
+           if (dabs(egas).gt.1d-9) then
              write(luout,820) egas
              write(luout,821) (gstote-gspol)
              write(luout,822) (gstote-gspol-egas),


### PR DESCRIPTION
When the `do_gasphase false` option is set inside the `cosmo` block, the gas phase calculation is skipped, and the `egas` variable is expected to be zero.

In this case, the printing routine should not display the gas phase value or the difference between the solvated and gas phase energies. This behavior is controlled by the conditional:

`if (dabs(egas).gt.0.d0) then`

However, `egas` is not strictly zero but instead takes on a very small value, likely due to machine/compiler variations. The fix updates the condition to:

`if (dabs(egas).gt.1d-9) then`

This small threshold (`1d-9`) is already used elsewhere in the code for similar checks.
