### PR TITLE
ENH: Allow driver clients to poll for input

### DIFF
--- a/src/driver/driver_input.F
+++ b/src/driver/driver_input.F
@@ -116,28 +116,23 @@ c
      >          call errquit('driver_input: rtdb put failed',8,RTDB_ERR)
                end if
 
-               max_retries = 30
-               retry_delay = 2
-
                do while (inp_a(field))
-                  if (inp_compare(.false., 'retries', field)) then
+                  if (inp_compare(.false.,'retries',field)) then
                      if (.not. inp_i(max_retries)) call errquit(
-     &                'driver_input: expected integer for retries', 0,
-     &                INPUT_ERR)
-                  else if (inp_compare(.false., 'delay', field)) then
+     &                  'driver_input: expected integer for retries',0,
+     &                  INPUT_ERR)
+                     if (.not. rtdb_put(rtdb,'driver:socket_retries',
+     &                    mt_int,1,max_retries)) call errquit(
+     &                    'driver_input: rtdb put failed',10,RTDB_ERR)
+                  else if (inp_compare(.false.,'delay',field)) then
                      if (.not. inp_i(retry_delay)) call errquit(
-     &                'driver_input: expected float for delay',0,
-     &                INPUT_ERR)
+     &                  'driver_input: expected int for delay',0,
+     &                  INPUT_ERR)
+                     if (.not. rtdb_put(rtdb,'driver:socket_delay',
+     &                    mt_int,1,retry_delay)) call errquit(
+     &                    'driver_input: rtdb put failed',11,RTDB_ERR)
                   end if
                end do
-
-               if (.not. rtdb_put(rtdb,'driver:socket_retries',mt_int,1,
-     &              max_retries)) call errquit(
-     &              'driver_input: rtdb put failed', 10, RTDB_ERR)
-
-               if (.not. rtdb_put(rtdb,'driver:socket_delay',mt_int,1,
-     &              retry_delay)) call errquit(
-     &              'driver_input: rtdb put failed', 11, RTDB_ERR)
 
                diagh = .true.
                if (.not. rtdb_put(rtdb,'driver:socket',

--- a/src/driver/driver_input.F
+++ b/src/driver/driver_input.F
@@ -29,6 +29,7 @@ c
       double precision ascale, bscale, tscale, hscale
       logical ignore,diagh
       integer mh,ind
+      integer max_retries,retry_delay
 
 *     **** external functions ****
       logical  driver_parse_boolean
@@ -98,7 +99,7 @@ c
      $                      mt_log,1,diagh))
      $        call errquit('driver_input: rtdb put failed',0, RTDB_ERR)
 c
-c socket ipi_client ip:port
+c socket ipi_client ip:port retries delay
 c
       else if (inp_compare(.false.,'socket', field)) then
          if (inp_a(f2)) then
@@ -114,6 +115,22 @@ c
      >                           ipname(1:ind)))
      >          call errquit('driver_input: rtdb put failed',8,RTDB_ERR)
                end if
+
+               if (.not. inp_i(max_retries)) call errquit(
+     &              'driver_input: failed to read retries integer', 0,
+     &              INPUT_ERR)
+               if (.not. inp_i(retry_delay)) call errquit(
+     &              'driver_input: failed to read delay float', 0,
+     &              INPUT_ERR)
+
+               if (.not. rtdb_put(rtdb,'driver:socket_retries',mt_int,1,
+     &              max_retries)) call errquit(
+     &              'driver_input: rtdb put failed', 10, RTDB_ERR)
+
+               if (.not. rtdb_put(rtdb,'driver:socket_delay',mt_int,1,
+     &              retry_delay)) call errquit(
+     &              'driver_input: rtdb put failed', 11, RTDB_ERR)
+
                diagh = .true.
                if (.not. rtdb_put(rtdb,'driver:socket',
      $                      mt_log,1,diagh))

--- a/src/driver/driver_input.F
+++ b/src/driver/driver_input.F
@@ -116,24 +116,6 @@ c
      >          call errquit('driver_input: rtdb put failed',8,RTDB_ERR)
                end if
 
-               do while (inp_a(field))
-                  if (inp_compare(.false.,'retries',field)) then
-                     if (.not. inp_i(max_retries)) call errquit(
-     &                  'driver_input: expected integer for retries',0,
-     &                  INPUT_ERR)
-                     if (.not. rtdb_put(rtdb,'driver:socket_retries',
-     &                    mt_int,1,max_retries)) call errquit(
-     &                    'driver_input: rtdb put failed',10,RTDB_ERR)
-                  else if (inp_compare(.false.,'delay',field)) then
-                     if (.not. inp_i(retry_delay)) call errquit(
-     &                  'driver_input: expected int for delay',0,
-     &                  INPUT_ERR)
-                     if (.not. rtdb_put(rtdb,'driver:socket_delay',
-     &                    mt_int,1,retry_delay)) call errquit(
-     &                    'driver_input: rtdb put failed',11,RTDB_ERR)
-                  end if
-               end do
-
                diagh = .true.
                if (.not. rtdb_put(rtdb,'driver:socket',
      $                      mt_log,1,diagh))
