### PR TITLE
skip QAs when FC=nvfortran and Zen4 CPUs

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -515,7 +515,9 @@ jobs:
         id: qa_test
         if: steps.compile.conclusion == 'success'
         run: |
+          if [[ $FC != 'nvfortran' && ${{ env.microarch}} != 'Zen4' ]]; then
           ./travis/run_qas.sh
+          fi
       - name: Check if QA testing has failed
         if: ${{ failure() &&  steps.qa_test.outcome == 'failure' }}
         run: |


### PR DESCRIPTION
This fix avoids the runtime error
```
__nvmath_abort:Math dispatch table is either misconfigured or corrupted.
```