### PR TITLE
Replace unit 6 with luout for output statements

### DIFF
--- a/src/bq/bq_data.F
+++ b/src/bq/bq_data.F
@@ -664,7 +664,7 @@ c      local variables
      &      0, MA_ERR)
 
        if (oprint) then
-         call util_print_centered(6,
+         call util_print_centered(luout,
      >      "Bq Structure Information (Angstroms)",
      >              36, .true.)
       
@@ -674,7 +674,7 @@ c      local variables
 c        == tally up bq charges ==
          bq_charge_total = 0.d0
          do i=1,bq_ncent(handle)
-           write(6,FMT=9000)
+           write(luout,FMT=9000)
 c     >           i,(dbl_mb(i_c+3*(i-1)+k-1),k=1,3),
      >           i,(dbl_mb(i_c+3*(i-1)+k-1)*0.529177249d00,k=1,3),
      >           dbl_mb(i_q+i-1)

--- a/src/ddscf/scf.F
+++ b/src/ddscf/scf.F
@@ -14,6 +14,7 @@ C$Id$
 #include "cscf.fh"
 #include "case.fh"
 #include "frozemb.fh"
+#include "stdio.fh"
 c
 c     ROHF module.
 c
@@ -85,13 +86,14 @@ c
 c     Print info
 c 
       if (ga_nodeid().eq.0 .and. oprint) then
-         call util_print_centered(6, 'NWChem SCF Module', 40, .true.)
-         write(6,*)
-         write(6,*)
+         call util_print_centered(luout, 'NWChem SCF Module', 40,
+     $                            .true.)
+         write(luout,*)
+         write(luout,*)
          if (title .ne. ' ') then
-            call util_print_centered(6, title, 40, .false.)
-            write(6,*)
-            write(6,*)
+            call util_print_centered(luout, title, 40, .false.)
+            write(luout,*)
+            write(luout,*)
          endif
 c
          if(.not. geom_systype_get(geom,itype))
@@ -102,7 +104,7 @@ c
          if (.not. geom_ncent(geom, natoms)) call errquit
      $        ('scf: geom_ncent failed', 0, GEOM_ERR)
 c
-         write(6,1) trans(1:inp_strlen(trans)), nbf
+         write(luout,1) trans(1:inp_strlen(trans)), nbf
  1       format(/
      $        '  ao basis        = "',a,'"'/
      $        '  functions       = ', i5)
@@ -111,23 +113,23 @@ c
             if (.not. bas_name(riscf_basis, name, ri_trans))
      $           call errquit('scf: bas_name?', 0,
      &       BASIS_ERR)
-            write(6,11) ri_trans(1:inp_strlen(ri_trans)), nff
+            write(luout,11) ri_trans(1:inp_strlen(ri_trans)), nff
  11         format(
      $           '  ri basis        = "',a,'"'/
      $           '  ri functions    = ', i5)
          endif
-         write(6,12) natoms
+         write(luout,12) natoms
  12      format('  atoms           = ', i5)
          if (scftype .eq. 'UHF') then
-            write(6,121) nalpha, nbeta
+            write(luout,121) nalpha, nbeta
  121        format('  alpha electrons = ', i5/
      $           '  beta  electrons = ', i5)
          else
-            write(6,122) nclosed, nopen
+            write(luout,122) nclosed, nopen
  122        format('  closed shells   = ', i5/
      $           '  open shells     = ', i5)
          endif
-         write(6,123)
+         write(luout,123)
      $        charge, scftype,
      $        movecs_in(1:inp_strlen(movecs_in)),
      $        movecs_out(1:inp_strlen(movecs_out)), oskel, oadapt
@@ -138,14 +140,14 @@ c
      $        '  output vectors  = ', a/
      $        '  use symmetry    = ', l1/
      $        '  symmetry adapt  = ', l1)
-         if (olock) write(6,124) olock
+         if (olock) write(luout,124) olock
  124     format('  lock orbitals   = ', l1)
          if (util_print('basis summary', print_default)) then
             if (.not.bas_summary_print(basis))
      &           call errquit('scf: basis summary print failed',911,
      &       BASIS_ERR)
          else
-            write(6,*)
+            write(luout,*)
          endif
          if (oadapt .and. util_print('char table', print_high)) then
             call sym_print_char_table(geom)
@@ -153,7 +155,7 @@ c
          if (oadapt .and. util_print('basis sym', print_default)) then
             call sym_bas_irreps(basis, .true., nbf_per_ir)
          endif
-         call util_flush(6)
+         call util_flush(luout)
       endif
 c
 c     Print out other info as requested by user
@@ -162,17 +164,17 @@ c
          if (util_print('geometry',print_high)) then
             if (.not. geom_print(geom))
      $        call errquit('scf: geom_print', 0, GEOM_ERR)
-            write(6,*)
+            write(luout,*)
          endif
          if (util_print('symmetry', print_debug)) then
             call sym_print_all(geom, .true., .true., .true., 
      $           .true., .true.)
-            write(6,*)
+            write(luout,*)
          endif
          if (util_print('basis', print_high)) then
             if (.not. bas_print(basis)) 
      $           call errquit('scf: bas_print', 0, BASIS_ERR)
-            write(6,*)
+            write(luout,*)
          endif
          if (util_print('basis labels',print_high) .and.
      $        ga_nodeid().eq.0) then
@@ -181,9 +183,9 @@ c
          if (util_print('geombas', print_debug)) then
             if (.not. gbs_map_print(basis)) 
      $           call errquit('scf:gmp', 0, BASIS_ERR)
-            write(6,*)
+            write(luout,*)
          endif
-         call util_flush(6)
+         call util_flush(luout)
       endif
 c
 c     Get and check the Coulomb Attenuation Method (CAM) parameters
@@ -208,10 +210,10 @@ c
      $           call errquit('scf: failed getting converged energy',0,
      &       RTDB_ERR)
             if (ga_nodeid().eq.0 .and. oprint) then
-               write(6,1101) energy
+               write(luout,1101) energy
  1101          format(/'  The SCF is already converged '//,
      $              '         Total SCF energy =', f20.12/)
-               call util_flush(6)
+               call util_flush(luout)
             endif
             goto 3131
          endif
@@ -225,14 +227,14 @@ c
      &       UNKNOWN_ERR)
         if (ga_nodeid().eq.0 .and. oprint) then
           if (nriscf.eq.1) then
-            call util_print_centered(6, 'RI hessian', 40, .true.)
+            call util_print_centered(luout, 'RI hessian', 40, .true.)
           else if (nriscf.eq.2) then
-            call util_print_centered(6, 'RISCF', 40, .true.)
+            call util_print_centered(luout, 'RISCF', 40, .true.)
           else if (nriscf.eq.3) then
-            call util_print_centered(6, 'preconverge with RISCF', 40, 
-     $           .true.)
+            call util_print_centered(luout, 'preconverge with RISCF',
+     $           40, .true.)
           endif
-          write(6,*)
+          write(luout,*)
         endif
       endif
 c
@@ -248,7 +250,7 @@ c
 c
 c     Form intial guess vectors
 c
-      if (ga_nodeid().eq.0 .and. oprint) write(6,711) util_wallsec()
+      if (ga_nodeid().eq.0 .and. oprint) write(luout,711) util_wallsec()
  711  format(/' Forming initial guess at ',f9.1,'s'/)
 c      call scf_vectors_guess(rtdb)
 c
@@ -266,7 +268,7 @@ c     Here branch to the appropriate wavefunction type ... returns
 c     true if happily converged, false otherwise (e.g., if restart
 c     is needed or problems encountered).
 c
-      if (ga_nodeid().eq.0 .and. oprint) write(6,712) util_wallsec()
+      if (ga_nodeid().eq.0 .and. oprint) write(luout,712) util_wallsec()
  712  format(/' Starting SCF solution at ',f9.1,'s'/)
 c
 c     frozen embedding 
@@ -289,9 +291,9 @@ c     reconverge with exact energy/gradient if requested
 c
       if (nriscf.eq.3) then
         if (ga_nodeid().eq.0 .and. oprint) then