@@ -147,7 +129,24 @@ c
      $                      mt_log,1,diagh))
      $        call errquit('driver_input: rtdb put failed',0, RTDB_ERR)
             end if
-         end if
+            do while (inp_a(field))
+               if (inp_compare(.false.,'retries',field)) then
+                  if (.not. inp_i(max_retries)) call errquit(
+     &               'driver_input: expected integer for retries',0,
+     &                 INPUT_ERR)
+                  if (.not. rtdb_put(rtdb,'driver:socket_retries',
+     &                   mt_int,1,max_retries)) call errquit(
+     &                   'driver_input: rtdb put failed',10,RTDB_ERR)
+               else if (inp_compare(.false.,'delay',field)) then
+                  if (.not. inp_i(retry_delay)) call errquit(
+     &                 'driver_input: expected int for delay',0,
+     &                 INPUT_ERR)
+                  if (.not. rtdb_put(rtdb,'driver:socket_delay',
+     &                   mt_int,1,retry_delay)) call errquit(
+     &                   'driver_input: rtdb put failed',11,RTDB_ERR)
+               end if
+            end do
+           end if
 c
       else if (inp_compare(.false.,'deloc', field)) then
          if (.not. rtdb_put(rtdb,'driver:deloc',mt_log,1,.true.))

--- a/src/driver/driver_input.F
+++ b/src/driver/driver_input.F
@@ -99,7 +99,7 @@ c
      $                      mt_log,1,diagh))
      $        call errquit('driver_input: rtdb put failed',0, RTDB_ERR)
 c
-c socket ipi_client ip:port retries delay
+c socket ipi_client ip:port [retries <int>] [delay <int>]
 c
       else if (inp_compare(.false.,'socket', field)) then
          if (inp_a(f2)) then
@@ -116,12 +116,20 @@ c
      >          call errquit('driver_input: rtdb put failed',8,RTDB_ERR)
                end if
 
-               if (.not. inp_i(max_retries)) call errquit(
-     &              'driver_input: failed to read retries integer', 0,
-     &              INPUT_ERR)
-               if (.not. inp_i(retry_delay)) call errquit(
-     &              'driver_input: failed to read delay float', 0,
-     &              INPUT_ERR)
+               max_retries = 30
+               retry_delay = 2
+
+               do while (inp_a(field))
+                  if (inp_compare(.false., 'retries', field)) then
+                     if (.not. inp_i(max_retries)) call errquit(
+     &                'driver_input: expected integer for retries', 0,
+     &                INPUT_ERR)
+                  else if (inp_compare(.false., 'delay', field)) then
+                     if (.not. inp_i(retry_delay)) call errquit(
+     &                'driver_input: expected float for delay',0,
+     &                INPUT_ERR)
+                  end if
+               end do
 
                if (.not. rtdb_put(rtdb,'driver:socket_retries',mt_int,1,
      &              max_retries)) call errquit(

--- a/src/driver/socket_driver.F
+++ b/src/driver/socket_driver.F
@@ -25,8 +25,7 @@
       integer rion(2),fion(2),nion,nion0
       real*8 unita(3,3),invunita(3,3),stress(3,3),energy
       real*8 cpu1,cpu2
-      real*8 retry_delay_seconds
-      integer max_retries
+      integer max_retries, retry_delay_seconds
 
 *     **** external functions ****
       logical  task_gradient
@@ -102,14 +101,21 @@
 
       statebuffer(1:13) = "READY        "
 
+      if (.not. rtdb_get(rtdb, 'driver:socket_retries', mt_int, 1,
+     >                     max_retries)) then
+         max_retries = 30
+      end if
+      if (.not. rtdb_get(rtdb, 'driver:socket_delay', mt_int, 1,
+     >                     retry_delay_seconds)) then
+         retry_delay_seconds = 2
+      end if
+
       if (taskid.eq.MASTER) then
          write(luout,*)
          write(luout,*) "== i-PI Socket Client Driver =="
          write(luout,'(" Connected to    = ",A)') socket_ip
          write(luout,'(" Number of atoms =",I8)') nion
          write(luout,*)
-         retry_delay_seconds = 2.0
-         max_retries = 30
          call util_talker(ip,inet,ii-1,port,sock,max_retries,
      >   retry_delay_seconds)
          write(luout,*)

--- a/src/driver/socket_driver.F
+++ b/src/driver/socket_driver.F
@@ -25,6 +25,8 @@
       integer rion(2),fion(2),nion,nion0
       real*8 unita(3,3),invunita(3,3),stress(3,3),energy
       real*8 cpu1,cpu2
+      real*8 retry_delay_seconds
+      integer max_retries
 
 *     **** external functions ****
       logical  task_gradient
@@ -106,7 +108,10 @@
          write(luout,'(" Connected to    = ",A)') socket_ip
          write(luout,'(" Number of atoms =",I8)') nion
          write(luout,*)
-         call util_talker(ip,inet,ii-1,port,sock)
+         retry_delay_seconds = 2.0
+         max_retries = 30
+         call util_talker(ip,inet,ii-1,port,sock,max_retries,
+     >   retry_delay_seconds)
          write(luout,*)
          !call nwpw_talker("127.0.0.1",9,port,sock)
       end if

--- a/src/util/util_talker.c
+++ b/src/util/util_talker.c
@@ -114,8 +114,8 @@ void FATR util_talker_(char addr_name[], Integer * inet, Integer * n1, Integer *
 
     printf("util_talker: Connection successful! Socket ID: %d\n", sock);
     *sockout = ((Integer)sock);
-    #endif
-    }
+#endif
+}
 
 
 

