### PR TITLE
fix COSMO util_print handling

### DIFF
--- a/src/solvation/cosmo_initialize.F
+++ b/src/solvation/cosmo_initialize.F
@@ -725,6 +725,7 @@ c     number of charges, the atoms they are associated with, etc.
 c
       status = rtdb_delete(rtdb,'cosmo:qraw')
 c
+      call util_print_pop
       return
  9999 format(/,10x,15(1h-),
      1       /,10x,'-cosmo- solvent',

--- a/src/solvation/cosmo_tidy.F
+++ b/src/solvation/cosmo_tidy.F
@@ -20,7 +20,7 @@ c
 #include "stdio.fh"
       integer rtdb !< [Input] the RTDB handle
 c
-      call util_print_pop
+c      call util_print_pop
       if (.not. bq_destroy(cosmo_bq_efc)) call errquit
      $     ('cosmo_tidy: bq destroy failed', 0, GEOM_ERR)
       if (.not. bq_destroy(cosmo_bq_invnuc)) call errquit

--- a/travis/build_env.sh
+++ b/travis/build_env.sh
@@ -294,24 +294,25 @@ if [[ "$os" == "Linux" ]]; then
 	    amdclang --version
 	fi
 	if [[ "$FC" == "nvfortran" ]]; then
-	    $MYSUDO apt-get -y install lmod g++ libtinfo5 libncursesw5 lua-posix lua-filesystem lua-lpeg lua-luaossl
+	    #$MYSUDO apt-get -y install lmod g++ libtinfo5 libncursesw5 lua-posix lua-filesystem lua-lpeg lua-luaossl
+	    #$MYSUDO apt-get -y install lmod g++ lua-posix lua-filesystem lua-lpeg lua-luaossl
 	    nv_major=26
 	    nv_minor=5
 	    nverdot="$nv_major"."$nv_minor"
 	    nverdash="$nv_major"-"$nv_minor"
 	    arch_dpkg=`dpkg --print-architecture`
-	    curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | $MYSUDO gpg --yes --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
-            echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/'$arch_dpkg' /' | $MYSUDO tee /etc/apt/sources.list.d/nvhpc.list
-	    echo '*** added hpc-sdk source to /etc/aps ***'
-	    ls -lrt /etc/apt/sources.list.d/ || true
-	    ls -lrt	/etc/apt/sources.list.d/nvhpc.list || true
-	    $MYSUDO cat /etc/apt/sources.list.d/nvhpc.list || true
-	    $MYSUDO apt-get update -y
-	    apt-cache search nvhpc
-	    tries=0 ; until [ "$tries" -ge 10 ] ; do \
-            $MYSUDO apt-get install -y nvhpc-"$nverdash" \
-            && break ; \
-            tries=$((tries+1)) ; echo attempt no.  $tries    ; sleep 30 ;  done
+	    set -ex
+	    fname=nvhpc-"$nverdash"_"$nverdot"-0_"$arch_dpkg".deb
+	    echo fname is $fname
+	    exitcode=0;tries=0 ; until [ "$tries" -ge 3 ] ; do
+                curl -LJO https://developer.download.nvidia.com/hpc-sdk/ubuntu/"$arch_dpkg"/"$fname" && dpkg-deb --info $fname  && break
+		exitcode=-1
+		tries=$((tries+1))
+		sleep 10
+				 done
+	    if [ $exitcode -ne 0 ]; then echo "nvhpc download failed"; exit 123;fi
+            $MYSUDO apt-get install -y ./"$fname"
+	    rm -f ./"$fname"
 	    export PATH=/opt/nvidia/hpc_sdk/Linux_"$arch"/"$nverdot"/compilers/bin:$PATH
 	    export LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_"$arch"/"$nverdot"/compilers/lib:$LD_LIBRARY_PATH
 	    $MYSUDO /opt/nvidia/hpc_sdk/Linux_"$arch"/"$nverdot"/compilers/bin/makelocalrc -x


### PR DESCRIPTION
Moved util_print_pop call to avoid conflict with theory prints.  
Prior to this fix, theory print/noprint options (e.g. DFT) were ignored when COSMo is present