-          call util_print_centered(6,
+          call util_print_centered(luout,
      $         'switching to exact energy/gradient', 40, .true.)
-          write(6,*)
+          write(luout,*)
         endif
         nriscf = 1
         if (scftype .eq. 'UHF') then

--- a/src/ddscf/uhf.F
+++ b/src/ddscf/uhf.F
@@ -12,6 +12,7 @@ C$Id$
 #include "cscf.fh"
 #include "geom.fh"
 #include "bas.fh"
+#include "stdio.fh"
 c
 c     Compute UHF wavefunction .
 c
@@ -80,16 +81,16 @@ c
 c
       if (ga_nodeid().eq.0 .and. (oprint .or. .not.converged)) then
          if (.not. converged) then
-            write(6,*)
-            call util_print_centered(6,
+            write(luout,*)
+            call util_print_centered(luout,
      $           'Calculation failed to converge', 20, .true.)
-            write(6,*)
+            write(luout,*)
          end if
-         write(6,2) scftype, energy, eone, etwo, enrep  
+         write(luout,2) scftype, energy, eone, etwo, enrep
          if (abs(ecosmo).gt.0.0d0) then
-           write(6,3) ecosmo
+           write(luout,3) ecosmo
          endif
-         write(6,4) sz, sz*(sz+1), s2, uhf_time
+         write(luout,4) sz, sz*(sz+1), s2, uhf_time
  2       format(//
      $        '       Final ',a4,' results '/
      $        '       ------------------ '//
@@ -104,7 +105,7 @@ c
      $        '                 Sz(Sz+1) =', f12.4/
      $        '                      S^2 =', f12.4//
      $        '        Time for solution =', f9.1,'s'//)
-         call util_flush(6)
+         call util_flush(luout)
          call ecce_print1('total energy', mt_dbl, energy, 1)
          call ecce_print1('one-electron energy', mt_dbl, eone, 1)
          call ecce_print1('two-electron energy', mt_dbl, etwo, 1)
@@ -134,14 +135,14 @@ C
       endif
       if (ga_nodeid() .eq. 0) then
          if (util_print('final evals', print_default)) then
-            call util_print_centered(6,'Final alpha eigenvalues',
+            call util_print_centered(luout,'Final alpha eigenvalues',
      $           20,.true.)
             call output(dbl_mb(k_eval), 1, nprint, 1, 1, nmo, 1, 1)
-            write(6,*)
-            call util_print_centered(6,'Final beta eigenvalues',
+            write(luout,*)
+            call util_print_centered(luout,'Final beta eigenvalues',
      $           20,.true.)
             call output(dbl_mb(k_eval+nbf), 1, nprint, 1, 1, nmo, 1, 1)
-            call util_flush(6)
+            call util_flush(luout)
          end if
       endif
       if (util_print('final vectors analysis', print_default)) then
@@ -164,10 +165,10 @@ C
       endif
       if (ga_nodeid() .eq. 0) then
          if (util_print('final vectors', print_debug)) then
-            write(6,*)
-            call util_print_centered(6,'Final MO vectors',40,.true.)
-            write(6,*)
-            call util_flush(6)
+            write(luout,*)
+            call util_print_centered(luout,'Final MO vectors',40,.true.)
+            write(luout,*)
+            call util_flush(luout)
          end if
       end if
       if (util_print('final vectors', print_debug)) then
@@ -240,6 +241,7 @@ C     $Id$
 #include "cscfps.fh"
 #include "util.fh"
 #include "cscf.fh"
+#include "stdio.fh"
 c     
 c     Solve the UHF equations using a hybrid NR/PCG method
 c     
@@ -282,7 +284,7 @@ c
 C      external uhf_hessv, uhf_hessv_precond
 c     
       
-      if (ga_nodeid().eq.0) call util_flush(6)
+      if (ga_nodeid().eq.0) call util_flush(luout)
 c     
 c     Allocate global arrays.  Gradient, search direction
 c     and work space for the PCG routine.
@@ -309,9 +311,9 @@ c
       tlastwrite = util_wallsec()
 c     
       if (ga_nodeid().eq.0.and. oprint_parm) then
-         write(6,1) gnorm_tol, maxiter, tol2e
-         if (ouser_changed_conv) write(6,11) shifts, nr_gswitch
-         write(6,111)
+         write(luout,1) gnorm_tol, maxiter, tol2e
+         if (ouser_changed_conv) write(luout,11) shifts, nr_gswitch
+         write(luout,111)
  1       format(//,
      $        1x,'----------------------------------------------',/
      $        1x,'        Quadratically convergent UHF',//,
@@ -328,7 +330,7 @@ c
      $        1x,'NR  enabled at maxg       :',9x,f10.3)
  111     format(
      $        1x,'----------------------------------------------',/)
-         call util_flush(6)
+         call util_flush(luout)
       end if
 c
       ododiag = .true.
@@ -388,11 +390,11 @@ c     go back to top of loop
 c     
                if (oprint_vecs) then
                   if (ga_nodeid() .eq. 0) then
-                     write(6,*)
-                     call util_print_centered(6,
+                     write(luout,*)
+                     call util_print_centered(luout,
      $                    'Intermediate MO vectors',40,.true.)
-                     write(6,*)
-                     call util_flush(6)
+                     write(luout,*)
+                     call util_flush(luout)
                   end if
                   call ga_print(g_movecs)
                   call ga_print(g_movecs(2))
@@ -413,7 +415,7 @@ c
 c     
 c     End SCF minimisation
 c     
-      if (ga_nodeid().eq.0) call util_flush(6)
+      if (ga_nodeid().eq.0) call util_flush(luout)
 c
       if (.not.noscf) then  ! bypass for noscf
 c     
@@ -442,7 +444,7 @@ c
       if (.not. ga_destroy(g_work)) call errquit
      $     ('uhf_nr_solve: ga_destroy work', 0, GA_ERR)
 c     
-      if (ga_nodeid().eq.0) call util_flush(6)
+      if (ga_nodeid().eq.0) call util_flush(luout)
       call ga_sync()
 c     
       uhf_nr_solve = converged
@@ -800,10 +802,10 @@ c
       call ga_maxelt(g_b_coul, errmaxb)
       if (max(errmaxa,errmaxb).gt.1d-4) then
          if (ga_nodeid().eq.0) then
-            write(6,77) errmaxa,errmaxb
+            write(luout,77) errmaxa,errmaxb
  77         format(' Warning: spatial symmetry breaking in UHF: ',
      $           1p,2d9.2)
-            call util_flush(6)
+            call util_flush(luout)
          endif
       endif
 c
@@ -937,9 +939,9 @@ c       Coulomb, alpha spin MOs
           dbl_mb(k_eps(1)+imo-1) = dbl_mb(k_eps(1)+imo-1)
      &      + dbl_mb(k_diag+imo-1)
         end do
-        if (master) write(6,*) 'V(C) alfa MOs'
+        if (master) write(luout,*) 'V(C) alfa MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, dbl_mb(k_eps(1)+imo-1)
+          if (master) write (luout,*) imo, dbl_mb(k_eps(1)+imo-1)
         end do
 c
 c       Coulomb, beta spin MOs
@@ -960,9 +962,9 @@ c       Coulomb, beta spin MOs
           dbl_mb(k_eps(2)+imo-1) = dbl_mb(k_eps(2)+imo-1)
      &      + dbl_mb(k_diag+imo-1)
         end do
-        if (master) write(6,*) 'V(C) beta MOs'
+        if (master) write(luout,*) 'V(C) beta MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, dbl_mb(k_eps(2)+imo-1)
+          if (master) write (luout,*) imo, dbl_mb(k_eps(2)+imo-1)
         end do
 c        
 c       XC, alfa spin MOs
@@ -971,9 +973,9 @@ c       XC, alfa spin MOs
         call two_index_transf(g_a_exch, g_vecs(1), g_vecs(1),
      &    g_tmp(1), g_tmp(2))
         call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
-        if (master) write(6,*) 'V(XC) alfa MOs'
+        if (master) write(luout,*) 'V(XC) alfa MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, -dbl_mb(k_diag+imo-1)
+          if (master) write (luout,*) imo, -dbl_mb(k_diag+imo-1)
         end do
         do imo = 1,nbf
           dbl_mb(k_eps(1)+imo-1) = dbl_mb(k_eps(1)+imo-1)
@@ -986,9 +988,9 @@ c       XC, beta spin MOs
         call two_index_transf(g_b_exch, g_vecs(2), g_vecs(2),
      &    g_tmp(1), g_tmp(2))
         call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
-        if (master) write(6,*) 'V(XC) beta MOs'
+        if (master) write(luout,*) 'V(XC) beta MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, -dbl_mb(k_diag+imo-1)
+          if (master) write (luout,*) imo, -dbl_mb(k_diag+imo-1)
         end do
         do imo = 1,nbf
           dbl_mb(k_eps(2)+imo-1) = dbl_mb(k_eps(2)+imo-1)
@@ -997,9 +999,9 @@ c       XC, beta spin MOs
       end if ! epsana
 c
       if (odebug .and. ga_nodeid().eq.0) then
-         write(6,*) ' coulomb energies', e_a_coul, e_b_coul
-         write(6,*) ' exchang energies', e_a_exch, e_b_exch
-         call util_flush(6)
+         write(luout,*) ' coulomb energies', e_a_coul, e_b_coul
+         write(luout,*) ' exchang energies', e_a_exch, e_b_exch
+         call util_flush(luout)
       endif
       if (odebug) then
          call ga_print(g_a_coul)
@@ -1065,9 +1067,9 @@ c       T, alfa spin MOs
         call two_index_transf(g_a_hcore, g_vecs(1), g_vecs(1),
      &    g_tmp(1), g_tmp(2))
         call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
-        if (master) write(6,*) 'T alfa MOs'
+        if (master) write(luout,*) 'T alfa MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+          if (master) write (luout,*) imo, dbl_mb(k_diag+imo-1)
         end do
 c       T, beta spin MOs
         call ga_zero(g_tmp(1))
@@ -1075,9 +1077,9 @@ c       T, beta spin MOs
         call two_index_transf(g_a_hcore, g_vecs(2), g_vecs(2),
      &    g_tmp(1), g_tmp(2))
         call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
-        if (master) write(6,*) 'T beta MOs'
+        if (master) write(luout,*) 'T beta MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+          if (master) write (luout,*) imo, dbl_mb(k_diag+imo-1)
         end do
       end if ! epsana
 cc If spin polarised ECP, split g_hcore
@@ -1103,9 +1105,9 @@ c       alfa spin MOs
         call two_index_transf(g_a_hcore, g_vecs(1), g_vecs(1),
      &    g_tmp(1), g_tmp(2))
         call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
-        if (master) write(6,*) 'T+V(nuc) alfa MOs'
+        if (master) write(luout,*) 'T+V(nuc) alfa MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+          if (master) write (luout,*) imo, dbl_mb(k_diag+imo-1)
           dbl_mb(k_eps(1)+imo-1) = dbl_mb(k_eps(1)+imo-1)
      &      + dbl_mb(k_diag+imo-1)
         end do
@@ -1116,16 +1118,16 @@ c       beta spin MOs
         call two_index_transf(g_b_hcore, g_vecs(2), g_vecs(2),
      &    g_tmp(1), g_tmp(2))
         call ga_get_diagonal(g_tmp(2),dbl_mb(k_diag))
-        if (master) write(6,*) 'T+V(nuc) beta MOs'
+        if (master) write(luout,*) 'T+V(nuc) beta MOs'
         do imo=1,nbf
-          if (master) write (6,*) imo, dbl_mb(k_diag+imo-1)
+          if (master) write (luout,*) imo, dbl_mb(k_diag+imo-1)
           dbl_mb(k_eps(2)+imo-1) = dbl_mb(k_eps(2)+imo-1)
      &      + dbl_mb(k_diag+imo-1)
         end do
-        if (master) write (6,'(//1x,a)')
+        if (master) write (luout,'(//1x,a)')
      &    'spin MO energies with T + V(nuc) + V(C) + V(XC)'
         do imo = 1,nbf
-          if (master) write (6,*) imo,
+          if (master) write (luout,*) imo,
      &       dbl_mb(k_eps(1)+imo-1) ,  dbl_mb(k_eps(2)+imo-1)
         end do
       end if ! epsana      
@@ -1139,7 +1141,7 @@ c     check if we are doing dft (e.g. cphf case)
      &        INPUT_ERR)
          if (theory.eq.'hyb') theory = 'dft'
          if(theory.ne.'dft') then
-            if(master) write(6,*) ' UHF theory ',theory
+            if(master) write(luout,*) ' UHF theory ',theory
             call errquit('uhf_energy not compatible with COSMO',0,
      C           CAPMIS_ERR)
          endif
@@ -1237,10 +1239,10 @@ c ... jochen: full MO energies, with all additional contributions
          call ga_get_diagonal(cuhf_g_falpha,dbl_mb(k_eps(1)))
          call ga_get_diagonal(cuhf_g_fbeta,dbl_mb(k_eps(2)))
          
-         if (master) write (6,'(//1x,a)')
+         if (master) write (luout,'(//1x,a)')
      &     'spin MO energies with all contributions (COSMO, etc.)'
          do imo = 1,nbf
-           if (master) write (6,*) imo,
+           if (master) write (luout,*) imo,
      &       dbl_mb(k_eps(1)+imo-1) ,  dbl_mb(k_eps(2)+imo-1)
          end do
 
@@ -1257,7 +1259,7 @@ c        shorter variable names
          na = nalpha
          nb = nbeta
 
-         if (master) write(6,'(/1x,a/)')
+         if (master) write(luout,'(/1x,a/)')
      &     'Some ERIs, Mulliken notation [1 1* | 2 2*]'
 
 c        ------------------------------------------------------         
@@ -1282,13 +1284,13 @@ c        Fock 2e matrix from alfa HOMO-1 density
          
          call ga_get(f(2), na-1, na-1, na-1, na-1, rtemp,1)
  1001    format(1x,"[",i3,"a,",i3,"a |",i3,"a,",i3,"a]=",f15.8)
-         if (master) write(6,1001) na-1,na-1,na-1,na-1,rtemp
+         if (master) write(luout,1001) na-1,na-1,na-1,na-1,rtemp
 
          call ga_get(f(2), na, na, na, na, rtemp,1)
-         if (master) write(6,1001) na-1,na-1,na,na,rtemp
+         if (master) write(luout,1001) na-1,na-1,na,na,rtemp
          
          call ga_get(f(2), na+1, na+1, na+1, na+1, rtemp,1)
-         if (master) write(6,1001) na-1,na-1,na+1,na+1,rtemp
+         if (master) write(luout,1001) na-1,na-1,na+1,na+1,rtemp
 
          call two_index_transf(f(1), g_vecs(2), g_vecs(2),
      $     d(2), f(2))
@@ -1296,10 +1298,10 @@ c        Fock 2e matrix from alfa HOMO-1 density
          call ga_sync()
          
          call ga_get(f(2), nb, nb, nb, nb, rtemp,1)
-         if (master) write(6,1001) na-1,na-1,nb,nb,rtemp
+         if (master) write(luout,1001) na-1,na-1,nb,nb,rtemp
          
          call ga_get(f(2), nb+1, nb+1, nb+1, nb+1, rtemp,1)
-         if (master) write(6,1001) na-1,na-1,nb+1,nb+1,rtemp            
+         if (master) write(luout,1001) na-1,na-1,nb+1,nb+1,rtemp
 
 c        ------------------------------------------------------         
 c        Fock 2e matrix from alfa HOMO density
@@ -1322,13 +1324,13 @@ c        Fock 2e matrix from alfa HOMO density
          call ga_sync()
          
          call ga_get(f(2), na-1, na-1, na-1, na-1, rtemp,1)
-         if (master) write(6,1001) na,na,na-1,na-1,rtemp
+         if (master) write(luout,1001) na,na,na-1,na-1,rtemp
          
          call ga_get(f(2), na, na, na, na, rtemp,1)
-         if (master) write(6,1001) na,na,na,na,rtemp
+         if (master) write(luout,1001) na,na,na,na,rtemp
          
          call ga_get(f(2), na+1, na+1, na+1, na+1, rtemp,1)
-         if (master) write(6,1001) na,na,na+1,na+1,rtemp
+         if (master) write(luout,1001) na,na,na+1,na+1,rtemp
 
          call two_index_transf(f(1), g_vecs(2), g_vecs(2),
      $     d(2), f(2))
@@ -1336,10 +1338,10 @@ c        Fock 2e matrix from alfa HOMO density
          call ga_sync()
          
          call ga_get(f(2), nb, nb, nb, nb, rtemp,1)
-         if (master) write(6,1001) na,na,nb,nb,rtemp
+         if (master) write(luout,1001) na,na,nb,nb,rtemp
          
          call ga_get(f(2), nb+1, nb+1, nb+1, nb+1, rtemp,1)
-         if (master) write(6,1001) na,na,nb+1,nb+1,rtemp         
+         if (master) write(luout,1001) na,na,nb+1,nb+1,rtemp         
 
          
 c        ------------------------------------------------------
@@ -1363,13 +1365,13 @@ c        Fock 2e matrix from alfa LUMO density
          call ga_sync()
          
          call ga_get(f(2), na-1, na-1, na-1, na-1, rtemp,1)
-         if (master) write(6,1001) na+1,na+1,na-1,na-1,rtemp         
+         if (master) write(luout,1001) na+1,na+1,na-1,na-1,rtemp         
 
          call ga_get(f(2), na, na, na, na, rtemp,1)
-         if (master) write(6,1001) na+1,na+1,na,na,rtemp         
+         if (master) write(luout,1001) na+1,na+1,na,na,rtemp         
 
          call ga_get(f(2), na+1, na+1, na+1, na+1, rtemp,1)
-         if (master) write(6,1001) na+1,na+1,na+1,na+1,rtemp         
+         if (master) write(luout,1001) na+1,na+1,na+1,na+1,rtemp         
 
          call two_index_transf(f(1), g_vecs(2), g_vecs(2),
      $     d(2), f(2))
@@ -1377,10 +1379,10 @@ c        Fock 2e matrix from alfa LUMO density
          call ga_sync()
          
          call ga_get(f(2), nb, nb, nb, nb, rtemp,1)
-         if (master) write(6,1001) na+1,na+1,nb,nb,rtemp
+         if (master) write(luout,1001) na+1,na+1,nb,nb,rtemp
          
          call ga_get(f(2), nb+1, nb+1, nb+1, nb+1, rtemp,1)
-         if (master) write(6,1001) na+1,na+1,nb+1,nb+1,rtemp             
+         if (master) write(luout,1001) na+1,na+1,nb+1,nb+1,rtemp             
 
 
 c        ------------------------------------------------------
@@ -1410,11 +1412,11 @@ c        Fock 2e matrix from SYMMETRIZED alfa HOMO-HOMO-1 product
 
          rtemp = zero
          call ga_get(f(2), na-1, na-1, na, na, rtemp,1)
-         if (master) write(6,1001) na,na-1,na,na-1,rtemp
+         if (master) write(luout,1001) na,na-1,na,na-1,rtemp
          
          rtemp = zero
          call ga_get(f(2), na, na, na-1, na-1, rtemp,1)
-         if (master) write(6,1001) na-1,na,na-1,na,rtemp
+         if (master) write(luout,1001) na-1,na,na-1,na,rtemp
 
 
 c        ------------------------------------------------------
@@ -1442,11 +1444,11 @@ c        Fock 2e matrix from SYMMETRIZED alfa LUMO-HOMO-1 product
          
          rtemp = zero
          call ga_get(f(2), na-1, na-1, na+1, na+1, rtemp,1)
-         if (master) write(6,1001) na+1,na-1,na+1,na-1,rtemp         
+         if (master) write(luout,1001) na+1,na-1,na+1,na-1,rtemp         
 
          rtemp = zero
          call ga_get(f(2), na+1, na+1, na-1, na-1, rtemp,1)
-         if (master) write(6,1001) na-1,na+1,na-1,na+1,rtemp  
+         if (master) write(luout,1001) na-1,na+1,na-1,na+1,rtemp  
          
 c        ------------------------------------------------------
 c        Fock 2e matrix from SYMMETRIZED alfa LUMO-HOMO product
@@ -1475,11 +1477,11 @@ c        Fock 2e matrix from SYMMETRIZED alfa LUMO-HOMO product
 
          rtemp = zero
          call ga_get(f(2), na, na, na+1, na+1, rtemp,1)
-         if (master) write(6,1001) na+1,na,na+1,na,rtemp
+         if (master) write(luout,1001) na+1,na,na+1,na,rtemp
 
          rtemp = zero
          call ga_get(f(2), na+1, na+1, na, na, rtemp,1)
-         if (master) write(6,1001) na,na+1,na,na+1,rtemp
+         if (master) write(luout,1001) na,na+1,na,na+1,rtemp
 
 
 c        ------------------------------------------------------
@@ -1509,11 +1511,11 @@ c        Fock 2e matrix from SYMMETRIZED beta LUMO-HOMO product
 
          rtemp = zero
          call ga_get(f(2), nb, nb, nb+1, nb+1, rtemp,1)
-         if (master) write(6,1001) nb+1,nb,nb+1,nb,rtemp
+         if (master) write(luout,1001) nb+1,nb,nb+1,nb,rtemp
 
          rtemp = zero
          call ga_get(f(2), nb+1, nb+1, nb, nb, rtemp,1)
-         if (master) write(6,1001) nb,nb+1,nb,nb+1,rtemp
+         if (master) write(luout,1001) nb,nb+1,nb,nb+1,rtemp
          
          
 c        ------------------------------------------------------
@@ -1613,7 +1615,7 @@ c     DIM energy term
       end if
 c
       if (odebug .and. ga_nodeid().eq.0) then
-         write(6,*) ' eone, etwo, enrep, energy ',
+         write(luout,*) ' eone, etwo, enrep, energy ',
      $        eone, etwo, enrep, energy
       endif
 c
@@ -1660,6 +1662,7 @@ c
 #include "util.fh"
 #include "mafdecls.fh"
 #include "rtdb.fh"
+#include "stdio.fh"
       integer rtdb
       integer g_grad
       integer g_work
@@ -1732,10 +1735,10 @@ c
       if (lshift .lt. min_shift) then
          lshift = min_shift + 2.0d0
          if (ga_nodeid().eq.0 .and. oprint_conv) then
-            write(6,3131) lshift
+            write(luout,3131) lshift
  3131       format('  Setting level-shift to ', f6.2,
      $           ' to force positive preconditioner')
-            call util_flush(6)
+            call util_flush(luout)
          end if
       end if
 c
@@ -1766,9 +1769,9 @@ c
                odisable_nr = .true.
                maxiter = maxiter + 10
                if (ga_nodeid() .eq. 0 .and. oprint_conv) then
-                  write(6,22) maxiter
+                  write(luout,22) maxiter
  22               format(/' Disabled NR: increased maxiter to ',i3/)
-                  call util_flush(6)
+                  call util_flush(luout)
                endif
                goto 30
             else
@@ -1780,9 +1783,9 @@ c
                endif
             endif
             if (ga_nodeid() .eq. 0 .and. oprint_conv) then
-               write(6,2) lshift
+               write(luout,2) lshift
  2             format(' Increased level shift to ', f8.2)
-               call util_flush(6)
+               call util_flush(luout)
             endif
             goto 20
          endif
@@ -1945,6 +1948,7 @@ C$Id$
 #include "cscfps.fh"
 #include "cscf.fh"
 #include "cuhf.fh"
+#include "stdio.fh"
       logical oaufbau
       logical oprint
 c
@@ -2038,18 +2042,18 @@ c
       end do
 c
       if (oprint .and. ga_nodeid().eq.0) then
-         write(6,*)
-         write(6,*)
-         call util_print_centered(6, 'Alpha-spin eigenvalues',
+         write(luout,*)
+         write(luout,*)
+         call util_print_centered(luout, 'Alpha-spin eigenvalues',
      $        20, .true.)
          call output(dbl_mb(k_eval), 1, min(nalpha+5,nmo), 
      $        1, 1, nmo, 1, 1)
-         write(6,*)
-         call util_print_centered(6, 'Beta-spin eigenvalues',
+         write(luout,*)
+         call util_print_centered(luout, 'Beta-spin eigenvalues',
      $        20, .true.)
          call output(dbl_mb(k_eval+nbf), 1, min(nalpha+5,nmo), 
      $        1, 1, nmo, 1, 1)
-         call util_flush(6)
+         call util_flush(luout)
       end if
 c
       if (.not. ga_destroy(g_u))
@@ -2124,6 +2128,7 @@ c
 #include "rtdb.fh"
 #include "mafdecls.fh"
 #include "bas.fh"
+#include "stdio.fh"
       integer rtdb
 c
 c     Analyze the UHF wavefunction.  Optionally print the mulliken
@@ -2178,31 +2183,31 @@ c
 c
       if (oprintmulliken) then
          if (ga_nodeid() .eq. 0) then
-            write(6,*)
-            call util_print_centered(6,
+            write(luout,*)
+            call util_print_centered(luout,
      $           'Mulliken analysis of the total density', 20,.true.)
          endif
          call mull_pop(geom, basis, g_dens, g_over, 'total')
 c
          if (ga_nodeid() .eq. 0) then
-            write(6,*)
-            call util_print_centered(6,
+            write(luout,*)
+            call util_print_centered(luout,
      $           'Mulliken analysis of the alpha density', 20,.true.)
          endif
          call mull_pop(geom, basis, g_adens, g_over, 'alpha')
 c     
          if (nbeta .gt. 0) then
             if (ga_nodeid() .eq. 0) then
-               write(6,*)
-               call util_print_centered(6,
+               write(luout,*)
+               call util_print_centered(luout,
      $              'Mulliken analysis of the beta density', 
      $              20,.true.)
             endif
             call mull_pop(geom, basis, g_bdens, g_over, 'beta')
 c
             if (ga_nodeid() .eq. 0) then
-               write(6,*)
-               call util_print_centered(6,
+               write(luout,*)
+               call util_print_centered(luout,
      $              'Mulliken analysis of the spin density', 
      $              20,.true.)
             endif
@@ -2235,14 +2240,14 @@ c
       enddo
 c
       if (oprintmultipole .and. ga_nodeid().eq.0) then
-         write(6,*)
-         call util_print_centered(6,
+         write(luout,*)
+         call util_print_centered(luout,
      $     'Multipole analysis of the density wrt the origin',
      $      30, .true.)
-         write(6,*)
-         write(6,*) '    L   x y z        total         alpha',
+         write(luout,*)
+         write(luout,*) '    L   x y z        total         alpha',
      $                 '         beta         nuclear'
-         write(6,*) '    -   - - -        -----         -----',
+         write(luout,*) '    -   - - -        -----         -----',
      $                 '         ----         -------'
          ind = 0
          do ltotal = 0, lmax
@@ -2250,13 +2255,13 @@ c
                do l = ltotal-k, 0, -1
                   m = ltotal - k - l
                   ind = ind + 1
-                  write(6,12) ltotal, k, l, m, totalmoments(ind),
+                  write(luout,12) ltotal, k, l, m, totalmoments(ind),
      $                 alphamoments(ind), betamoments(ind),
      $                 nuclmoments(ind)
  12               format(4x,i2,2x,3i2,4f14.6)
                enddo
             enddo
-            write(6,*)
+            write(luout,*)
          enddo
       endif
 c

--- a/src/ddscf/vectors.F
+++ b/src/ddscf/vectors.F
@@ -55,7 +55,7 @@ c
          read(unitno, err=1001, end=2001) nsets
          read(unitno, err=1001, end=2001) nbf
          if (nsets .gt. ldnmo) then
-            write(6,*) ' movecs_read_header: ldnmo too small ',
+            write(luout,*) ' movecs_read_header: ldnmo too small ',
      $           nsets, ldnmo
             close(unitno, err=1002)
             goto 10
@@ -80,28 +80,28 @@ c
 c
       return
 c
- 1000 write(6,*) ' movecs_read_header: failed to open ',
+ 1000 write(luout,*) ' movecs_read_header: failed to open ',
      $     filename(1:inp_strlen(filename)),
      A ' IERR = ', ioserr
       call util_flush(luout)
       ok = 0
       goto 10
 c
- 1001 write(6,*) ' movecs_read_header: failing reading from ',
+ 1001 write(luout,*) ' movecs_read_header: failing reading from ',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
       close(unitno, err=1002)
       goto 10
 c
- 2001 write(6,*) ' movecs_read_header:eof: failing reading from '
+ 2001 write(luout,*) ' movecs_read_header:eof: failing reading from '
      &    , filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
       close(unitno, err=1002)
       goto 10
 c
- 1002 write(6,*) ' movecs_read_header: failed to close',
+ 1002 write(luout,*) ' movecs_read_header: failed to close',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
@@ -199,27 +199,27 @@ c
       movecs_read = ok .eq. 1
       if (ga_nodeid() .eq. 0 .and. movecs_read .and.
      $     util_print('vectors i/o', print_high)) then
-         write(6,22) filename(1:inp_strlen(filename))
+         write(luout,22) filename(1:inp_strlen(filename))
  22      format(/' Read molecular orbitals from ',a/)
          call util_flush(luout)
       endif
       if (oscfps) call pstat_off(ps_vecio)
       return
 c
- 1000 write(6,*) ' movecs_read: failed to open ',
+ 1000 write(luout,*) ' movecs_read: failed to open ',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
       goto 10
 c
- 1001 write(6,*) ' movecs_read: failing reading from ',
+ 1001 write(luout,*) ' movecs_read: failing reading from ',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
       close(unitno,err=1002)
       goto 10
 c
- 1002 write(6,*) ' movecs_read: failed to close',
+ 1002 write(luout,*) ' movecs_read: failed to close',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
@@ -409,7 +409,7 @@ c get nuclear repulsion energy
 c
       if (ga_nodeid() .eq. 0) then
          if (nsets .gt. 2) then
-            write(6,*) ' movecs_write: nsets > 2 ', nsets
+            write(luout,*) ' movecs_write: nsets > 2 ', nsets
             goto 10
          endif
          open(unitno, status='unknown', form='unformatted',
@@ -470,7 +470,7 @@ c
       movecs_write = ok .eq. 1
       if (ga_nodeid() .eq. 0 .and.
      $     util_print('vectors i/o', print_high)) then
-         write(6,22) filename(1:inp_strlen(filename))
+         write(luout,22) filename(1:inp_strlen(filename))
  22      format(/' Wrote molecular orbitals to ',a/)
          call util_flush(luout)
       endif
@@ -478,20 +478,20 @@ c
       if (oscfps) call pstat_off(ps_vecio)
       return
 c
- 1000 write(6,*) ' movecs_write: failed to open ',
+ 1000 write(luout,*) ' movecs_write: failed to open ',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
       goto 10
 c
- 1001 write(6,*) ' movecs_write: failing writing to ',
+ 1001 write(luout,*) ' movecs_write: failing writing to ',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
       close(unitno,err=1002)
       goto 10
 c
- 1002 write(6,*) ' movecs_write: failed to close',
+ 1002 write(luout,*) ' movecs_write: failed to close',
      $     filename(1:inp_strlen(filename))
       call util_flush(luout)
       ok = 0
@@ -574,7 +574,7 @@ c
          call ga_sync()
          call ga_inquire(g_vecs, type, dim1, dim2)
          if (ga_nodeid() .eq. 0) then
-            if (oprint) write(6,*)
+            if (oprint) write(luout,*)
             if (.not. ma_push_get(mt_dbl, dim1, 'swap', l_veci, k_veci))
      $           call errquit('movecs_swap: no scratch space', dim1,
      &       MA_ERR)
@@ -584,7 +584,7 @@ c
             do pair = 1, nelem, 2
                i = int_mb(index+pair-1)
                j = int_mb(index+pair  )
-               if (oprint) write(6,1) text(1:inp_strlen(text)), i, j
+               if (oprint) write(luout,1) text(1:inp_strlen(text)), i, j
  1             format(' Swapping ',a,' orbitals ', 2i5)
                if (i.lt.0 .or. i.gt.dim2) call errquit
      $              ('movecs_swap: invalid vector ', i, INPUT_ERR)
@@ -1064,13 +1064,13 @@ c
          endif
          goto 10
 c
- 1000    write(6,*) ' file_read_ga_info: failed to open ',
+ 1000    write(luout,*) ' file_read_ga_info: failed to open ',
      $        fname(1:inp_strlen(fname))
          call util_flush(luout)
          ok = 0
          goto 10
 c     
- 1001    write(6,*) ' file_read_ga_info: failing reading from ',
+ 1001    write(luout,*) ' file_read_ga_info: failing reading from ',
      $        fname(1:inp_strlen(fname))
          call util_flush(luout)
          ok = 0
@@ -1086,7 +1086,7 @@ c
          endif
          goto 10
 c     
- 1002    write(6,*) ' file_read_ga_info: failed to close',
+ 1002    write(luout,*) ' file_read_ga_info: failed to close',
      $        fname(1:inp_strlen(fname))
          call util_flush(luout)
          ok = 0
@@ -1213,19 +1213,19 @@ c
       file_write_ga_patch = ok .eq. 1
       if (ga_nodeid() .eq. 0 .and.
      $     util_print('vectors i/o', print_high)) then
-         write(6,22) gtitle(1:len1), fname(1:inp_strlen(fname))
+         write(luout,22) gtitle(1:len1), fname(1:inp_strlen(fname))
  22      format(/' Wrote ',a,' to ',a/)
          call util_flush(luout)
       endif
       return
 c
- 1000 write(6,*) ' file_write_ga: failed to open ',
+ 1000 write(luout,*) ' file_write_ga: failed to open ',
      $     fname(1:inp_strlen(fname))
       call util_flush(luout)
       ok = 0
       goto 10
 c
- 1001 write(6,*) ' file_write_ga: failing writing to ',
+ 1001 write(luout,*) ' file_write_ga: failing writing to ',
      $     fname(1:inp_strlen(fname))
       call util_flush(luout)
       ok = 0
@@ -1241,7 +1241,7 @@ c
       endif
       goto 10
 c
- 1002 write(6,*) ' file_write_ga: failed to close',
+ 1002 write(luout,*) ' file_write_ga: failed to close',
      $     fname(1:inp_strlen(fname))
       call util_flush(luout)
       ok = 0
@@ -1360,19 +1360,19 @@ c
       file_read_ga_patch = ok .eq. 1
       if (ga_nodeid() .eq. 0 .and.
      $     util_print('vectors i/o', print_high)) then
-         write(6,22) gtitle(1:len1), fname(1:inp_strlen(fname))
+         write(luout,22) gtitle(1:len1), fname(1:inp_strlen(fname))
  22      format(/' Read ',a,' from ',a/)
          call util_flush(luout)
       endif
       return
 c
- 1000 write(6,*) ' file_read_ga: failed to open ',
+ 1000 write(luout,*) ' file_read_ga: failed to open ',
      $     fname(1:inp_strlen(fname))
       call util_flush(luout)
       ok = 0
       goto 10
 c
- 1001 write(6,*) ' file_read_ga: failing reading from ',
+ 1001 write(luout,*) ' file_read_ga: failing reading from ',
      $     fname(1:inp_strlen(fname))
       call util_flush(luout)
       ok = 0
@@ -1388,13 +1388,13 @@ c
       endif
       goto 10
 c
- 1002 write(6,*) ' file_read_ga: failed to close',
+ 1002 write(luout,*) ' file_read_ga: failed to close',
      $     fname(1:inp_strlen(fname))
       call util_flush(luout)
       ok = 0
       goto 10
 c
- 2000 write(6,*) ' file_read_ga: GA and file ',
+ 2000 write(luout,*) ' file_read_ga: GA and file ',
      $           'contents mismatch dimensions',
      $           nrow, ncol, grow, gcol
       call util_flush(luout)

--- a/src/ddscf/vectors_inp.F
+++ b/src/ddscf/vectors_inp.F
@@ -5,6 +5,7 @@ C     $Id$
 #include "inp.fh"
 #include "rtdb.fh"
 #include "mafdecls.fh"
+#include "stdio.fh"
       integer rtdb
       character*(*) module
 c     
@@ -252,13 +253,13 @@ c
 c     
       return
 c     
-10000 write(6,10001)
+10000 write(luout,10001)
 10001 format(/' vectors [[input] filename|atomic|hcore] '
      $     /'         [output  filename] [lock]'
      $     /'         [swap [alpha|beta] pair_list]'
      $     /'         [reorder pair_list]'
      $     /'         [rotate geometry filename]'/)
-      call util_flush(6)
+      call util_flush(luout)
       call errquit('vectors_input: invalid format', 0, INPUT_ERR)
 c     
       end

--- a/src/nwdft/lr_tddft/tddft_analysis.F
+++ b/src/nwdft/lr_tddft/tddft_analysis.F
@@ -1882,7 +1882,7 @@ c
       if (.not.rtdb_put(rtdb,'tddft:energy',mt_dbl,1,energy))
      1  call errquit('tddft_analysis: failed to put tddft energy',0,
      &       RTDB_ERR)
-      if(ga_nodeid().eq.0) write(6,*) ' stored tddft:energy ',energy
+      if(ga_nodeid().eq.0) write(luout,*) ' stored tddft:energy ',energy
 c     storing all calculated excited state energies on RTDB
       if(.not.rtdb_put(rtdb,'tddft:energy-all',mt_dbl,nroots,
      $                 apbval(1:nroots)))

--- a/src/util/ga_it2.F
+++ b/src/util/ga_it2.F
@@ -491,7 +491,7 @@ c       understand these choices.
       endif
 c
       if (oprint .and. ga_nodeid().eq.0) then
-         write(6,1) n, nvec, maxsub, maxiter, tol, util_wallsec()
+         write(luout,1) n, nvec, maxsub, maxiter, tol, util_wallsec()
  1       format(//,'Iterative solution of linear equations',/,
      $        '  No. of variables', i9,/,
      $        '  No. of equations', i9,/,

--- a/src/util/ga_iter_diag.F
+++ b/src/util/ga_iter_diag.F
@@ -6,6 +6,7 @@ C$Id$
 #include "global.fh"
 #include "mafdecls.fh"
 #include "tcgmsg.fh"
+#include "stdio.fh"
       integer n                 ! Matrix dimension
       integer nroot             ! No. of eigen vectors sought
       integer maxiter           ! Maximum no. of iterations
@@ -161,16 +162,16 @@ c
       enddo
 c
       if (oprint .and. ga_nodeid().eq.0) then
-         write(6,1) tol, prod_acc
+         write(luout,1) tol, prod_acc
  1       format(/,12x,'----- iterative diag (tol:',1p,e8.1,' prod-acc:',
      $        e8.1,') -----'/)
-         write(6,2) 
+         write(luout,2) 
  2       format(
      $        7x, ' iter nsub  cur root   eigenvalue      residual',
      $        '    time'/
      $        7x, ' ---- ---- ---- ---- --------------- -----------',
      $        ' -------')
-         call util_flush(6)
+         call util_flush(luout)
       endif
 c     
       test_tol = 0.5d0
@@ -195,9 +196,9 @@ c               write(*,*)"i,j,aa,ss", i,j, aa(i,j), ss(i,j)
             enddo
          enddo
          if (odebug .and. ga_nodeid().eq.0) then
-            write(6,*) ' ga_iter_diag: Reduced space matrix'
+            write(luout,*) ' ga_iter_diag: Reduced space matrix'
             call output(aa, 1, nsub, 1, nsub, maxdim, nsub, 1)
-            write(6,*) ' ga_iter_diag: Reduced space overlap'
+            write(luout,*) ' ga_iter_diag: Reduced space overlap'
             call output(ss, 1, nsub, 1, nsub, maxdim, nsub, 1)
          endif
 c     
@@ -207,9 +208,9 @@ c
          if (info .ne. 0) call errquit
      $        ('ga_iter_diag: rsg failed', info, CALC_ERR)
          if (odebug .and. ga_nodeid().eq.0) then
-            write(6,*) ' ga_iter_diag: Reduced space eigenvectors'
+            write(luout,*) ' ga_iter_diag: Reduced space eigenvectors'
             call output(yy, 1, nsub, 1, nsub, maxdim, nsub, 1)
-            write(6,*) ' ga_iter_diag: Reduced space eigenvalues'
+            write(luout,*) ' ga_iter_diag: Reduced space eigenvalues'
             call output(ee, 1, nsub, 1, 1, nsub, 1, 1)
          endif
          call dcopy(nroot, ee, 1, eval, 1)
@@ -241,7 +242,7 @@ c     Print
 c     
          if (oprint .and. ga_nodeid().eq.0) then
             do iroot = 1, nroot
-               write(6,3) iter, nsub, cur_root, iroot, eval(iroot),
+               write(luout,3) iter, nsub, cur_root, iroot, eval(iroot),
      $              rnorm(iroot), tcgtime()
  3             format(7x,4i5,1p,e16.9,e12.4,0p,f8.1)
                call ga_copy_patch('n',g_x,1,n,iroot,iroot,g_tmp,1,n,1,1)
@@ -249,7 +250,7 @@ c
 c               call ga_get(g_x, 1, n, iroot, iroot, vout(1), 21)
 c               call output(vout, 1, 3, 1, 7, 3, 7, 1)
             enddo
-            call util_flush(6)
+            call util_flush(luout)
          endif
 c     
 c     Determine the next vector to update
@@ -280,9 +281,9 @@ c
 c     
          if (iter.eq.maxiter) then
             if (ga_nodeid() .eq. 0) then
-               write(6,*) ' ga_iter_diag: exceeded max iters ... ',
+               write(luout,*) ' ga_iter_diag: exceeded max iters ... ',
      $              'aborting solve'
-               call util_flush(6)
+               call util_flush(luout)
             endif
             goto 1000
          endif

--- a/src/util/ga_lkain_2cpl3.F
+++ b/src/util/ga_lkain_2cpl3.F
@@ -95,11 +95,11 @@ c     after the preconditioner has been applied to the residual
      &                            converge_precond))
      &  converge_precond = .false.
       
-      if (debug) write (6,*) 'ga_lkain_2cpl3 omega =',omega
-      if (debug) write (6,*) 'ga_lkain_2cpl3 limag =',limag
-      if (debug) write (6,*) 'ga_lkain_2cpl3 lifetime,gamwidth',
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 omega =',omega
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 limag =',limag
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 lifetime,gamwidth',
      &   lifetime,gamwidth
-      if (debug) write (6,*) 'ga_lkain_2cpl3 converge_precond',
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 converge_precond',
      &   converge_precond
 c
       if (lifetime) call errquit('ga_lkain_2cpl3 called with damping',
@@ -130,14 +130,14 @@ c     length if we have two components, otherwise not:
       maxsub = (maxsub/nvec)*nvec
 c     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,1) n2, nvec, maxsub, tol, util_wallsec()
+        write(luout,1) n2, nvec, maxsub, tol, util_wallsec()
     1   format(//,'Iterative solution of linear equations',/,
      $     '  No. of variables', i9,/,
      $     '  No. of equations', i9,/,
      $     '  Maximum subspace', i9,/,
      $     '       Convergence', 1p,d9.1,/,
      $     '        Start time', 0p,f9.1,/)
-        call util_flush(6)
+        call util_flush(luout)
       end if
 c     
       do ipm = 1,ncomp
@@ -187,8 +187,8 @@ c     the number of components
       call ga_sync()
 c     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,2)
-        call util_flush(6)
+        write(luout,2)
+        call util_flush(luout)
     2   format(/
      $     '   iter   nsub   residual    time ',/,
      $     '   ----  ------  --------  --------- ')
@@ -219,7 +219,9 @@ c
 c ... jochen: call product routine with initial or intermediate
 c       solution vector: g_x and g_Ax MUST have two components here
         
-        if (debug) write (6,*) 'calling product from ga_lkain_2cpl'
+        if (debug) then
+          write (luout,*) 'calling product from ga_lkain_2cpl'
+        endif
 
         call product(acc, 
      &               g_x   , g_Ax, 
@@ -228,7 +230,9 @@ c       solution vector: g_x and g_Ax MUST have two components here
      &               lifetime, gamwidth, ncomp)
 
         call ga_sync()
-        if (debug) write (6,*) 'returning product from ga_lkain_2cpl'
+        if (debug) then
+          write (luout,*) 'returning product from ga_lkain_2cpl'
+        endif
 
 c       g_r is zeroed below so we should make sure to do the same
 c       with g_r2 here
@@ -282,8 +286,8 @@ c       before or after the call to the preconditioner
          rmax = max(rmax1, rmax2)  
       
         if (oprint .and. ga_nodeid().eq.0) then
-          write(6,3) iter, nsub+nvec, rmax, util_wallsec()
-          call util_flush(6)
+          write(luout,3) iter, nsub+nvec, rmax, util_wallsec()
+          call util_flush(luout)
     3     format(' ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
         end if
 
@@ -365,7 +369,7 @@ c
         call ga_dgemm('n','n',n2,nvec,nsub,-1.0d0,
      &                g_Ay,g_c,1.0d0,g_r2)
         if (odebug) then
-          write(6,*) ' The update in the complement '
+          write(luout,*) ' The update in the complement '
           call ga_print(g_r2)
         end if
 c       
@@ -389,7 +393,7 @@ c       copy components of g_r2 into g_r before adding g_r to  g_x
 
         call ga_sync()
         if (odebug) then
-          write(6,*) ' The update in the subspace '
+          write(luout,*) ' The update in the subspace '
           call ga_print(g_r2)
         end if
 c       
@@ -619,13 +623,15 @@ c     after the preconditioner has been applied to the residual
      &                            converge_precond))
      &  converge_precond = .false.
       
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp omega =',omega
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp limag =',limag
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
-      if (debug) write (6,*) 'ga_lkain_2cpl3 converge_precond',
+      if (debug) then
+        write (luout,*) 'ga_lkain_2cpl_damp omega =',omega
+        write (luout,*) 'ga_lkain_2cpl_damp limag =',limag
+        write (luout,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
+        write (luout,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
+        write (luout,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
+        write (luout,*) 'ga_lkain_2cpl3 converge_precond',
      &   converge_precond
+      endif
 c
 c     exit if this is the wrong routine to call (lifetime switch
 c     must be set)
@@ -679,7 +685,7 @@ c ========= to be removed ============ start
       n4 = n
       if (ncomp.gt.1 .or. lifetime) n4 = 2* n
       if (lifetime .and. ncomp.gt.1) n4 = 4 * n
-      if (debug) write (6,*) 'n1n2n3n4',n,n2,n3,n4
+      if (debug) write (luout,*) 'n1n2n3n4',n,n2,n3,n4
 c ========= to be removed ============ end
 
       maxsub = mmaxsub          ! So don't modify input scalar arg
@@ -687,14 +693,14 @@ c ========= to be removed ============ end
       maxsub = (maxsub/nvec)*nvec
 c     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,1) n4, nvec, maxsub, tol, util_wallsec()
+        write(luout,1) n4, nvec, maxsub, tol, util_wallsec()
     1   format(//,'Iterative solution of linear equations',/,
      $     '  No. of variables', i9,/,
      $     '  No. of equations', i9,/,
      $     '  Maximum subspace', i9,/,
      $     '       Convergence', 1p,d9.1,/,
      $     '        Start time', 0p,f9.1,/)
-        call util_flush(6)
+        call util_flush(luout)
       end if
 c     
       do ipm = 1,ncomp
@@ -762,8 +768,8 @@ c     all necessary components simultaneously
       call ga_sync()
 c     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,2)
-        call util_flush(6)
+        write(luout,2)
+        call util_flush(luout)
     2   format(/
      $     '   iter   nsub   residual    time ',/,
      $     '   ----  ------  --------  --------- ')
@@ -840,7 +846,7 @@ c       even if only one of them is used
             enddo ! end-loop-ipm
          endif ! end-if-debug
         
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'calling product from ga_lkain_2cpl_damp'
         call product(acc, g_x, g_Ax,  g_x_im, g_Ax_im, omega, limag,
      &     lifetime, gamwidth, ncomp)
@@ -892,7 +898,7 @@ c     &          write(*,*) 'FA-STOP-convergence at 3rd iter'
 c               stop
 c             endif              
 
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'returning product from ga_lkain_2cpl_damp'
 
 c       g_r is zeroed below so we should make sure to do the same
@@ -1023,14 +1029,14 @@ c ---- FA-03-12-14 --- END
         endif
 c ---------- FA-12-03-13 ----- START
           if (debug1) then
-           write(6,4) iter, nsub+nvec, rmax, util_wallsec()
-           call util_flush(6)
+           write(luout,4) iter, nsub+nvec, rmax, util_wallsec()
+           call util_flush(luout)
     4      format('FA-chk: ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
           endif
 c ---------- FA-12-03-13 ----- END         
         if (oprint .and. ga_nodeid().eq.0) then
-          write(6,3) iter, nsub+nvec, rmax, util_wallsec()
-          call util_flush(6)
+          write(luout,3) iter, nsub+nvec, rmax, util_wallsec()
+          call util_flush(luout)
     3     format(' ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
         end if
         
@@ -1068,7 +1074,7 @@ c FA-03-12-14 ---- START
         endif
 c FA-03-12-14 ---- END  
 
-        if (debug) write (6,*) 'lkain3_damp: back from precond'
+        if (debug) write (luout,*) 'lkain3_damp: back from precond'
                 
 c       Copy the vectors to the subspace work area
 c   
@@ -1373,7 +1379,7 @@ c
      &   ('lkain_2cpl: destroy r2',6, GA_ERR)
 
       if (debug) then
-        write (6,*) 'ga_lkain_2cpl3_damp: solution vectors:'
+        write (luout,*) 'ga_lkain_2cpl3_damp: solution vectors:'
         call ga_print(g_x(1))
         if (ncomp.gt.1) call ga_print(g_x(2))
         if (lifetime) then

--- a/src/util/ga_lkain_2cpl3_ext.F
+++ b/src/util/ga_lkain_2cpl3_ext.F
@@ -107,11 +107,11 @@ c     after the preconditioner has been applied to the residual
      &                            converge_precond))
      &  converge_precond = .false.
       
-      if (debug) write (6,*) 'ga_lkain_2cpl3 omega =',omega
-      if (debug) write (6,*) 'ga_lkain_2cpl3 limag =',limag
-      if (debug) write (6,*) 'ga_lkain_2cpl3 lifetime,gamwidth',
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 omega =',omega
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 limag =',limag
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 lifetime,gamwidth',
      &   lifetime,gamwidth
-      if (debug) write (6,*) 'ga_lkain_2cpl3 converge_precond',
+      if (debug) write (luout,*) 'ga_lkain_2cpl3 converge_precond',
      &   converge_precond
 
       if (lifetime) call errquit('ga_lkain_2cpl3 called with damping',
@@ -142,14 +142,14 @@ c     length if we have two components, otherwise not:
       maxsub = (maxsub/nvec)*nvec
 c     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,1) n2, nvec, maxsub, tol, util_wallsec()
+        write(luout,1) n2, nvec, maxsub, tol, util_wallsec()
     1   format(//,'Iterative solution of linear equations',/,
      $     '  No. of variables', i9,/,
      $     '  No. of equations', i9,/,
      $     '  Maximum subspace', i9,/,
      $     '       Convergence', 1p,d9.1,/,
      $     '        Start time', 0p,f9.1,/)
-        call util_flush(6)
+        call util_flush(luout)
       end if
 c     
       do ipm = 1,ncomp
@@ -235,8 +235,8 @@ c         write(6,*) ' attempt reading restart '
       end if  ! solver_restart
 c     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,2)
-        call util_flush(6)
+        write(luout,2)
+        call util_flush(luout)
     2   format(/
      $     '   iter   nsub   residual    time ',/,
      $     '   ----  ------  --------  --------- ')
@@ -267,7 +267,9 @@ c
 c ... jochen: call product routine with initial or intermediate
 c       solution vector: g_x and g_Ax MUST have two components here
         
-        if (debug) write (6,*) 'calling product from ga_lkain_2cpl'
+        if (debug) then
+            write (luout,*) 'calling product from ga_lkain_2cpl'
+        endif
 
         call product(acc, 
      &               g_x   , g_Ax, 
@@ -275,7 +277,9 @@ c       solution vector: g_x and g_Ax MUST have two components here
      &               omega, limag,
      &               lifetime, gamwidth, ncomp)
 
-        if (debug) write (6,*) 'returning product from ga_lkain_2cpl'
+        if (debug) then
+            write (luout,*) 'returning product from ga_lkain_2cpl'
+        endif
 
 c       g_r is zeroed below so we should make sure to do the same
 c       with g_r2 here
@@ -325,8 +329,8 @@ c       JEM: Putting rmax into rtdb
      $                 RTDB_ERR) 
 
         if (oprint .and. ga_nodeid().eq.0) then
-          write(6,3) iter, nsub+nvec, rmax, util_wallsec()
-          call util_flush(6)
+          write(luout,3) iter, nsub+nvec, rmax, util_wallsec()
+          call util_flush(luout)
     3     format(' ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
         end if
 
@@ -749,14 +753,16 @@ c     after the preconditioner has been applied to the residual
       if (.not. rtdb_get(rtdb, 'aoresponse:precond',    mt_log, 1,
      &                            converge_precond))
      &  converge_precond = .false.
-      
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp omega =',omega
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp limag =',limag
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
-      if (debug) write (6,*) 'ga_lkain_2cpl3 converge_precond',
+
+      if (debug) then
+        write (luout,*) 'ga_lkain_2cpl_damp omega =',omega
+        write (luout,*) 'ga_lkain_2cpl_damp limag =',limag
+        write (luout,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
+        write (luout,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
+        write (luout,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
+        write (luout,*) 'ga_lkain_2cpl3 converge_precond',
      &   converge_precond
+      endif
 c
 c     exit if this is the wrong routine to call (lifetime switch
 c     must be set)
@@ -832,14 +838,14 @@ c       ... jochen: do a sanity check on the array dimensions
       endif     
     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,1) n1, nvec, maxsub, tol, util_wallsec()
+        write(luout,1) n1, nvec, maxsub, tol, util_wallsec()
     1   format(//,'Iterative solution of linear equations',/,
      $     '  No. of variables', i9,/,
      $     '  No. of equations', i9,/,
      $     '  Maximum subspace', i9,/,
      $     '       Convergence', 1p,d9.1,/,
      $     '        Start time', 0p,f9.1,/)
-        call util_flush(6)
+        call util_flush(luout)
       end if
 c     
       do ipm = 1,ncomp
@@ -887,8 +893,8 @@ c
       enddo                     ! ipm = 1,ncomp
      
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,2)
-        call util_flush(6)
+        write(luout,2)
+        call util_flush(luout)
     2   format(/
      $     '   iter   nsub   residual    time ',/,
      $     '   ----  ------  --------  --------- ')
@@ -928,7 +934,7 @@ c       even if only one of them is used
             enddo ! end-loop-ipm
          endif ! end-if-debug
         
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'calling product from ga_lkain_2cpl_damp'
         call product(acc, 
      &               g_x,      ! in  : x
@@ -963,7 +969,7 @@ c       even if only one of them is used
              enddo ! end-loop-ipm
            endif ! end-if-debug  
 
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'returning product from ga_lkain_2cpl_damp'
         
         do ipm = 1,ncomp
@@ -1043,8 +1049,8 @@ c     &   write(*,*) 'FA AFT get_precond_rmax'
 
 c -------- printout per iteration -------------- START
         if (oprint .and. ga_nodeid().eq.0) then
-          write(6,3) iter, nsub+nvec, rmax, util_wallsec()
-          call util_flush(6)
+          write(luout,3) iter, nsub+nvec, rmax, util_wallsec()
+          call util_flush(luout)
     3     format(' ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
         end if
 c -------- printout per iteration -------------- END
@@ -1443,13 +1449,15 @@ c     after the preconditioner has been applied to the residual
      &                            converge_precond))
      &  converge_precond = .false.
       
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp omega =',omega
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp limag =',limag
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
-      if (debug) write (6,*) 'ga_lkain_2cpl3 converge_precond',
+      if (debug) then
+         write (luout,*) 'ga_lkain_2cpl_damp omega =',omega
+         write (luout,*) 'ga_lkain_2cpl_damp limag =',limag
+         write (luout,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
+         write (luout,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
+         write (luout,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
+         write (luout,*) 'ga_lkain_2cpl3 converge_precond',
      &   converge_precond
+      endif
 c
 c     exit if this is the wrong routine to call (lifetime switch
 c     must be set)
@@ -1516,19 +1524,19 @@ c ++++++ added for solve_zlineq_KAIN1 +++ END
 c ------- create (zre,zim) ---------- END
     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,1) n1, nvec, maxsub, tol, util_wallsec()
+        write(luout,1) n1, nvec, maxsub, tol, util_wallsec()
     1   format(//,'Iterative solution of linear equations',/,
      $     '  No. of variables', i9,/,
      $     '  No. of equations', i9,/,
      $     '  Maximum subspace', i9,/,
      $     '       Convergence', 1p,d9.1,/,
      $     '        Start time', 0p,f9.1,/)
-        call util_flush(6)
+        call util_flush(luout)
       end if
      
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,2)
-        call util_flush(6)
+        write(luout,2)
+        call util_flush(luout)
     2   format(/
      $     '   iter   nsub   residual    time ',/,
      $     '   ----  ------  --------  --------- ')
@@ -1660,7 +1668,7 @@ c +++++++++++++++++++++++++++++++++++++++++++++++++ START
 c ========== complex linear solver iteration =========
 c +++++++++++++++++++++++++++++++++++++++++++++++++ START
       do iter = 1, maxiter       
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'calling product from ga_lkain_2cpl_damp'
 c Note.- product=rohf_hessv3_cmplx,uhf_hessv3_cmplx
           if (debug1) then
@@ -1688,7 +1696,7 @@ c Note.- product=rohf_hessv3_cmplx,uhf_hessv3_cmplx
      &               ncomp,    ! in  : nr. components
      &               iter)
 
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'returning product from ga_lkain_2cpl_damp'
 
           p1=nsub+1
@@ -1813,13 +1821,13 @@ c -------- printout per iteration -------------- START
         if (oprint .and. ga_nodeid().eq.0) then
 
           if (debug1) then
-           write(6,4) iter, nsub+nvec, rmax, util_wallsec()
-           call util_flush(6)
+           write(luout,4) iter, nsub+nvec, rmax, util_wallsec()
+           call util_flush(luout)
     4      format('FA-chk: ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
           endif     
 
-          write(6,3) iter, nsub+nvec, rmax, util_wallsec()
-          call util_flush(6)
+          write(luout,3) iter, nsub+nvec, rmax, util_wallsec()
+          call util_flush(luout)
     3     format(' ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
         end if
 c -------- printout per iteration -------------- END
@@ -2680,13 +2688,15 @@ c     after the preconditioner has been applied to the residual
      &                            converge_precond))
      &  converge_precond = .false.
       
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp omega =',omega
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp limag =',limag
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
-      if (debug) write (6,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
-      if (debug) write (6,*) 'ga_lkain_2cpl3 converge_precond',
+      if (debug) then
+        write (luout,*) 'ga_lkain_2cpl_damp omega =',omega
+        write (luout,*) 'ga_lkain_2cpl_damp limag =',limag
+        write (luout,*) 'ga_lkain_2cpl_damp lifetime =',lifetime
+        write (luout,*) 'ga_lkain_2cpl_damp gamwidth =',gamwidth
+        write (luout,*) 'ga_lkain_2cpl_damp ncomp =', ncomp
+        write (luout,*) 'ga_lkain_2cpl3 converge_precond',
      &   converge_precond
+      endif
 c
 c     exit if this is the wrong routine to call (lifetime switch
 c     must be set)
@@ -2739,19 +2749,19 @@ c ------- create (zre,zim) ---------- START
 c ------- create (zre,zim) ---------- END
     
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,1) n1, nvec, maxsub, tol, util_wallsec()
+        write(luout,1) n1, nvec, maxsub, tol, util_wallsec()
     1   format(//,'Iterative solution of linear equations',/,
      $     '  No. of variables', i9,/,
      $     '  No. of equations', i9,/,
      $     '  Maximum subspace', i9,/,
      $     '       Convergence', 1p,d9.1,/,
      $     '        Start time', 0p,f9.1,/)
-        call util_flush(6)
+        call util_flush(luout)
       end if
      
       if (oprint .and. ga_nodeid().eq.0) then
-        write(6,2)
-        call util_flush(6)
+        write(luout,2)
+        call util_flush(luout)
     2   format(/
      $     '   iter   nsub   residual    time ',/,
      $     '   ----  ------  --------  --------- ')
@@ -2884,7 +2894,7 @@ c ========== complex linear solver iteration =========
 c +++++++++++++++++++++++++++++++++++++++++++++++++ START
 
       do iter = 1, maxiter
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'calling product from ga_lkain_2cpl_damp'
 c Note.- product=rohf_hessv3_cmplx,uhf_hessv3_cmplx
 
@@ -2913,7 +2923,7 @@ c Note.- product=rohf_hessv3_cmplx,uhf_hessv3_cmplx
      &               gamwidth, ! in  :
      &               ncomp)    ! in  : nr. components
 
-        if (debug) write (6,*)
+        if (debug) write (luout,*)
      &     'returning product from ga_lkain_2cpl_damp'
 
           p1=nsub+1
@@ -3035,8 +3045,8 @@ c        then skip iter=1 to avoid storing repeteadly the last block.
         endif ! end-if-write-block
 c -------- printout per iteration -------------- START
         if (oprint .and. ga_nodeid().eq.0) then
-          write(6,3) iter, nsub+nvec, rmax, util_wallsec()
-          call util_flush(6)
+          write(luout,3) iter, nsub+nvec, rmax, util_wallsec()
+          call util_flush(luout)
     3     format(' ', i5, i7, 3x,1p,d9.2,0p,f10.1,5x,i3)
         end if
 c -------- printout per iteration -------------- END
@@ -5886,6 +5896,7 @@ c           located in ga_it2.F
 #include "global.fh"
 #include "mafdecls.fh"
 #include "util.fh"
+#include "stdio.fh"
       integer g_a, g_b, g_x
       double precision tol
 c
@@ -5940,7 +5951,7 @@ c
       do i = 0, nsing-1
          if (dbl_mb(k_val+i) .lt. tol) then
             if (ga_nodeid() .eq. 0 .and. oprint) then
-              write(6,*) ' neglecting ', i+1, dbl_mb(k_val+i)
+              write(luout,*) ' neglecting ', i+1, dbl_mb(k_val+i)
             endif
             dbl_mb(k_val+i) = 0.0d0
          else

--- a/src/util/ga_lkain_ext.F
+++ b/src/util/ga_lkain_ext.F
@@ -25,6 +25,7 @@ c Date             : 03-15-12
 #include "global.fh"
 #include "util.fh"
 #include "rtdb.fh"
+#include "stdio.fh"
 
       integer g_x               ! [input/output] Initial guess/solution
       integer g_b               ! [input] Right-hand side vectors
@@ -91,7 +92,7 @@ c       understand these choices.
       endif
 
       if (oprint .and. ga_nodeid().eq.0) then
-         write(6,1) n, nvec, maxsub, maxiter, tol, util_wallsec()
+         write(luout,1) n, nvec, maxsub, maxiter, tol, util_wallsec()
  1       format(//,'Iterative solution of linear equations',/,
      $        '  No. of variables', i9,/,
      $        '  No. of equations', i9,/,
@@ -99,7 +100,7 @@ c       understand these choices.
      $        '        Iterations', i9,/,
      $        '       Convergence', 1p,d9.1,/,
      $        '        Start time', 0p,f9.1,/)
-         call util_flush(6)
+         call util_flush(luout)
       end if
 
       if (.not. ga_create(MT_DBL, n, maxsub, 'lkain: Y', 
@@ -136,8 +137,8 @@ c       understand these choices.
       call ga_zero(g_r)
 
       if (oprint .and. ga_nodeid().eq.0) then
-         write(6,2)
-         call util_flush(6)
+         write(luout,2)
+         call util_flush(luout)
  2       format(/
      $        '   iter   nsub   residual    time',/,
      $        '   ----  ------  --------  ---------')
@@ -238,8 +239,8 @@ c ======== visualize output to product ============ END
 
          call ga_maxelt(g_r, rmax)
          if (oprint .and. ga_nodeid().eq.0) then
-            write(6,3) iter, nsub+nvec, rmax, util_wallsec()
-            call util_flush(6)
+            write(luout,3) iter, nsub+nvec, rmax, util_wallsec()
+            call util_flush(luout)
  3          format(' ', i5, i7, 3x,1p,d9.2,0p,f10.1)
          end if
          if (rmax .lt. tol) then
@@ -300,13 +301,13 @@ c
 c     Form and add the correction, in parts, onto the solution
          call ga_dgemm('n','n',n,nvec,nsub,-1.0d0,g_Ay,g_c,1.0d0,g_r)
          if (odebug) then
-            write(6,*) ' The update in the complement '
+            write(luout,*) ' The update in the complement '
             call ga_print(g_r)
          end if
          call ga_add(1.0d0, g_r, 1.0d0, g_x, g_x)
          call ga_dgemm('n','n',n,nvec,nsub,1.0d0,g_y,g_c,0.0d0,g_r)
          if (odebug) then
-            write(6,*) ' The update in the subspace '
+            write(luout,*) ' The update in the subspace '
             call ga_print(g_r)
          end if
          call ga_add(1.0d0, g_r, 1.0d0, g_x, g_x)

--- a/src/util/ga_pcg_min.F
+++ b/src/util/ga_pcg_min.F
@@ -6,6 +6,7 @@ C$Id$
 #include "global.fh"
 #include "mafdecls.fh"
 #include "util.fh"
+#include "stdio.fh"
       integer n                 ! No. of parameters [input]
       integer iter              ! Current macro iteration no. [input/output]
       double precision e        ! Energy of current point [input]
@@ -160,15 +161,15 @@ c
 c     Don't write out the header unless are also printing LS info
 c     except on the first iteration ... keeps output compact
 c
-               if (ls_print .or. iter.eq.1) write(6,1)
+               if (ls_print .or. iter.eq.1) write(luout,1)
  1             format(/,
      $              13x,' iter       energy          gnorm     gmax   ',
      $              '    time'/
      $              13x,'----- ------------------- --------- ---------',
      $              ' --------')
-               write(6,2) iter, e, gnorm, gmax, util_cpusec()
+               write(luout,2) iter, e, gnorm, gmax, util_cpusec()
  2             format(13x,i5,f20.10,1p,2d10.2,0p,f9.1)
-               call util_flush(6)
+               call util_flush(luout)
             endif
          endif
          iter = iter + 1

--- a/src/util/output.F
+++ b/src/util/output.F
@@ -23,6 +23,7 @@ c          florida, gainesville
 c.......................................................................
 C$Id$
       implicit none
+#include "stdio.fh"
       integer rowlow,rowhi,collow,colhi,rowdim,coldim,begin,kcol
       integer nctl, i, j, last, k
       double precision z(rowdim,coldim), zero
@@ -38,7 +39,7 @@ C$Id$
             if (z(i,j).ne.zero) go to 15
  10      continue
  11   continue
-      write (6,3000)
+      write (luout,3000)
  3000 format (/' zero matrix'/)
       go to 3
  15   continue
@@ -49,13 +50,13 @@ C$Id$
       last = min(colhi,collow+kcol-1)
       do 2 begin = collow,colhi,kcol
 *         write (6,1000) (column,i,i = begin,last)
-         write (6,1000) (i,i = begin,last)
+         write (luout,1000) (i,i = begin,last)
          do 1 k = rowlow,rowhi
             do 4 i=begin,last
                if (z(k,i).ne.zero) go to 5
  4          continue
             go to 1
- 5          write (6,2000) ctl,k,(z(k,i), i = begin,last)
+ 5          write (luout,2000) ctl,k,(z(k,i), i = begin,last)
  1       continue
          last = min(last+kcol,colhi)
  2    continue
@@ -100,6 +101,7 @@ c          florida, gainesville
 c.......................................................................
 C$Id$
       implicit none
+#include "stdio.fh"
       integer rowlow,rowhi,collow,colhi,rowdim,coldim,begin,kcol
       integer nctl, i, j, last, k
       double complex z(rowdim,coldim), zero
@@ -115,7 +117,7 @@ C$Id$
             if (z(i,j).ne.zero) go to 15
  10      continue
  11   continue
-      write (6,3000)
+      write (luout,3000)
  3000 format (/' zero matrix'/)
       go to 3
  15   continue
@@ -126,13 +128,13 @@ C$Id$
       last = min(colhi,collow+kcol-1)
       do 2 begin = collow,colhi,kcol
 *         write (6,1000) (column,i,i = begin,last)
-         write (6,1000) (i,i = begin,last)
+         write (luout,1000) (i,i = begin,last)
          do 1 k = rowlow,rowhi
             do 4 i=begin,last
                if (z(k,i).ne.zero) go to 5
  4          continue
             go to 1
- 5          write (6,2000) ctl,k,(z(k,i), i = begin,last)
+ 5          write (luout,2000) ctl,k,(z(k,i), i = begin,last)
  1       continue
          last = min(last+kcol,colhi)
  2    continue
@@ -177,6 +179,7 @@ c          florida, gainesville
 c.......................................................................
 C$Id$
       implicit none
+#include "stdio.fh"
       integer rowlow,rowhi,collow,colhi,rowdim,coldim,begin,kcol
       integer nctl, i, j, last, k
       double precision z(rowdim,coldim), zero
@@ -192,7 +195,7 @@ C$Id$
             if (z(i,j).ne.zero) go to 15
  10      continue
  11   continue
-      write (6,3000)
+      write (luout,3000)
  3000 format (/' zero matrix'/)
       go to 3
  15   continue
@@ -203,13 +206,13 @@ C$Id$
       last = min(colhi,collow+kcol-1)
       do 2 begin = collow,colhi,kcol
 *         write (6,1000) (column,i,i = begin,last)
-         write (6,1000) (i,i = begin,last)
+         write (luout,1000) (i,i = begin,last)
          do 1 k = rowlow,rowhi
             do 4 i=begin,last
                if (z(k,i).ne.zero) go to 5
  4          continue
             go to 1
- 5          write (6,2000) ctl,k,(z(k,i), i = begin,last)
+ 5          write (luout,2000) ctl,k,(z(k,i), i = begin,last)
  1       continue
          last = min(last+kcol,colhi)
  2    continue
@@ -254,6 +257,7 @@ c          florida, gainesville
 c.......................................................................
 C$Id$
       implicit none
+#include "stdio.fh"
       integer rowlow,rowhi,collow,colhi,rowdim,coldim,begin,kcol
       integer nctl, i, j, last, k
       integer z(rowdim,coldim), zero
@@ -269,7 +273,7 @@ C$Id$
             if (z(i,j).ne.zero) go to 15
  10      continue
  11   continue
-      write (6,3000)
+      write (luout,3000)
  3000 format (/' zero matrix'/)
       go to 3
  15   continue
@@ -280,13 +284,13 @@ C$Id$
       last = min(colhi,collow+kcol-1)
       do 2 begin = collow,colhi,kcol
 *         write (6,1000) (column,i,i = begin,last)
-         write (6,1000) (i,i = begin,last)
+         write (luout,1000) (i,i = begin,last)
          do 1 k = rowlow,rowhi
             do 4 i=begin,last
                if (z(k,i).ne.zero) go to 5
  4          continue
             go to 1
- 5          write (6,2000) ctl,k,(z(k,i), i = begin,last)
+ 5          write (luout,2000) ctl,k,(z(k,i), i = begin,last)
  1       continue
          last = min(last+kcol,colhi)
  2    continue


### PR DESCRIPTION
Dear NWChem developers,

Thank you for the fixes you have included in response to our issue https://github.com/nwchemgit/nwchem/issues/1018. I have been testing the new version of NWChem, and there is a nice improvement in terms of output being sent to `luout` rather than to the standard output, unit 6. When using ChemShell, this causes the NWChem output to get mixed in with ChemShell output.

Following the example of your changes, I have tried to fix some other examples of the same behaviour.

Just let me know if there are any problems with the changes I have introduced here. In one instance I had to change the file extension so that the file is pre-processed (opt.f to opt.F) and the header containing the definition of `luout` is included.

Thank you for your help with this issue.

All the best,
Tom