--- a/src/util/util_talker.c
+++ b/src/util/util_talker.c
@@ -14,16 +14,26 @@
 #endif
 #include "typesf2c.h"
 
-void FATR util_talker_(char addr_name[], Integer * inet, Integer * n1, Integer * portin, Integer * sockout)
+void FATR util_talker_(char addr_name[], Integer * inet, Integer * n1, Integer * portin, Integer * sockout, Integer * max_retries_in, Integer * retry_delay_seconds_in)
 {
 #if defined(__MINGW32__)
     perror("util_talker: not coded for this architecture");
     exit(1);
 #else
     int sock = 0;
-    const int max_retries = 30;
-    const int retry_delay_seconds = 2;
+    int max_retries = ((int) *max_retries_in);
+    int retry_delay_seconds = ((int) *retry_delay_seconds_in);
     int retries = 0;
+
+    if (max_retries <= 0){
+        perror("Got an invalid (<=0) number of retries, resetting to 30\n");
+        max_retries = 30;
+    }
+    if (retry_delay_seconds <= 0){
+        perror("Got an invalid (<=0) delay for retries, resetting to 2\n");
+        retry_delay_seconds = 2;
+    }
+
 
     if (*inet > 0)
     {
@@ -58,7 +68,7 @@ void FATR util_talker_(char addr_name[], Integer * inet, Integer * n1, Integer *
                 fprintf(stderr, "\nutil_talker: TCP connection failed after %d attempts: %s. Exiting.\n", max_retries, strerror(errno));
                 exit(1);
             }
-            printf("util_talker: Connection failed. Retrying in %d seconds... (%d/%d)\n",
+            printf("util_talker: Connection failed. Retrying in %d second(s)... (%d/%d)\n",
                    retry_delay_seconds, retries, max_retries);
             sleep(retry_delay_seconds);
         }
@@ -96,8 +106,7 @@ void FATR util_talker_(char addr_name[], Integer * inet, Integer * n1, Integer *
                         max_retries, strerror(errno));
                 exit(1);
             }
-            printf("util_talker: Connection failed. Retrying in %d seconds... "
-                   "(%d/%d)\n",
+            printf("util_talker: Connection failed. Retrying in %d second(s)... (%d/%d)\n",
                    retry_delay_seconds, retries, max_retries);
             sleep(retry_delay_seconds);
         }


### PR DESCRIPTION
Closes #1144.

Basically now the client will wait for a server to come up.

```bash
 == i-PI Socket Client Driver ==
 Connected to    = eon_nwchem                                                                      
 Number of atoms =       9

util_talker: Attempting to connect to UNIX socket /tmp/ipi_eon_nwchem
util_talker: Connection failed. Retrying in 2 seconds... (1/30)
util_talker: Connection failed. Retrying in 2 seconds... (2/30)
util_talker: Connection failed. Retrying in 2 seconds... (3/30)
^C⏎                                                                      
```

I did indeed figure out the parameter pack.. so now:

```bash

 == i-PI Socket Client Driver ==
 Connected to    = eon_nwchem                                                                      
 Number of atoms =       9

util_talker: Attempting to connect to UNIX socket /tmp/ipi_eon_nwchem
util_talker: Connection failed. Retrying in 1 second(s)... (1/20)
util_talker: Connection failed. Retrying in 1 second(s)... (2/20)
util_talker: Connection failed. Retrying in 1 second(s)... (3/20)
util_talker: Connection failed. Retrying in 1 second(s)... (4/20)
```

i.e. from 

```ini
driver
  socket unix eon_nwchem retries 20 delay 1
end
```

Some documentation is now in https://github.com/nwchemgit/nwchem-wiki/pull/39.